### PR TITLE
experimental e2e coverage hacks

### DIFF
--- a/.buildkite/go/build.sh
+++ b/.buildkite/go/build.sh
@@ -15,5 +15,5 @@ set -euxo pipefail
 # Build the Go parts
 ####################
 pushd go
-  make
+  make all oasis-node/integrationrunner/integrationrunner.test
 popd

--- a/.buildkite/go/build.sh
+++ b/.buildkite/go/build.sh
@@ -15,5 +15,5 @@ set -euxo pipefail
 # Build the Go parts
 ####################
 pushd go
-  make all oasis-node/integrationrunner/integrationrunner.test
+  make all integrationrunner
 popd

--- a/.buildkite/go/test_and_coverage.sh
+++ b/.buildkite/go/test_and_coverage.sh
@@ -45,7 +45,4 @@ popd
 ############################
 # Upload coverage to codecov
 ############################
-set +x
-export CODECOV_TOKEN=$(cat ~/.codecov/oasis_core_api_token)
-set -x
-bash <(curl -s https://codecov.io/bash) -Z
+.buildkite/scripts/upload_coverage.sh

--- a/.buildkite/go/test_and_coverage.sh
+++ b/.buildkite/go/test_and_coverage.sh
@@ -28,21 +28,16 @@ export OASIS_TEST_WORKER_HOST_RUNTIME_BINARY=$(pwd)/target/debug/simple-keyvalue
 pushd go
   make generate
   # We need to do multiple test passes for different parts to get correct coverage.
-  env -u GOPATH go test -race -coverprofile=coverage.txt -covermode=atomic -v \
+  env -u GOPATH go test -race -coverprofile=../coverage-misc.txt -covermode=atomic -v \
     $(go list ./... | \
         grep -v github.com/oasislabs/oasis-core/go/oasis-node | \
         grep -v github.com/oasislabs/oasis-core/go/storage/mkvs/urkel )
   # Oasis node tests.
   pushd oasis-node
-    env -u GOPATH go test -race -coverpkg ../... -coverprofile=coverage.txt -covermode=atomic -v ./...
+    env -u GOPATH go test -race -coverpkg ../... -coverprofile=../../coverage-oasis-node.txt -covermode=atomic -v ./...
   popd
   # Urkel tree tests.
   pushd storage/mkvs/urkel
-    env -u GOPATH go test -race -coverpkg ./... -coverprofile=coverage.txt -covermode=atomic -v ./...
+    env -u GOPATH go test -race -coverpkg ./... -coverprofile=../../../../coverage-urkel.txt -covermode=atomic -v ./...
   popd
 popd
-
-############################
-# Upload coverage to codecov
-############################
-.buildkite/scripts/upload_coverage.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -213,6 +213,7 @@ steps:
       - .buildkite/scripts/test_e2e.sh
     artifact_paths:
       - e2e/**/*.log
+      - coverage-e2e-*.txt
     env:
       TEST_BASE_DIR: e2e
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -93,6 +93,8 @@ steps:
       # Upload the built artifacts.
       - cd /workdir/go/oasis-node
       - buildkite-agent artifact upload oasis-node
+      - cd /workdir/go/oasis-node/integrationrunner
+      - buildkite-agent artifact upload integrationrunner.test
       - cd /workdir/go/oasis-test-runner
       - buildkite-agent artifact upload oasis-test-runner
       - cd /workdir/go/oasis-net-runner
@@ -186,6 +188,7 @@ steps:
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       - .buildkite/scripts/test_e2e.sh
+      - .buildkite/scripts/upload_coverage.sh
     artifact_paths:
       - e2e/**/*.log
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -176,6 +176,10 @@ steps:
   - label: Test Go node
     command:
       - .buildkite/go/test_and_coverage.sh
+    artifact_paths:
+      - coverage-misc.txt
+      - coverage-oasis-node.txt
+      - coverage-urkel.txt
     plugins:
       <<: *docker_plugin
 
@@ -188,9 +192,9 @@ steps:
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       - .buildkite/scripts/test_e2e.sh
-      - .buildkite/scripts/upload_coverage.sh
     artifact_paths:
       - e2e/**/*.log
+      - coverage-e2e-*.txt
     env:
       TEST_BASE_DIR: e2e
     agents:
@@ -250,3 +254,19 @@ steps:
       message: "${BUILDKITE_MESSAGE}"
       commit: "${BUILDKITE_COMMIT}"
       branch: "${BUILDKITE_BRANCH}"
+
+  ###########################
+  # Merge coverage and upload
+  ###########################
+
+  - label: "Merge and upload coverage"
+    command:
+      - mkdir -p /tmp/coverage-to-merge
+      - buildkite-agent artifact download "coverage-*.txt" /tmp/coverage-to-merge
+      - type gocovmerge || go get github.com/wadey/gocovmerge
+      - gocovmerge /tmp/coverage-to-merge/coverage-*.txt >merged-coverage.txt
+      - .buildkite/scripts/upload_coverage.sh
+    artifact_paths:
+      - merged-coverage.txt
+    plugins:
+      <<: *docker_plugin

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -206,7 +206,7 @@ steps:
   # E2E test jobs - intel-sgx
   ###########################
   - label: E2E tests - intel-sgx
-    parallelism: 6
+    parallelism: 5
     timeout_in_minutes: 9
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh

--- a/.buildkite/scripts/download_e2e_test_artifacts.sh
+++ b/.buildkite/scripts/download_e2e_test_artifacts.sh
@@ -14,6 +14,7 @@ source .buildkite/scripts/common.sh
 
 # Oasis node, test runner and runtime loader.
 download_artifact oasis-node go/oasis-node 755
+download_artifact integrationrunner.test go/oasis-node/integrationrunner 755
 download_artifact oasis-test-runner go/oasis-test-runner 755
 download_artifact oasis-core-runtime-loader target/debug 755
 

--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -32,7 +32,7 @@ fi
 ${WORKDIR}/go/oasis-test-runner/oasis-test-runner \
     ${BUILDKITE:+--basedir ${WORKDIR}/e2e} \
     --basedir.no_cleanup \
-    --e2e.node.binary ${WORKDIR}/go/oasis-node/oasis-node \
+    --e2e.node.binary ${WORKDIR}/scripts/integrationrunner-wrapper.sh \
     --e2e.client.binary_dir ${WORKDIR}/target/debug \
     --e2e.runtime.binary_dir ${WORKDIR}/target/${runtime_target}/debug \
     --e2e.runtime.loader ${WORKDIR}/target/debug/oasis-core-runtime-loader \

--- a/.buildkite/scripts/upload_coverage.sh
+++ b/.buildkite/scripts/upload_coverage.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+set +x
+CODECOV_TOKEN=$(cat ~/.codecov/oasis_core_api_token)
+export CODECOV_TOKEN
+set -x
+bash <(curl -s https://codecov.io/bash) -Z

--- a/.buildkite/scripts/upload_coverage.sh
+++ b/.buildkite/scripts/upload_coverage.sh
@@ -6,4 +6,4 @@ set +x
 CODECOV_TOKEN=$(cat ~/.codecov/oasis_core_api_token)
 export CODECOV_TOKEN
 set -x
-bash <(curl -s https://codecov.io/bash) -Z
+bash <(curl -s https://codecov.io/bash) -Z -f merged-coverage.txt

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -2,6 +2,7 @@
 *~
 
 oasis-node/oasis-node
+oasis-node/integrationrunner/integrationrunner.test
 oasis-test-runner/oasis-test-runner
 oasis-net-runner/oasis-net-runner
 storage/mkvs/urkel/interop/urkel_test_helpers

--- a/go/Makefile
+++ b/go/Makefile
@@ -30,6 +30,10 @@ build: generate
 	@echo "Building Oasis local network runner"
 	@env -u GOPATH $(OASIS_GO) build $(GOFLAGS) -o ./oasis-net-runner/oasis-net-runner ./oasis-net-runner
 
+# Oasis node with coverage.
+oasis-node/integrationrunner/integrationrunner.test: generate
+	env -u GOPATH $(OASIS_GO) test $(GOFLAGS) -c -covermode=atomic -coverpkg=./... -o $@ ./oasis-node/integrationrunner
+
 # Run go fmt.
 fmt:
 	@env -u GOPATH $(OASIS_GO) fmt ./...

--- a/go/Makefile
+++ b/go/Makefile
@@ -31,6 +31,7 @@ build: generate
 	@env -u GOPATH $(OASIS_GO) build $(GOFLAGS) -o ./oasis-net-runner/oasis-net-runner ./oasis-net-runner
 
 # Oasis node with coverage.
+integrationrunner: oasis-node/integrationrunner/integrationrunner.test
 oasis-node/integrationrunner/integrationrunner.test: generate
 	env -u GOPATH $(OASIS_GO) test $(GOFLAGS) -c -covermode=atomic -coverpkg=./... -o $@ ./oasis-node/integrationrunner
 
@@ -54,4 +55,4 @@ urkel-test-helpers: generate
 clean:
 	@env -u GOPATH $(OASIS_GO) clean
 
-.PHONY: all generate build lint test clean
+.PHONY: all generate build integrationrunner lint test clean

--- a/go/oasis-node/cmd/root.go
+++ b/go/oasis-node/cmd/root.go
@@ -2,6 +2,8 @@
 package cmd
 
 import (
+	"syscall"
+
 	"github.com/spf13/cobra"
 
 	"github.com/oasislabs/oasis-core/go/common/version"
@@ -33,6 +35,10 @@ func RootCommand() *cobra.Command {
 // Execute spawns the main entry point after handling the config file
 // and command line arguments.
 func Execute() {
+	// Only the owner should have read/write/execute permissions for
+	// anything created by the oasis-node binary.
+	syscall.Umask(0077)
+
 	if err := rootCmd.Execute(); err != nil {
 		cmdCommon.EarlyLogAndExit(err)
 	}

--- a/go/oasis-node/integrationrunner/integration_test.go
+++ b/go/oasis-node/integrationrunner/integration_test.go
@@ -1,0 +1,17 @@
+package integrationrunner
+
+import (
+	"flag"
+	"testing"
+)
+
+var run = flag.Bool("integration.run", false, "Run the node")
+
+func TestIntegration(t *testing.T) {
+	if !*run {
+		t.Skip("Pass -integration.run to run the node")
+		return
+	}
+
+	launch()
+}

--- a/go/oasis-node/integrationrunner/integration_test.go
+++ b/go/oasis-node/integrationrunner/integration_test.go
@@ -9,6 +9,8 @@ var run = flag.Bool("integration.run", false, "Run the node")
 
 func TestIntegration(t *testing.T) {
 	if !*run {
+		// This test requires a bunch of extra arguments and isn't automated on its own. Because of that, it's disabled
+		// by default. This way, running `go test` with ./... works with no fuss.
 		t.Skip("Pass -integration.run to run the node")
 		return
 	}

--- a/go/oasis-node/integrationrunner/utils.go
+++ b/go/oasis-node/integrationrunner/utils.go
@@ -1,0 +1,21 @@
+package integrationrunner
+
+import (
+	"os"
+
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd"
+)
+
+func trimArgs(words []string) []string {
+	for i, w := range words {
+		if w == "--" {
+			return words[i:]
+		}
+	}
+	return nil
+}
+
+func launch() {
+	os.Args = trimArgs(os.Args)
+	cmd.Execute()
+}

--- a/go/oasis-node/main.go
+++ b/go/oasis-node/main.go
@@ -2,15 +2,9 @@
 package main
 
 import (
-	"syscall"
-
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd"
 )
 
 func main() {
-	// Only the owner should have read/write/execute permissions for
-	// anything created by the oasis-node binary.
-	syscall.Umask(0077)
-
 	cmd.Execute()
 }

--- a/scripts/build-run-e2e-cov.sh
+++ b/scripts/build-run-e2e-cov.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+make
+make -C go oasis-node/integrationrunner/integrationrunner.test
+
+.buildkite/scripts/test_e2e.sh --test basic
+
+type gocovmerge || go get github.com/wadey/gocovmerge
+gocovmerge coverage-e2e-*.txt >merged-cov.txt
+
+cd go/oasis-node/integrationrunner
+go tool cover -html=../../../merged-cov.txt

--- a/scripts/build-run-e2e-cov.sh
+++ b/scripts/build-run-e2e-cov.sh
@@ -6,7 +6,7 @@ make -C go oasis-node/integrationrunner/integrationrunner.test
 .buildkite/scripts/test_e2e.sh --test basic
 
 type gocovmerge || go get github.com/wadey/gocovmerge
-gocovmerge coverage-e2e-*.txt >merged-cov.txt
+gocovmerge coverage-e2e-*.txt >merged-coverage.txt
 
 cd go/oasis-node/integrationrunner
-go tool cover -html=../../../merged-cov.txt
+go tool cover -html=../../../merged-coverage.txt

--- a/scripts/build-run-e2e-cov.sh
+++ b/scripts/build-run-e2e-cov.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 make
-make -C go oasis-node/integrationrunner/integrationrunner.test
+make -C go integrationrunner
 
 .buildkite/scripts/test_e2e.sh --test basic
 

--- a/scripts/integrationrunner-wrapper.sh
+++ b/scripts/integrationrunner-wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+covfile=$(mktemp coverage-e2e-XXXXXXXXXX.txt)
+
+exec ./go/oasis-node/integrationrunner/integrationrunner.test \
+  -test.coverprofile "$covfile" \
+  -integration.run \
+  -- "$@"


### PR DESCRIPTION
add a test that runs the node, so that we can get coverage in integration tests

somehow codecov doesn't merge the coverage files correctly, so add a step to merge them ourselves