### PR TITLE
runtime: check AVR quote for debug bit

### DIFF
--- a/.buildkite/rust/common.sh
+++ b/.buildkite/rust/common.sh
@@ -9,4 +9,5 @@ source .buildkite/scripts/common.sh
 ####################
 export OASIS_UNSAFE_SKIP_AVR_VERIFY="1"
 export OASIS_UNSAFE_KM_POLICY_KEYS="1"
+export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES="1"
 export RUST_BACKTRACE="1"

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ slightly different environmental variables set:
 ```
 export OASIS_UNSAFE_SKIP_AVR_VERIFY="1"
 export OASIS_UNSAFE_KM_POLICY_KEYS="1"
+export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES="1"
 export OASIS_TEE_HARDWARE=intel-sgx
 make
 ```

--- a/docker/deployment/build_context.sh
+++ b/docker/deployment/build_context.sh
@@ -13,6 +13,8 @@ dst=$1
 
 OASIS_UNSAFE_SKIP_AVR_VERIFY=1
 export OASIS_UNSAFE_SKIP_AVR_VERIFY
+OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1
+export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES
 
 # Install oasis-core-tools
 cargo install --force --path tools

--- a/go/common/sgx/ias/avr.go
+++ b/go/common/sgx/ias/avr.go
@@ -19,7 +19,10 @@ import (
 
 const nonceMaxLen = 32
 
-var unsafeSkipVerify bool
+var (
+	unsafeSkipVerify         bool
+	unsafeAllowDebugEnclaves bool
+)
 
 // TimestampFormat is the format of the AVR timestamp, suitable for use with
 // time.Parse.
@@ -404,6 +407,18 @@ func validateAVRSignature(data, encodedSignature, encodedCertChain []byte, trust
 // of the process' lifetime.
 func SetSkipVerify() {
 	unsafeSkipVerify = true
+}
+
+// SetAllowDebugEnclave will enable running and communicating with enclaves
+// with debug flag enabled in AVR for the remainder of the process' lifetime.
+func SetAllowDebugEnclaves() {
+	unsafeAllowDebugEnclaves = true
+}
+
+// UnsetAllowDebugEnclave will disable running and communicating with enclaves
+// with debug flag enabled in AVR for the remainder of the process' lifetime.
+func UnsetAllowDebugEnclaves() {
+	unsafeAllowDebugEnclaves = false
 }
 
 // BuildMrSignerBlacklist builds the MRSIGNER blacklist.

--- a/go/common/sgx/ias/avr_test.go
+++ b/go/common/sgx/ias/avr_test.go
@@ -14,6 +14,10 @@ func TestAVR(t *testing.T) {
 }
 
 func testAVRv2(t *testing.T) {
+	// TODO: Generate and test production AVR without debug bit.
+	SetAllowDebugEnclaves()
+	defer UnsetAllowDebugEnclaves()
+
 	raw, sig, certs := loadAVRv2(t)
 
 	avr, err := DecodeAVR(raw, sig, certs, IntelTrustRoots, time.Now())

--- a/go/common/sgx/ias/ias.go
+++ b/go/common/sgx/ias/ias.go
@@ -101,6 +101,10 @@ func (e *httpEndpoint) VerifyEvidence(ctx context.Context, quoteBinary, pseManif
 		return nil, nil, nil, fmt.Errorf("ias: invalid nonce length")
 	}
 
+	if err := quote.Verify(); err != nil {
+		return nil, nil, nil, err
+	}
+
 	// Encode the payload in the format that IAS wants.
 	reqPayload, err := json.Marshal(&iasEvidencePayload{
 		ISVEnclaveQuote: quoteBinary,
@@ -253,7 +257,8 @@ func NewIASEndpoint(cfg *EndpointConfig) (Endpoint, error) {
 	if cfg.DebugIsMock {
 		logger.Warn("DebugSkipVerify set, VerifyEvidence calls will be mocked")
 
-		SetSkipVerify() // Intel isn't signing anything.
+		SetSkipVerify()         // Intel isn't signing anything.
+		SetAllowDebugEnclaves() // Debug enclaves are used for testing.
 		return &mockEndpoint{
 			spidInfo: SPIDInfo{
 				SPID:               spidBin,

--- a/go/common/sgx/ias/quote.go
+++ b/go/common/sgx/ias/quote.go
@@ -85,11 +85,34 @@ func (b *Body) MarshalBinary() ([]byte, error) {
 	return bBin, nil
 }
 
+// AttributesFlags is attributes flags inside enclave report attributes.
+type AttributesFlags uint64
+
+// Predefined enclave report attributes flags.
+const (
+	AttributeInit          AttributesFlags = 0b0000_0001
+	AttributeDebug         AttributesFlags = 0b0000_0010
+	AttributeMode64Bit     AttributesFlags = 0b0000_0100
+	AttributeProvisionKey  AttributesFlags = 0b0001_0000
+	AttributeEInitTokenKey AttributesFlags = 0b0010_0000
+)
+
+// Attributes is a SGX enclave attributes value inside report.
+type Attributes struct {
+	Flags AttributesFlags
+	Xfrm  uint64
+}
+
+// GetFlagInit returns value of given flag attribute of the Report.
+func (a AttributesFlags) Contains(flag AttributesFlags) bool {
+	return (uint64(a) & uint64(flag)) != 0
+}
+
 // Report is an enclave report body.
-type Report struct {
+type Report struct { // nolint: maligned
 	CPUSVN     [16]byte
 	MiscSelect uint32
-	Attributes [16]byte
+	Attributes Attributes
 	MRENCLAVE  sgx.MrEnclave
 	MRSIGNER   sgx.MrSigner
 	ISVProdID  uint16
@@ -102,12 +125,16 @@ func (r *Report) MarshalBinary() ([]byte, error) {
 	rBin := []byte{}
 	uint16b := make([]byte, 2)
 	uint32b := make([]byte, 4)
+	uint64b := make([]byte, 8)
 
 	rBin = append(rBin, r.CPUSVN[:]...)
 	binary.LittleEndian.PutUint32(uint32b, r.MiscSelect)
 	rBin = append(rBin, uint32b[:]...)
 	rBin = append(rBin, make([]byte, 28)...) // 28 reserved bytes.
-	rBin = append(rBin, r.Attributes[:]...)
+	binary.LittleEndian.PutUint64(uint64b, uint64(r.Attributes.Flags))
+	rBin = append(rBin, uint64b[:]...)
+	binary.LittleEndian.PutUint64(uint64b, r.Attributes.Xfrm)
+	rBin = append(rBin, uint64b[:]...)
 	rBin = append(rBin, r.MRENCLAVE[:]...)
 	rBin = append(rBin, make([]byte, 32)...) // 32 reserved bytes.
 	rBin = append(rBin, r.MRSIGNER[:]...)
@@ -126,7 +153,8 @@ func (r *Report) MarshalBinary() ([]byte, error) {
 func (r *Report) UnmarshalBinary(data []byte) error {
 	copy(r.CPUSVN[:], data[0:])
 	r.MiscSelect = binary.LittleEndian.Uint32(data[16:])
-	copy(r.Attributes[:], data[48:])
+	r.Attributes.Flags = AttributesFlags(binary.LittleEndian.Uint64(data[48:]))
+	r.Attributes.Xfrm = binary.LittleEndian.Uint64(data[56:])
 	_ = r.MRENCLAVE.UnmarshalBinary(data[64 : 64+sgx.MrEnclaveSize])
 	_ = r.MRSIGNER.UnmarshalBinary(data[128 : 128+sgx.MrSignerSize])
 	r.ISVProdID = binary.LittleEndian.Uint16(data[256:])
@@ -146,6 +174,19 @@ func (q *Quote) Verify() error {
 	if mrSignerBlacklist[q.Report.MRSIGNER] {
 		return fmt.Errorf("ias/quote: blacklisted MRSIGNER")
 	}
+
+	if !unsafeAllowDebugEnclaves {
+		// Disallow debug enclaves, if we are in production mode.
+		if q.Report.Attributes.Flags.Contains(AttributeDebug) {
+			return fmt.Errorf("ias/avr: disallowed debug enclave since we are in production mode")
+		}
+	} else {
+		// Disallow non-debug enclaves, if we are in debug mode.
+		if !q.Report.Attributes.Flags.Contains(AttributeDebug) {
+			return fmt.Errorf("ias/avr: disallowed production enclave since we are in debug mode")
+		}
+	}
+
 	return nil
 }
 

--- a/go/common/sgx/ias/quote_test.go
+++ b/go/common/sgx/ias/quote_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestQuote(t *testing.T) {
+	// TODO: Generate and test production AVR without debug bit.
+	SetAllowDebugEnclaves()
+	defer UnsetAllowDebugEnclaves()
+
 	raw, sig, certs := loadAVRv2(t)
 	avr, err := DecodeAVR(raw, sig, certs, IntelTrustRoots, time.Now())
 	require.NoError(t, err, "DecodeAVR")
@@ -38,12 +42,8 @@ func TestQuote(t *testing.T) {
 		"CPUSVN",
 	)
 	require.EqualValues(t, 0x00000000, quote.Report.MiscSelect, "MISCSELECT")
-	require.Equal(
-		t,
-		"07000000000000000700000000000000",
-		hex.EncodeToString(quote.Report.Attributes[:]),
-		"ATTRIBUTES",
-	)
+	require.EqualValues(t, 0x0000000000000007, quote.Report.Attributes.Flags, "ATTRIBUTES.FLAGS")
+	require.EqualValues(t, 0x0000000000000007, quote.Report.Attributes.Xfrm, "ATTRIBUTES.XFRM")
 	require.Equal(
 		t,
 		"83d1607d933a8f1970fa30ac94cdb6921fd8ffb8414650af06fe63c008a4a9af",

--- a/go/oasis-node/cmd/debug/byzantine/byzantine.go
+++ b/go/oasis-node/cmd/debug/byzantine/byzantine.go
@@ -75,6 +75,7 @@ func activateCommonConfig(cmd *cobra.Command, args []string) {
 	// This subcommand is used in networks where other nodes are honest or colluding with us.
 	// Set this so we don't reject things when we run without real IAS.
 	ias.SetSkipVerify()
+	ias.SetAllowDebugEnclaves()
 }
 
 func doComputeHonest(cmd *cobra.Command, args []string) {

--- a/go/oasis-node/cmd/debug/byzantine/steps.go
+++ b/go/oasis-node/cmd/debug/byzantine/steps.go
@@ -73,6 +73,9 @@ func initFakeCapabilitiesSGX() (signature.Signer, *node.Capabilities, error) {
 			Version: 1,
 		},
 		Report: ias.Report{
+			Attributes: ias.Attributes{
+				Flags: ias.AttributeDebug,
+			},
 			MRENCLAVE: enclaveIdentity.MrEnclave,
 			MRSIGNER:  enclaveIdentity.MrSigner,
 		},

--- a/go/oasis-node/cmd/debug/byzantine/steps_test.go
+++ b/go/oasis-node/cmd/debug/byzantine/steps_test.go
@@ -14,5 +14,6 @@ func TestFakeCapabilitySGX(t *testing.T) {
 	require.NoError(t, err, "initFakeCapabilitiesSGX failed")
 
 	ias.SetSkipVerify()
+	ias.SetAllowDebugEnclaves()
 	require.NoError(t, fakeCapabilitiesSGX.TEE.Verify(time.Now()), "fakeCapabilitiesSGX not valid")
 }

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/common/sgx"
 	"github.com/oasislabs/oasis-core/go/epochtime"
+	"github.com/oasislabs/oasis-core/go/ias"
 	cmdCommon "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/grpc"
@@ -308,12 +309,13 @@ func (args *argBuilder) appendEntity(ent *Entity) *argBuilder {
 	return args
 }
 
-func (args *argBuilder) appendIASProxy(ias *iasProxy) *argBuilder {
-	if ias != nil {
+func (args *argBuilder) appendIASProxy(iasProxy *iasProxy) *argBuilder {
+	if iasProxy != nil {
 		args.vec = append(args.vec, []string{
-			"--ias.proxy_addr", "127.0.0.1:" + strconv.Itoa(int(ias.grpcPort)),
-			"--ias.tls", ias.tlsCertPath(),
-			"--ias.debug.skip_verify",
+			"--" + ias.CfgProxyAddress, "127.0.0.1:" + strconv.Itoa(int(iasProxy.grpcPort)),
+			"--" + ias.CfgTLSCertFile, iasProxy.tlsCertPath(),
+			"--" + ias.CfgDebugSkipVerify,
+			"--" + ias.CfgAllowDebugEnclaves,
 		}...)
 	}
 	return args

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -84,6 +84,9 @@ lazy_static! {
             // AVR signature verification MUST be enabled.
             let maybe_secure = maybe_secure && option_env!("OASIS_UNSAFE_SKIP_AVR_VERIFY").is_none();
 
+            // Disallow debug enclaves MUST be enabled.
+            let maybe_secure = maybe_secure && option_env!("OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES").is_none();
+
             // IAS `GROUP_OUT_OF_DATE` and `CONFIGRUATION_NEEDED` responses
             // MUST count as IAS failure.
             //


### PR DESCRIPTION
PR for https://github.com/oasislabs/ekiden/issues/2181

This PR:
- adds `OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES` env variable at compile time which checks AVR attributes Debug flag in rust,
- adds `ias.debug.allow_debug_enclaves` runtime switch for worker which checks AVR attributes Debug flag in go,
- if debug enclaves are not allowed, they are dropped; similarly, if debug enclaves are allowed, production enclaves are dropped.