### PR TITLE
go/registry: remove obsolete GetNodeTransport API function

### DIFF
--- a/go/grpc/registry/entity.proto
+++ b/go/grpc/registry/entity.proto
@@ -15,7 +15,6 @@ service EntityRegistry {
     rpc GetNode (NodeRequest) returns (NodeResponse) {}
     rpc GetNodes (NodesRequest) returns (NodesResponse) {}
     rpc GetNodesForEntity (EntityNodesRequest) returns (EntityNodesResponse) {}
-    rpc GetNodeTransport (NodeRequest) returns (NodeTransportResponse) {}
     rpc WatchNodes (WatchNodeRequest) returns (stream WatchNodeResponse) {}
     rpc WatchNodeList (WatchNodeListRequest) returns (stream WatchNodeListResponse) {}
 }

--- a/go/grpc/registry/entity.proto
+++ b/go/grpc/registry/entity.proto
@@ -14,7 +14,6 @@ service EntityRegistry {
     rpc RegisterNode (RegisterNodeRequest) returns (RegisterNodeResponse) {}
     rpc GetNode (NodeRequest) returns (NodeResponse) {}
     rpc GetNodes (NodesRequest) returns (NodesResponse) {}
-    rpc GetNodesForEntity (EntityNodesRequest) returns (EntityNodesResponse) {}
     rpc WatchNodes (WatchNodeRequest) returns (stream WatchNodeResponse) {}
     rpc WatchNodeList (WatchNodeListRequest) returns (stream WatchNodeListResponse) {}
 }

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -144,9 +144,6 @@ type Backend interface {
 	// GetNodesForEntity gets a list of nodes registered to an entity ID.
 	GetNodesForEntity(context.Context, signature.PublicKey) []*node.Node
 
-	// GetNodeTransport gets a registered node's transport information.
-	GetNodeTransport(context.Context, signature.PublicKey) (*NodeTransport, error)
-
 	// WatchNodes returns a channel that produces a stream of
 	// NodeEvent on node registration changes.
 	WatchNodes() (<-chan *NodeEvent, *pubsub.Subscription)

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -141,9 +141,6 @@ type Backend interface {
 	// GetNodes gets a list of all registered nodes.
 	GetNodes(context.Context) ([]*node.Node, error)
 
-	// GetNodesForEntity gets a list of nodes registered to an entity ID.
-	GetNodesForEntity(context.Context, signature.PublicKey) []*node.Node
-
 	// WatchNodes returns a channel that produces a stream of
 	// NodeEvent on node registration changes.
 	WatchNodes() (<-chan *NodeEvent, *pubsub.Subscription)

--- a/go/registry/grpc.go
+++ b/go/registry/grpc.go
@@ -162,21 +162,6 @@ func (s *grpcServer) GetNodes(ctx context.Context, req *pb.NodesRequest) (*pb.No
 	return &pb.NodesResponse{Node: pbNodes}, nil
 }
 
-func (s *grpcServer) GetNodesForEntity(ctx context.Context, req *pb.EntityNodesRequest) (*pb.EntityNodesResponse, error) {
-	var id signature.PublicKey
-	if err := id.UnmarshalBinary(req.GetId()); err != nil {
-		return nil, err
-	}
-
-	nodes := s.backend.GetNodesForEntity(ctx, id)
-	pbNodes := make([]*commonPB.Node, 0, len(nodes))
-	for _, v := range nodes {
-		pbNodes = append(pbNodes, v.ToProto())
-	}
-
-	return &pb.EntityNodesResponse{Node: pbNodes}, nil
-}
-
 func (s *grpcServer) WatchNodes(req *pb.WatchNodeRequest, stream pb.EntityRegistry_WatchNodesServer) error {
 	ch, sub := s.backend.WatchNodes()
 	defer sub.Close()

--- a/go/registry/grpc.go
+++ b/go/registry/grpc.go
@@ -177,28 +177,6 @@ func (s *grpcServer) GetNodesForEntity(ctx context.Context, req *pb.EntityNodesR
 	return &pb.EntityNodesResponse{Node: pbNodes}, nil
 }
 
-func (s *grpcServer) GetNodeTransport(ctx context.Context, req *pb.NodeRequest) (*pb.NodeTransportResponse, error) {
-	var id signature.PublicKey
-	if err := id.UnmarshalBinary(req.GetId()); err != nil {
-		return nil, err
-	}
-
-	transport, err := s.backend.GetNodeTransport(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-
-	var resp pb.NodeTransportResponse
-	if transport.Addresses != nil {
-		resp.Addresses = node.ToProtoAddresses(transport.Addresses)
-	}
-	if transport.Certificate != nil {
-		resp.Certificate = transport.Certificate
-	}
-
-	return &resp, nil
-}
-
 func (s *grpcServer) WatchNodes(req *pb.WatchNodeRequest, stream pb.EntityRegistry_WatchNodesServer) error {
 	ch, sub := s.backend.WatchNodes()
 	defer sub.Close()

--- a/go/registry/tendermint/tendermint.go
+++ b/go/registry/tendermint/tendermint.go
@@ -157,11 +157,6 @@ func (r *tendermintBackend) GetNodes(ctx context.Context) ([]*node.Node, error) 
 	return nodes, nil
 }
 
-func (r *tendermintBackend) GetNodesForEntity(ctx context.Context, id signature.PublicKey) []*node.Node {
-	// TODO: Need support for range queries on previous versions of the tree.
-	return nil
-}
-
 func (r *tendermintBackend) WatchNodes() (<-chan *api.NodeEvent, *pubsub.Subscription) {
 	typedCh := make(chan *api.NodeEvent)
 	sub := r.nodeNotifier.Subscribe()

--- a/go/registry/tendermint/tendermint.go
+++ b/go/registry/tendermint/tendermint.go
@@ -162,18 +162,6 @@ func (r *tendermintBackend) GetNodesForEntity(ctx context.Context, id signature.
 	return nil
 }
 
-func (r *tendermintBackend) GetNodeTransport(ctx context.Context, id signature.PublicKey) (*api.NodeTransport, error) {
-	node, err := r.GetNode(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-
-	return &api.NodeTransport{
-		Certificate: node.Committee.Certificate,
-		Addresses:   node.Committee.Addresses,
-	}, nil
-}
-
 func (r *tendermintBackend) WatchNodes() (<-chan *api.NodeEvent, *pubsub.Subscription) {
 	typedCh := make(chan *api.NodeEvent)
 	sub := r.nodeNotifier.Subscribe()

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -148,11 +148,6 @@ func testRegistryEntityNodes(t *testing.T, backend api.Backend, timeSource epoch
 				require.NoError(err, "GetNode")
 				require.EqualValues(v.Node, nod, "retrieved node")
 
-				tp, err := backend.GetNodeTransport(context.Background(), v.Node.ID)
-				require.NoError(err, "GetNodeTransport")
-				require.EqualValues(v.Node.Committee.Addresses, tp.Addresses, "retrieved transport addresses")
-				require.EqualValues(v.Node.Committee.Certificate, tp.Certificate, "retrieved transport certificate")
-
 				err = backend.RegisterNode(context.Background(), v.SignedValidReRegistration)
 				require.NoError(err, "Re-registering a node with differnet address should work")
 


### PR DESCRIPTION
Fix for #1947.

This PR:
* removes `GetNodeTransport` function from registry API
* removes `GetNodesForEntity` function from registry API