### PR TITLE
Add storage export debug subcommand

### DIFF
--- a/go/common/namespace.go
+++ b/go/common/namespace.go
@@ -43,6 +43,16 @@ func (n *Namespace) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
+// UnmarshalHex deserializes a hexadecimal text string into the given type.
+func (n *Namespace) UnmarshalHex(text string) error {
+	b, err := hex.DecodeString(text)
+	if err != nil {
+		return err
+	}
+
+	return n.UnmarshalBinary(b)
+}
+
 // Equal compares vs another namespace for equality.
 func (n *Namespace) Equal(cmp *Namespace) bool {
 	if cmp == nil {

--- a/go/ekiden/cmd/debug/storage/export.go
+++ b/go/ekiden/cmd/debug/storage/export.go
@@ -1,0 +1,115 @@
+// Package storage implements the storage debug sub-commands.
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	cmdCommon "github.com/oasislabs/ekiden/go/ekiden/cmd/common"
+	storageApi "github.com/oasislabs/ekiden/go/storage/api"
+	storageDb "github.com/oasislabs/ekiden/go/storage/database"
+)
+
+const (
+	cfgExportDbBackend = "database.backend"
+	cfgExportDbPath    = "database.path"
+	cfgExportNamespace = "namespace"
+	cfgExportRound     = "round"
+	cfgExportRoot      = "root"
+)
+
+var (
+	storageExportCmd = &cobra.Command{
+		Use:   "export",
+		Short: "export specific storage roots",
+		Run:   doExport,
+	}
+
+	// ExportFlags has the export command configuration flags.
+	ExportFlags = flag.NewFlagSet("", flag.ContinueOnError)
+)
+
+func doExport(cmd *cobra.Command, args []string) {
+	if err := cmdCommon.Init(); err != nil {
+		cmdCommon.EarlyLogAndExit(err)
+	}
+
+	// Create storage backend.
+	cfg := &storageApi.Config{
+		Backend: strings.ToLower(viper.GetString(cfgExportDbBackend)),
+		DB:      viper.GetString(cfgExportDbPath),
+	}
+	backend, err := storageDb.New(cfg)
+	if err != nil {
+		logger.Error("failed to create storage backend",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+
+	// Determine what to export.
+	var root storageApi.Root
+	if err = root.Namespace.UnmarshalHex(viper.GetString(cfgExportNamespace)); err != nil {
+		logger.Error("failed to unmarshal namespace",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+
+	if err = root.Hash.UnmarshalHex(viper.GetString(cfgExportRoot)); err != nil {
+		logger.Error("failed to unmarshal root hash",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+
+	root.Round = viper.GetUint64(cfgExportRound)
+
+	// Fetch checkpoint.
+	it, err := backend.GetCheckpoint(context.Background(), root)
+	if err != nil {
+		logger.Error("failed to get checkpoint from storage",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+
+	// TODO: Consider iterative JSON encoding to avoid holding everything
+	//       in memory before encoding.
+	var wl storageApi.WriteLog
+	for {
+		more, err := it.Next()
+		if !more {
+			break
+		}
+		if err != nil {
+			logger.Error("error while reading from storage",
+				"err", err,
+			)
+			os.Exit(1)
+		}
+
+		entry, _ := it.Value()
+		wl = append(wl, entry)
+	}
+
+	encoded, _ := json.Marshal(wl)
+	fmt.Printf("%s\n", encoded)
+}
+
+func init() {
+	ExportFlags.String(cfgExportDbBackend, "", "Database backend")
+	ExportFlags.String(cfgExportDbPath, "", "Path to database file")
+	ExportFlags.String(cfgExportNamespace, "", "Namespace to export")
+	ExportFlags.Uint64(cfgExportRound, 0, "Round to export")
+	ExportFlags.String(cfgExportRoot, "", "Root hash to export")
+
+	_ = viper.BindPFlags(ExportFlags)
+}

--- a/go/ekiden/cmd/debug/storage/storage.go
+++ b/go/ekiden/cmd/debug/storage/storage.go
@@ -292,7 +292,10 @@ func Register(parentCmd *cobra.Command) {
 	storageForceFinalizeCmd.Flags().Uint64Var(&finalizeRound, "round", committee.RoundLatest, "the round to force finalize; default latest")
 	storageForceFinalizeCmd.PersistentFlags().AddFlagSet(cmdGrpc.ClientFlags)
 
+	storageExportCmd.Flags().AddFlagSet(ExportFlags)
+
 	storageCmd.AddCommand(storageCheckRootsCmd)
 	storageCmd.AddCommand(storageForceFinalizeCmd)
+	storageCmd.AddCommand(storageExportCmd)
 	parentCmd.AddCommand(storageCmd)
 }

--- a/go/storage/mkvs/urkel/writelog/writelog.go
+++ b/go/storage/mkvs/urkel/writelog/writelog.go
@@ -17,6 +17,11 @@ type LogEntry struct {
 	Value []byte `json:"value,omitempty"`
 }
 
+func (k *LogEntry) MarshalJSON() ([]byte, error) {
+	kv := [2][]byte{k.Key, k.Value}
+	return json.Marshal(kv)
+}
+
 func (k *LogEntry) UnmarshalJSON(src []byte) error {
 	var kv [2][]byte
 	if err := json.Unmarshal(src, &kv); err != nil {


### PR DESCRIPTION
Fixes #1845.

Blocked on #1835.

TODO
* [ ] Merge with genesis dump tool to export all roots for the dumped roothash block(s).