### PR TITLE
go/common/node: fix address IsRoutable

### DIFF
--- a/go/common/node/address.go
+++ b/go/common/node/address.go
@@ -144,7 +144,6 @@ func init() {
 		"255.255.255.255/32", // RFC 919: Limited Broadcast
 		"::1/128",            // RFC 4291: Loopback Address
 		"::/128",             // RFC 4291: Unspecified Address
-		"::ffff:0:0/96",      // RFC 4291: IPv4-mapped Address
 		"100::/64",           // RFC 6666: Discard-Only Address Block
 		"2001::/32",          // RFC 4380: TEREDO
 		"2001:2::/48",        // RFC 5180: Benchmarking

--- a/go/common/node/address_test.go
+++ b/go/common/node/address_test.go
@@ -1,0 +1,36 @@
+package node
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRoutable(t *testing.T) {
+	type testCase struct {
+		ip         string
+		isRoutable bool
+	}
+
+	testCases := []testCase{
+		// IPv4 routable.
+		{"35.237.83.124", true},
+		// IPv4 unroutable.
+		{"10.10.0.11", false},
+		// IPv6 routable.
+		{"2001:05c0:9168:0000:0000:0000:0000:0001", true},
+		// IPv6 loopback - unroutable.
+		{"::1", false},
+		// IPv6 - IPv4 mapped - routable.
+		{"0000:0000:0000:0000:0000:ffff:35.237.83.124", true},
+		// IPv6 - IPv4 mapped - unroutable.
+		{"0000:0000:0000:0000:0000:ffff:10.10.0.11", false},
+	}
+
+	for _, testCase := range testCases {
+		var address Address
+		require.NoError(t, address.FromIP(net.ParseIP(testCase.ip), uint16(8000)), "could not parse address")
+		require.Equal(t, testCase.isRoutable, address.IsRoutable(), "Unexpected Address IsRoutable().")
+	}
+}


### PR DESCRIPTION
~In hindsight the split into IPv4 and IPv6 ranges was not necessary so i'm ok with reverting that part.~ reverted

However the `"::ffff:0:0/96",      // RFC 4291: IPv4-mapped Address` had to be removed as go converts IP4-mapped IPv6 addresses to IPv4 addresses automatically. So that range basically matched all IPv4 addresses.