### PR TITLE
(no merge) Byzantine node testing and debugging changes

### DIFF
--- a/.buildkite/scripts/common_e2e.sh
+++ b/.buildkite/scripts/common_e2e.sh
@@ -447,7 +447,6 @@ run_byzantine_node() {
     ${EKIDEN_NODE} debug byzantine ${script_name} \
         --log.level debug \
         --log.format JSON \
-        --log.file ${log_file} \
         --genesis.file ${EKIDEN_GENESIS_FILE} \
         --tendermint.core.listen_address tcp://0.0.0.0:${tm_port} \
         --tendermint.consensus.timeout_commit 250ms \

--- a/.buildkite/scripts/common_e2e.sh
+++ b/.buildkite/scripts/common_e2e.sh
@@ -261,6 +261,7 @@ run_backend_tendermint_committee() {
 
         ${EKIDEN_NODE} \
             --log.level debug \
+            --log.format JSON \
             --log.file ${committee_dir}/validator-${idx}.log \
             --grpc.log.verbose_debug \
             --grpc.debug.port ${grpc_debug_port} \
@@ -368,6 +369,7 @@ run_compute_node() {
 
     ${EKIDEN_NODE} \
         --log.level debug \
+        --log.format JSON \
         --log.file ${log_file} \
         --grpc.log.verbose_debug \
         --storage.backend cachingclient \
@@ -444,6 +446,7 @@ run_byzantine_node() {
 
     ${EKIDEN_NODE} debug byzantine ${script_name} \
         --log.level debug \
+        --log.format JSON \
         --log.file ${log_file} \
         --genesis.file ${EKIDEN_GENESIS_FILE} \
         --tendermint.core.listen_address tcp://0.0.0.0:${tm_port} \
@@ -566,6 +569,7 @@ run_client_node() {
 
     ${EKIDEN_NODE} \
         --log.level debug \
+        --log.format JSON \
         --log.file ${log_file} \
         --grpc.log.verbose_debug \
         --epochtime.backend ${EKIDEN_EPOCHTIME_BACKEND} \
@@ -659,6 +663,7 @@ run_keymanager_node() {
 
     ${EKIDEN_NODE} \
         --log.level debug \
+        --log.format JSON \
         --log.file ${log_file} \
         --grpc.log.verbose_debug \
         --storage.backend cachingclient \
@@ -723,6 +728,7 @@ run_seed_node() {
 
     ${EKIDEN_NODE} \
         --log.level info \
+        --log.format JSON \
         --log.file ${log_file} \
         --metrics.mode none \
         --genesis.file ${EKIDEN_GENESIS_FILE} \

--- a/.buildkite/scripts/common_e2e.sh
+++ b/.buildkite/scripts/common_e2e.sh
@@ -457,7 +457,7 @@ run_byzantine_node() {
         --tendermint.seeds "${EKIDEN_SEED_NODE_ID}@127.0.0.1:${EKIDEN_SEED_NODE_PORT}" \
         --datadir ${data_dir} \
         --debug.allow_test_keys \
-        ${extra_args} 2>&1 | tee ${out_file} | sed "s/^/[byzantine] /" &
+        ${extra_args} 2>&1 | tee ${out_file} | python -u ../private-ops/untracked/color-log.py | sed "s/^/[byzantine] /" &
 }
 
 # Run a storage node.

--- a/go/roothash/api/commitment/pool.go
+++ b/go/roothash/api/commitment/pool.go
@@ -251,6 +251,11 @@ func (p *Pool) CheckEnoughCommitments(didTimeout bool) error {
 		required -= int(p.Runtime.ReplicaAllowedStragglers)
 	}
 
+	logger.Debug("%%% pool checking if we have enough commitments",
+		"kind", p.Committee.Kind,
+		"commits", commits,
+		"required", required,
+	)
 	if commits < required {
 		return ErrStillWaiting
 	}
@@ -288,6 +293,10 @@ func (p *Pool) DetectDiscrepancy() (OpenCommitment, error) {
 			commit = c
 		}
 		if !commit.MostlyEqual(c) {
+			if !discrepancyDetected {
+				logger.Error("discrepancy detected %%%", "commitment", commit)
+			}
+			logger.Error("discrepancy detected %%%", "commitment", c)
 			discrepancyDetected = true
 		}
 	}

--- a/go/worker/common/p2p/p2p.go
+++ b/go/worker/common/p2p/p2p.go
@@ -164,6 +164,7 @@ func (p *P2P) publishImpl(ctx context.Context, node *node.Node, msg *Message) er
 	}
 
 	if response.Error != nil {
+		p.logger.Warn("peer responded with error %%%", "message", response.Error.Message)
 		return errors.New(response.Error.Message)
 	} else if response.Ack != nil {
 		return nil

--- a/go/worker/compute/committee/node.go
+++ b/go/worker/compute/committee/node.go
@@ -639,6 +639,7 @@ func (n *Node) proposeBatchLocked(batch *protocol.ComputedBatch) {
 				WriteLog: batch.StateWriteLog,
 			},
 		}
+		n.logger.Debug("here's our applyOps %%%", "apply_ops", applyOps)
 
 		receipts, err := n.commonNode.Storage.ApplyBatch(ctx, lastHeader.Namespace, lastHeader.Round+1, applyOps)
 		if err != nil {

--- a/go/worker/merge/committee/node.go
+++ b/go/worker/merge/committee/node.go
@@ -315,6 +315,7 @@ func (n *Node) handleResultsLocked(ctx context.Context, commit *commitment.Compu
 
 	sp, err := state.pool.AddComputeCommitment(n.commonNode.CurrentBlock, epoch, commit)
 	if err != nil {
+		n.logger.Warn("pool refused commitment %%%", "err", err)
 		return err
 	}
 


### PR DESCRIPTION
Here's some mods that I use for running the WIP Byzantine node and debugging issues with it.

cc @jberci, who's also working on the Byzantine node

## commands
### test merge-honest
```
make && rm -rf /tmp/ekiden-e2e-* && reset && .buildkite/scripts/test_e2e.sh -t e2e-tm-byzantine-merge-honest
```
wait for `[client] Getting "hello_key"...`. should appear after `[byzantine] xx:xx.xxx debug cmd/byzantine                > honest Tendermint service quit done caller="tendermint.go:128"`

### view logs
```
cd /tmp
<ekiden-e2e-*/committee-1/client-1.log python ~/work/ekiden/private-ops/untracked/color-log.py | less -RS
```

## deterministic committees
### compute tests

|                | compute       | merge         | transaction scheduler |
|----------------|---------------|---------------|-----------------------|
| worker-1       | backup worker | backup worker | leader                |
| worker-2       | worker        | worker        | invalid               |
| worker-3       | invalid       | worker        | invalid               |
| byzantine node | worker        | n/a           | n/a                   |

### merge tests

|                | compute       | merge         | transaction scheduler |
|----------------|---------------|---------------|-----------------------|
| worker-1       | worker        | worker        | leader                |
| worker-2       | backup worker | invalid       | invalid               |
| worker-3       | worker        | backup worker | invalid               |
| byzantine node | n/a           | worker        | n/a                   |