### PR TITLE
go/tendermint: ABCI interface cleanup

### DIFF
--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -65,7 +65,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	BackendProtocol = Version{Major: 0, Minor: 7, Patch: 0}
+	BackendProtocol = Version{Major: 0, Minor: 8, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)

--- a/go/tendermint/abci/context.go
+++ b/go/tendermint/abci/context.go
@@ -1,13 +1,12 @@
 package abci
 
 import (
-	"sort"
 	"time"
 
+	"github.com/tendermint/iavl"
 	"github.com/tendermint/tendermint/abci/types"
 	tmcmn "github.com/tendermint/tendermint/libs/common"
 
-	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/tendermint/api"
 )
 
@@ -27,28 +26,21 @@ const (
 	ContextEndBlock
 )
 
-// OnCommitHook is a function used as a on commit hook.
-type OnCommitHook func(*ApplicationState)
-
 // Context is the context of processing a transaction/block.
 type Context struct {
 	outputType  ContextType
 	data        interface{}
 	tags        []tmcmn.KVPair
 	currentTime time.Time
-
-	onCommitHooks map[string]OnCommitHook
-
-	timerLogger *logging.Logger
+	state       *ApplicationState
 }
 
 // NewContext creates a new Context of the given type.
-func NewContext(outputType ContextType, now time.Time) *Context {
+func NewContext(outputType ContextType, now time.Time, state *ApplicationState) *Context {
 	return &Context{
-		outputType:    outputType,
-		currentTime:   now,
-		onCommitHooks: make(map[string]OnCommitHook),
-		timerLogger:   logging.GetLogger("tendermint/context/timer"),
+		outputType:  outputType,
+		currentTime: now,
+		state:       state,
 	}
 }
 
@@ -111,19 +103,10 @@ func (c *Context) Now() time.Time {
 	return c.currentTime
 }
 
-// RegisterOnCommitHook registers a new on commit hook.
-func (c *Context) RegisterOnCommitHook(id string, hook OnCommitHook) {
-	c.onCommitHooks[id] = hook
-}
-
-func (c *Context) fireOnCommitHooks(state *ApplicationState) {
-	hookOrder := make([]string, 0, len(c.onCommitHooks))
-	for id := range c.onCommitHooks {
-		hookOrder = append(hookOrder, id)
+// State returns the mutable state tree.
+func (c *Context) State() *iavl.MutableTree {
+	if c.IsCheckOnly() {
+		return c.state.CheckTxTree()
 	}
-	sort.Strings(hookOrder)
-
-	for _, id := range hookOrder {
-		c.onCommitHooks[id](state)
-	}
+	return c.state.DeliverTxTree()
 }

--- a/go/tendermint/abci/context.go
+++ b/go/tendermint/abci/context.go
@@ -110,3 +110,31 @@ func (c *Context) State() *iavl.MutableTree {
 	}
 	return c.state.DeliverTxTree()
 }
+
+// NewStateCheckpoint creates a new state checkpoint.
+func (c *Context) NewStateCheckpoint() *StateCheckpoint {
+	return &StateCheckpoint{
+		ImmutableTree: *c.State().ImmutableTree,
+		ctx:           c,
+	}
+}
+
+// StateCheckpoint is a state checkpoint that can be used to rollback state.
+type StateCheckpoint struct {
+	iavl.ImmutableTree
+
+	ctx *Context
+}
+
+// Close releases resources associated with the checkpoint.
+func (sc *StateCheckpoint) Close() {
+	sc.ctx = nil
+}
+
+// Rollback rolls back the active state to the one from the checkpoint.
+func (sc *StateCheckpoint) Rollback() {
+	if sc.ctx == nil {
+		return
+	}
+	sc.ctx.State().ImmutableTree = &sc.ImmutableTree
+}

--- a/go/tendermint/abci/timer_test.go
+++ b/go/tendermint/abci/timer_test.go
@@ -1,73 +1,27 @@
 package abci
 
 import (
+	"encoding/hex"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestSerializationRoundTripProblem(t *testing.T) {
-	// WARNING: time.Unix uses local time, the test cases are in UTC.
-	// The Equal method used will handle timezones for us.
-
-	// First case: 2018-11-12 04:37:37.999999748 +0000. Serialization round trip
-	// causes the timestamp to change due to loss of precision.
-	//
-	// The new codec library can store time as RFC 3339 strings (no loss of
-	// precision), or second-granular UNIX timestamps.  We use the latter.
-	//
-	// This was due to go codec originally serializing to CBOR floats if
-	// nanoseconds are present.
-	timer := &timerState{
-		ID:       "test",
-		App:      "test",
-		Armed:    true,
-		Deadline: time.Date(2018, 11, 12, 4, 37, 37, 999999748, time.UTC),
+func TestTimerKey(t *testing.T) {
+	timer := timerState{
+		app:      0x42,
+		kind:     0x21,
+		id:       []byte("test timer id"),
+		deadline: 1571157805,
+		data:     []byte("timer data"),
 	}
 
-	data := timer.MarshalCBOR()
+	key := timer.getKey()
+	// See timerKeyFmt for the key format.
+	require.EqualValues(t, "f0000000005da5f72d4221746573742074696d6572206964", hex.EncodeToString(key))
 
-	var deserialized timerState
-	require.NoError(t, deserialized.UnmarshalCBOR(data), "Unmarshal")
-	require.False(t, timer.Deadline.Equal(deserialized.Deadline), "Deadline should differ")
+	var dec timerState
+	dec.fromKeyValue(key, timer.data)
 
-	// Second case: 2018-11-12 04:37:37.000 +0000. Serialization round trip preserves
-	// the timestamp.
-	timer = &timerState{
-		ID:       "test",
-		App:      "test",
-		Armed:    true,
-		Deadline: time.Date(2018, 11, 12, 4, 37, 37, 0, time.UTC),
-	}
-
-	data = timer.MarshalCBOR()
-
-	var deserialized2 timerState
-	require.NoError(t, deserialized2.UnmarshalCBOR(data), "Unmarshal")
-	require.True(t, timer.Deadline.Equal(deserialized2.Deadline), "Deadline should not differ")
-}
-
-func TestGetDeadlineMapKey(t *testing.T) {
-	timer := &timerState{
-		ID:       "test",
-		App:      "test",
-		Armed:    true,
-		Deadline: time.Date(2018, 11, 12, 4, 37, 37, 999999748, time.UTC),
-	}
-
-	require.PanicsWithValue(
-		t,
-		"getDeadlineMapKey: deadline must be rounded to the nearest second",
-		func() { timer.getDeadlineMapKey() },
-	)
-
-	timer = &timerState{
-		ID:       "test",
-		App:      "test",
-		Armed:    true,
-		Deadline: time.Date(2018, 11, 12, 4, 37, 37, 0, time.UTC),
-	}
-
-	require.EqualValues(t, timer.getDeadlineMapKey(), []byte("timers/deadline/1541997457/test"))
+	require.EqualValues(t, timer, dec, "timer state must round-trip")
 }

--- a/go/tendermint/apps/beacon/beacon.go
+++ b/go/tendermint/apps/beacon/beacon.go
@@ -70,14 +70,6 @@ func (app *beaconApplication) SetOption(req types.RequestSetOption) types.Respon
 	return types.ResponseSetOption{}
 }
 
-func (app *beaconApplication) CheckTx(ctx *abci.Context, tx []byte) error {
-	return errUnexpectedTransaction
-}
-
-func (app *beaconApplication) ForeignCheckTx(ctx *abci.Context, other abci.Application, tx []byte) error {
-	return nil
-}
-
 func (app *beaconApplication) InitChain(ctx *abci.Context, req types.RequestInitChain, doc *genesis.Document) error {
 	// Note: If we ever decide that we need a beacon for the 0th epoch
 	// (that is *only* for the genesis state), it should be initiailized
@@ -95,11 +87,11 @@ func (app *beaconApplication) BeginBlock(ctx *abci.Context, req types.RequestBeg
 	return nil
 }
 
-func (app *beaconApplication) DeliverTx(ctx *abci.Context, tx []byte) error {
+func (app *beaconApplication) ExecuteTx(ctx *abci.Context, tx []byte) error {
 	return errUnexpectedTransaction
 }
 
-func (app *beaconApplication) ForeignDeliverTx(ctx *abci.Context, other abci.Application, tx []byte) error {
+func (app *beaconApplication) ForeignExecuteTx(ctx *abci.Context, other abci.Application, tx []byte) error {
 	return nil
 }
 

--- a/go/tendermint/apps/beacon/beacon.go
+++ b/go/tendermint/apps/beacon/beacon.go
@@ -162,7 +162,7 @@ func (app *beaconApplication) onBeaconEpochChange(ctx *abci.Context, epoch epoch
 }
 
 func (app *beaconApplication) onNewBeacon(ctx *abci.Context, beacon []byte) error {
-	state := NewMutableState(app.state.DeliverTxTree())
+	state := NewMutableState(ctx.State())
 
 	if err := state.setBeacon(beacon); err != nil {
 		app.logger.Error("onNewBeacon: failed to set beacon",

--- a/go/tendermint/apps/beacon/beacon.go
+++ b/go/tendermint/apps/beacon/beacon.go
@@ -19,6 +19,7 @@ import (
 
 var (
 	errUnexpectedTransaction = errors.New("beacon: unexpected transaction")
+	errUnexpectedTimer       = errors.New("beacon: unexpected timer")
 
 	prodEntropyCtx  = []byte("EkB-tmnt")
 	debugEntropyCtx = []byte("Ekb-Dumm")
@@ -106,7 +107,8 @@ func (app *beaconApplication) EndBlock(req types.RequestEndBlock) (types.Respons
 	return types.ResponseEndBlock{}, nil
 }
 
-func (app *beaconApplication) FireTimer(ctx *abci.Context, t *abci.Timer) {
+func (app *beaconApplication) FireTimer(ctx *abci.Context, t *abci.Timer) error {
+	return errUnexpectedTimer
 }
 
 func (app *beaconApplication) queryGetBeacon(s interface{}, r interface{}) ([]byte, error) {

--- a/go/tendermint/apps/epochtime_mock/epochtime_mock.go
+++ b/go/tendermint/apps/epochtime_mock/epochtime_mock.go
@@ -149,7 +149,8 @@ func (app *epochTimeMockApplication) EndBlock(request types.RequestEndBlock) (ty
 	return types.ResponseEndBlock{}, nil
 }
 
-func (app *epochTimeMockApplication) FireTimer(ctx *abci.Context, timer *abci.Timer) {
+func (app *epochTimeMockApplication) FireTimer(ctx *abci.Context, timer *abci.Timer) error {
+	return errors.New("tendermint/epochtime_mock: unexpected timer")
 }
 
 func (app *epochTimeMockApplication) executeTx(

--- a/go/tendermint/apps/keymanager/keymanager.go
+++ b/go/tendermint/apps/keymanager/keymanager.go
@@ -159,7 +159,9 @@ func (app *keymanagerApplication) EndBlock(request types.RequestEndBlock) (types
 	return types.ResponseEndBlock{}, nil
 }
 
-func (app *keymanagerApplication) FireTimer(ctx *abci.Context, timer *abci.Timer) {}
+func (app *keymanagerApplication) FireTimer(ctx *abci.Context, timer *abci.Timer) error {
+	return errors.New("tendermint/keymanager: unexpected timer")
+}
 
 func (app *keymanagerApplication) queryGetStatus(s interface{}, r interface{}) ([]byte, error) {
 	state := s.(*immutableState)

--- a/go/tendermint/apps/keymanager/keymanager.go
+++ b/go/tendermint/apps/keymanager/keymanager.go
@@ -67,15 +67,6 @@ func (app *keymanagerApplication) SetOption(request types.RequestSetOption) type
 	return types.ResponseSetOption{}
 }
 
-func (app *keymanagerApplication) CheckTx(ctx *abci.Context, tx []byte) error {
-	// TODO: Add policy support.
-	return errors.New("tendermint/keymanager: transactions not supported yet")
-}
-
-func (app *keymanagerApplication) ForeignCheckTx(ctx *abci.Context, other abci.Application, tx []byte) error {
-	return nil
-}
-
 func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.RequestInitChain, doc *genesis.Document) error {
 	st := doc.KeyManager
 
@@ -146,12 +137,12 @@ func (app *keymanagerApplication) BeginBlock(ctx *abci.Context, request types.Re
 	return nil
 }
 
-func (app *keymanagerApplication) DeliverTx(ctx *abci.Context, tx []byte) error {
+func (app *keymanagerApplication) ExecuteTx(ctx *abci.Context, tx []byte) error {
 	// TODO: Add policy support.
 	return errors.New("tendermint/keymanager: transactions not supported yet")
 }
 
-func (app *keymanagerApplication) ForeignDeliverTx(ctx *abci.Context, other abci.Application, tx []byte) error {
+func (app *keymanagerApplication) ForeignExecuteTx(ctx *abci.Context, other abci.Application, tx []byte) error {
 	return nil
 }
 

--- a/go/tendermint/apps/keymanager/keymanager.go
+++ b/go/tendermint/apps/keymanager/keymanager.go
@@ -104,7 +104,7 @@ func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.Req
 	}
 
 	var toEmit []*api.Status
-	state := NewMutableState(app.state.DeliverTxTree())
+	state := NewMutableState(ctx.State())
 	for _, v := range st.Statuses {
 		rt := rtMap[v.ID.ToMapKey()]
 		if rt == nil {
@@ -202,10 +202,8 @@ func (app *keymanagerApplication) queryGenesis(s interface{}, r interface{}) ([]
 }
 
 func (app *keymanagerApplication) onEpochChange(ctx *abci.Context, epoch epochtime.EpochTime) error {
-	tree := app.state.DeliverTxTree()
-
 	// Query the runtime and node lists.
-	regState := registryapp.NewMutableState(tree)
+	regState := registryapp.NewMutableState(ctx.State())
 	runtimes, _ := regState.GetRuntimes()
 	nodes, _ := regState.GetNodes()
 	registry.SortNodeList(nodes)
@@ -214,7 +212,7 @@ func (app *keymanagerApplication) onEpochChange(ctx *abci.Context, epoch epochti
 	//
 	// Note: This assumes that once a runtime is registered, it never expires.
 	var toEmit []*api.Status
-	state := NewMutableState(app.state.DeliverTxTree())
+	state := NewMutableState(ctx.State())
 	for _, rt := range runtimes {
 		if rt.Kind != registry.KindKeyManager {
 			continue

--- a/go/tendermint/apps/registry/registry.go
+++ b/go/tendermint/apps/registry/registry.go
@@ -287,7 +287,8 @@ func (app *registryApplication) EndBlock(request types.RequestEndBlock) (types.R
 	return types.ResponseEndBlock{}, nil
 }
 
-func (app *registryApplication) FireTimer(*abci.Context, *abci.Timer) {
+func (app *registryApplication) FireTimer(*abci.Context, *abci.Timer) error {
+	return errors.New("tendermint/registry: unexpected timer")
 }
 
 func (app *registryApplication) onRegistryEpochChanged(ctx *abci.Context, registryEpoch epochtime.EpochTime) error {

--- a/go/tendermint/apps/registry/registry.go
+++ b/go/tendermint/apps/registry/registry.go
@@ -179,26 +179,6 @@ func (app *registryApplication) queryGenesis(s interface{}, r interface{}) ([]by
 	return cbor.Marshal(gen), nil
 }
 
-func (app *registryApplication) CheckTx(ctx *abci.Context, tx []byte) error {
-	request := &Tx{}
-	if err := cbor.Unmarshal(tx, request); err != nil {
-		app.logger.Error("CheckTx: failed to unmarshal",
-			"tx", hex.EncodeToString(tx),
-		)
-		return errors.Wrap(err, "registry: failed to unmarshal")
-	}
-
-	if err := app.executeTx(ctx, request); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (app *registryApplication) ForeignCheckTx(ctx *abci.Context, other abci.Application, tx []byte) error {
-	return nil
-}
-
 func (app *registryApplication) InitChain(ctx *abci.Context, request types.RequestInitChain, doc *genesis.Document) error {
 	st := doc.Registry
 
@@ -266,19 +246,33 @@ func (app *registryApplication) BeginBlock(ctx *abci.Context, request types.Requ
 	return nil
 }
 
-func (app *registryApplication) DeliverTx(ctx *abci.Context, tx []byte) error {
-	request := &Tx{}
-	if err := cbor.Unmarshal(tx, request); err != nil {
-		app.logger.Error("DeliverTx: failed to unmarshal",
-			"tx", hex.EncodeToString(tx),
+func (app *registryApplication) ExecuteTx(ctx *abci.Context, rawTx []byte) error {
+	var tx Tx
+	if err := cbor.Unmarshal(rawTx, &tx); err != nil {
+		app.logger.Error("failed to unmarshal",
+			"tx", hex.EncodeToString(rawTx),
 		)
 		return errors.Wrap(err, "registry: failed to unmarshal")
 	}
 
-	return app.executeTx(ctx, request)
+	state := NewMutableState(ctx.State())
+
+	if tx.TxRegisterEntity != nil {
+		return app.registerEntity(ctx, state, &tx.TxRegisterEntity.Entity)
+	} else if tx.TxDeregisterEntity != nil {
+		return app.deregisterEntity(ctx, state, &tx.TxDeregisterEntity.Timestamp)
+	} else if tx.TxRegisterNode != nil {
+		return app.registerNode(ctx, state, &tx.TxRegisterNode.Node)
+	} else if tx.TxRegisterRuntime != nil {
+		if !app.cfg.DebugAllowRuntimeRegistration {
+			return registry.ErrForbidden
+		}
+		return app.registerRuntime(ctx, state, &tx.TxRegisterRuntime.Runtime)
+	}
+	return registry.ErrInvalidArgument
 }
 
-func (app *registryApplication) ForeignDeliverTx(ctx *abci.Context, other abci.Application, tx []byte) error {
+func (app *registryApplication) ForeignExecuteTx(ctx *abci.Context, other abci.Application, tx []byte) error {
 	return nil
 }
 
@@ -324,26 +318,6 @@ func (app *registryApplication) onRegistryEpochChanged(ctx *abci.Context, regist
 	ctx.EmitTag(TagNodesExpired, cbor.Marshal(expiredNodes))
 
 	return nil
-}
-
-// Execute transaction against given state.
-func (app *registryApplication) executeTx(ctx *abci.Context, tx *Tx) error {
-	state := NewMutableState(ctx.State())
-
-	if tx.TxRegisterEntity != nil {
-		return app.registerEntity(ctx, state, &tx.TxRegisterEntity.Entity)
-	} else if tx.TxDeregisterEntity != nil {
-		return app.deregisterEntity(ctx, state, &tx.TxDeregisterEntity.Timestamp)
-	} else if tx.TxRegisterNode != nil {
-		return app.registerNode(ctx, state, &tx.TxRegisterNode.Node)
-	} else if tx.TxRegisterRuntime != nil {
-		if !app.cfg.DebugAllowRuntimeRegistration {
-			return registry.ErrForbidden
-		}
-		return app.registerRuntime(ctx, state, &tx.TxRegisterRuntime.Runtime)
-	} else {
-		return registry.ErrInvalidArgument
-	}
 }
 
 // Perform actual entity registration.

--- a/go/tendermint/apps/scheduler/scheduler.go
+++ b/go/tendermint/apps/scheduler/scheduler.go
@@ -80,8 +80,8 @@ func (acc *stakeAccumulator) checkThreshold(id signature.PublicKey, kind staking
 	return nil
 }
 
-func newStakeAccumulator(appState *abci.ApplicationState, ctx *abci.Context, unsafeBypass bool) (*stakeAccumulator, error) {
-	snapshot, err := stakingapp.NewSnapshot(appState, ctx)
+func newStakeAccumulator(ctx *abci.Context, unsafeBypass bool) (*stakeAccumulator, error) {
+	snapshot, err := stakingapp.NewSnapshot(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (app *schedulerApplication) BeginBlock(ctx *abci.Context, request types.Req
 			return errors.Wrap(err, "tendermint/scheduler: couldn't get nodes")
 		}
 
-		entityStake, err := newStakeAccumulator(app.state, ctx, app.cfg.DebugBypassStake)
+		entityStake, err := newStakeAccumulator(ctx, app.cfg.DebugBypassStake)
 		if err != nil {
 			return errors.Wrap(err, "tendermint/scheduler: couldn't get stake snapshot")
 		}

--- a/go/tendermint/apps/scheduler/scheduler.go
+++ b/go/tendermint/apps/scheduler/scheduler.go
@@ -406,7 +406,9 @@ func (app *schedulerApplication) EndBlock(req types.RequestEndBlock) (types.Resp
 	return resp, nil
 }
 
-func (app *schedulerApplication) FireTimer(ctx *abci.Context, t *abci.Timer) {}
+func (app *schedulerApplication) FireTimer(ctx *abci.Context, t *abci.Timer) error {
+	return errors.New("tendermint/scheduler: unexpected timer")
+}
 
 func (app *schedulerApplication) queryAllCommittees(s interface{}, r interface{}) ([]byte, error) {
 	state := s.(*immutableState)

--- a/go/tendermint/apps/scheduler/scheduler.go
+++ b/go/tendermint/apps/scheduler/scheduler.go
@@ -138,14 +138,6 @@ func (app *schedulerApplication) SetOption(req types.RequestSetOption) types.Res
 	return types.ResponseSetOption{}
 }
 
-func (app *schedulerApplication) CheckTx(ctx *abci.Context, tx []byte) error {
-	return errUnexpectedTransaction
-}
-
-func (app *schedulerApplication) ForeignCheckTx(ctx *abci.Context, other abci.Application, tx []byte) error {
-	return nil
-}
-
 func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestInitChain, doc *genesis.Document) error {
 	if app.cfg.DebugStaticValidators {
 		app.logger.Warn("static validators are configured")
@@ -319,11 +311,11 @@ func (app *schedulerApplication) BeginBlock(ctx *abci.Context, request types.Req
 	return nil
 }
 
-func (app *schedulerApplication) DeliverTx(ctx *abci.Context, tx []byte) error {
+func (app *schedulerApplication) ExecuteTx(ctx *abci.Context, tx []byte) error {
 	return errUnexpectedTransaction
 }
 
-func (app *schedulerApplication) ForeignDeliverTx(ctx *abci.Context, other abci.Application, tx []byte) error {
+func (app *schedulerApplication) ForeignExecuteTx(ctx *abci.Context, other abci.Application, tx []byte) error {
 	return nil
 }
 


### PR DESCRIPTION
Simplifies ABCI timers and transaction execution.