### PR TITLE
.buildkite/rust-coverage: tarpaulin fix

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -218,7 +218,7 @@ steps:
   ####################################
 
   - label: Coverage Rust crates
-    branches: master
+    branches: ptrus/fix/tarpaulin-0.9 # TODO: master
     command:
       # Build storage interoperability test helpers first.
       - make -C go urkel-test-helpers

--- a/.buildkite/rust/coverage.sh
+++ b/.buildkite/rust/coverage.sh
@@ -59,5 +59,8 @@ cargo tarpaulin \
   --exclude-files tests \
   --exclude-files runtime/src/storage/mkvs/urkel/interop \
   --coveralls ${coveralls_api_token} \
-  -v
+  -v \
+  # Revert to pre-0.9 behaviour
+  # https://github.com/xd009642/tarpaulin/issues/264
+  -- --test-threads=1
 set -x


### PR DESCRIPTION
Updating to 0.9 increased the number of segfaults. This change reverts the behaviour to match pre-0.9