### PR TITLE
go: Use a faster ed25519 implementation

### DIFF
--- a/go/common/crypto/mrae/api/api.go
+++ b/go/common/crypto/mrae/api/api.go
@@ -11,7 +11,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/curve25519"
+
+	curve25519 "github.com/oasislabs/ed25519/extra/x25519"
 )
 
 // Resetable is the interface implemented by cipher.AEAD implementations

--- a/go/common/crypto/mrae/api/api_test.go
+++ b/go/common/crypto/mrae/api/api_test.go
@@ -5,7 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/curve25519"
+
+	curve25519 "github.com/oasislabs/ed25519/extra/x25519"
 )
 
 func Test_GenerateKeypair(t *testing.T) {

--- a/go/common/crypto/signature/signature.go
+++ b/go/common/crypto/signature/signature.go
@@ -13,8 +13,7 @@ import (
 	"os"
 	"sync"
 
-	"golang.org/x/crypto/ed25519"
-
+	"github.com/oasislabs/ed25519"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/pem"
 	"github.com/oasislabs/oasis-core/go/grpc/common"

--- a/go/common/crypto/signature/signers/file/file_signer.go
+++ b/go/common/crypto/signature/signers/file/file_signer.go
@@ -9,8 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"golang.org/x/crypto/ed25519"
-
+	"github.com/oasislabs/ed25519"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/pem"
 )

--- a/go/common/crypto/signature/signers/memory/memory_signer.go
+++ b/go/common/crypto/signature/signers/memory/memory_signer.go
@@ -5,8 +5,7 @@ import (
 	"crypto/sha512"
 	"io"
 
-	"golang.org/x/crypto/ed25519"
-
+	"github.com/oasislabs/ed25519"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 )
 

--- a/go/common/node/node_test.go
+++ b/go/common/node/node_test.go
@@ -3,9 +3,10 @@ package node
 import (
 	"testing"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/ed25519"
+
+	"github.com/oasislabs/ed25519"
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 )
 
 func TestSerialization(t *testing.T) {

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,10 @@
 module github.com/oasislabs/oasis-core/go
 
-replace github.com/tendermint/iavl => github.com/oasislabs/iavl v0.12.0-ekiden3
+replace (
+	github.com/tendermint/iavl => github.com/oasislabs/iavl v0.12.0-ekiden3
+	golang.org/x/crypto/curve25519 => github.com/oasislabs/ed25519/extra/x25519 v0.0.0-20191022155220-a426dcc8ad5f
+	golang.org/x/crypto/ed25519 => github.com/oasislabs/ed25519 v0.0.0-20191022155220-a426dcc8ad5f
+)
 
 require (
 	github.com/RoaringBitmap/roaring v0.4.18 // indirect
@@ -39,6 +43,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.0.1
 	github.com/multiformats/go-multihash v0.0.6 // indirect
 	github.com/oasislabs/deoxysii v0.0.0-20190807103041-6159f99c2236
+	github.com/oasislabs/ed25519 v0.0.0-20191022155220-a426dcc8ad5f
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -341,6 +341,8 @@ github.com/oasislabs/deoxysii v0.0.0-20190610083944-a3e81dcb2dde h1:VtFvwkYI10rP
 github.com/oasislabs/deoxysii v0.0.0-20190610083944-a3e81dcb2dde/go.mod h1:PyjqElilQd4b7CBW+PT+ylPW06zHsb2Cr6ifPL6pWgM=
 github.com/oasislabs/deoxysii v0.0.0-20190807103041-6159f99c2236 h1:eTbRemVO4uAXU5RlqqQ/OiPtBcB3tBez28rV0JusKss=
 github.com/oasislabs/deoxysii v0.0.0-20190807103041-6159f99c2236/go.mod h1:gFIu170Sklo1wPRTYMTDxA664TYdgrl9NENFXfC+u3g=
+github.com/oasislabs/ed25519 v0.0.0-20191022155220-a426dcc8ad5f h1:d7qNaW+eJwgZ/PMMvLo1iGezGH7XwYI6FRcUEjZKDDo=
+github.com/oasislabs/ed25519 v0.0.0-20191022155220-a426dcc8ad5f/go.mod h1:BB2J82Ap0q/mSJZ0ALKKeQ5PTsiEoF/OSNGmwvrHrOI=
 github.com/oasislabs/iavl v0.12.0-ekiden2 h1:kzdp6OTHYrn8TXlAo+2NsL84Qi2gqydFvjhWQZ/H9GM=
 github.com/oasislabs/iavl v0.12.0-ekiden2/go.mod h1:B/tMpl5cg7n42n3xYQTCckJzQezoI75jedkc8FOiOF0=
 github.com/oasislabs/iavl v0.12.0-ekiden3 h1:8544fXJb57urhAEpTlIwDBdTJukgpPS/FCS/yj14I8E=

--- a/go/registry/api/runtime_test.go
+++ b/go/registry/api/runtime_test.go
@@ -3,11 +3,12 @@ package api
 import (
 	"testing"
 
+	"github.com/oasislabs/ed25519"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/common/version"
+
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/ed25519"
 )
 
 func TestSerialization(t *testing.T) {


### PR DESCRIPTION
This should force everything to use our ed25519 and x25519.