### PR TITLE
.buildkite/rust-coverage: tarpaulin revert to 0.8.7

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -224,6 +224,8 @@ steps:
       - make -C go urkel-test-helpers
       - export OASIS_STORAGE_PROTOCOL_SERVER_BINARY=$(realpath go/storage/mkvs/urkel/interop/urkel_test_helpers)
       - .buildkite/rust/coverage.sh
+    # Don't cause the build to fail, as tarpaulin is pretty unstable at the moment.
+    soft_fail: true
     agents:
       buildkite_agent_size: large
     plugins:

--- a/docker/testing/Dockerfile
+++ b/docker/testing/Dockerfile
@@ -36,4 +36,4 @@ RUN wget -O codecov https://codecov.io/bash && \
 
 # Install tarpaulin.
 RUN RUSTFLAGS="--cfg procmacro2_semver_exempt" \
-    cargo install --version 0.9.0 cargo-tarpaulin
+    cargo install --version 0.8.7 cargo-tarpaulin


### PR DESCRIPTION
- 0.9 seems to have increased the number of segfaults in tests.
- don't fail build if coverage fails