### PR TITLE
go/tendermint: Add validator slashing

### DIFF
--- a/go/beacon/tendermint/tendermint.go
+++ b/go/beacon/tendermint/tendermint.go
@@ -25,7 +25,7 @@ type tendermintBackend struct {
 }
 
 func (t *tendermintBackend) GetBeacon(ctx context.Context, height int64) ([]byte, error) {
-	q, err := t.querier.QueryAt(height)
+	q, err := t.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -128,6 +128,12 @@ func (n *Node) HasRoles(r RolesMask) bool {
 	return n.Roles&r != 0
 }
 
+// IsExpired returns true if the node expiration epoch is strictly smaller
+// than the passed (current) epoch.
+func (n *Node) IsExpired(epoch uint64) bool {
+	return n.Expiration < epoch
+}
+
 // Runtime represents the runtimes supported by a given Oasis node.
 type Runtime struct {
 	// ID is the public key identifying the runtime.

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -65,7 +65,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	BackendProtocol = Version{Major: 0, Minor: 11, Patch: 0}
+	BackendProtocol = Version{Major: 0, Minor: 12, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)

--- a/go/epochtime/tendermint_mock/tendermint_mock.go
+++ b/go/epochtime/tendermint_mock/tendermint_mock.go
@@ -44,7 +44,7 @@ func (t *tendermintMockBackend) GetBaseEpoch(context.Context) (api.EpochTime, er
 }
 
 func (t *tendermintMockBackend) GetEpoch(ctx context.Context, height int64) (api.EpochTime, error) {
-	q, err := t.querier.QueryAt(height)
+	q, err := t.querier.QueryAt(ctx, height)
 	if err != nil {
 		return api.EpochInvalid, err
 	}
@@ -129,7 +129,7 @@ func (t *tendermintMockBackend) worker(ctx context.Context) {
 	defer t.service.Unsubscribe("epochtime-worker", app.QueryApp) // nolint: errcheck
 
 	// Populate current epoch (if available).
-	q, err := t.querier.QueryAt(0)
+	q, err := t.querier.QueryAt(ctx, 0)
 	if err == nil {
 		var epoch api.EpochTime
 		var height int64

--- a/go/grpc/registry/entity.proto
+++ b/go/grpc/registry/entity.proto
@@ -97,12 +97,6 @@ message EntityNodesResponse {
     repeated common.Node node = 1;
 }
 
-message NodeTransportResponse {
-    repeated common.Address addresses = 1;
-    bytes certificate = 2;
-    int64 height = 3;
-}
-
 message WatchNodeRequest {
 }
 

--- a/go/keymanager/tendermint/tendermint.go
+++ b/go/keymanager/tendermint/tendermint.go
@@ -34,7 +34,7 @@ type tendermintBackend struct {
 }
 
 func (tb *tendermintBackend) GetStatus(ctx context.Context, id signature.PublicKey, height int64) (*api.Status, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (tb *tendermintBackend) GetStatus(ctx context.Context, id signature.PublicK
 }
 
 func (tb *tendermintBackend) GetStatuses(ctx context.Context, height int64) ([]*api.Status, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (tb *tendermintBackend) WatchStatuses() (<-chan *api.Status, *pubsub.Subscr
 }
 
 func (tb *tendermintBackend) ToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/oasis-node/cmd/debug/byzantine/registry.go
+++ b/go/oasis-node/cmd/debug/byzantine/registry.go
@@ -65,7 +65,7 @@ func registryRegisterNode(svc service.TendermintService, id *identity.Identity, 
 }
 
 func registryGetNode(ht *honestTendermint, height int64, runtimeID signature.PublicKey) (*node.Node, error) {
-	q, err := ht.registryQuery.QueryAt(height)
+	q, err := ht.registryQuery.QueryAt(context.Background(), height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/oasis-node/cmd/debug/byzantine/roothash.go
+++ b/go/oasis-node/cmd/debug/byzantine/roothash.go
@@ -13,7 +13,7 @@ import (
 )
 
 func roothashGetLatestBlock(ht *honestTendermint, height int64, runtimeID signature.PublicKey) (*block.Block, error) {
-	q, err := ht.roothashQuery.QueryAt(height)
+	q, err := ht.roothashQuery.QueryAt(context.Background(), height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/oasis-node/cmd/debug/byzantine/scheduler.go
+++ b/go/oasis-node/cmd/debug/byzantine/scheduler.go
@@ -54,7 +54,7 @@ func schedulerNextElectionHeight(svc service.TendermintService, kind scheduler.C
 }
 
 func schedulerGetCommittee(ht *honestTendermint, height int64, kind scheduler.CommitteeKind, runtimeID signature.PublicKey) (*scheduler.Committee, error) {
-	q, err := ht.schedulerQuery.QueryAt(height)
+	q, err := ht.schedulerQuery.QueryAt(context.Background(), height)
 	if err != nil {
 		return nil, errors.Wrap(err, "Tendermint QueryAt scheduler")
 	}

--- a/go/oasis-node/cmd/debug/byzantine/tendermint.go
+++ b/go/oasis-node/cmd/debug/byzantine/tendermint.go
@@ -51,7 +51,7 @@ func (t *fakeTimeBackend) GetEpoch(ctx context.Context, height int64) (epochtime
 
 	if t.useMockEpochTime {
 		// Query the epochtime_mock Tendermint application.
-		q, err := t.service.epochtimeMockQuery.QueryAt(height)
+		q, err := t.service.epochtimeMockQuery.QueryAt(ctx, height)
 		if err != nil {
 			return epochtime.EpochInvalid, errors.Wrap(err, "epochtime: epoch query failed")
 		}
@@ -159,7 +159,7 @@ func (ht *honestTendermint) start(id *identity.Identity, dataDir string, useMock
 	}
 	ht.schedulerQuery = schedApp.QueryFactory().(*schedulerapp.QueryFactory)
 	// storage has no registration
-	roothashApp := roothashapp.New(context.Background(), timeSource, nil, 10*time.Second)
+	roothashApp := roothashapp.New(timeSource, nil, 10*time.Second)
 	if err = ht.service.RegisterApplication(roothashApp); err != nil {
 		return errors.Wrap(err, "honest Tendermint service RegisterApplication roothash")
 	}

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -327,7 +327,7 @@ func testScheduler(t *testing.T, node *testNode) {
 func testStaking(t *testing.T, node *testNode) {
 	timeSource := (node.Epochtime).(epochtime.SetableBackend)
 
-	stakingTests.StakingImplementationTests(t, node.Staking, timeSource, node.Identity, node.entity)
+	stakingTests.StakingImplementationTests(t, node.Staking, timeSource, node.Registry, node.Identity, node.entity)
 }
 
 func testRootHash(t *testing.T, node *testNode) {

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -197,6 +197,9 @@ func TestNode(t *testing.T) {
 		// Client tests also need a functional runtime.
 		{"Client", testClient},
 
+		// Staking requires a registered node that is a validator.
+		{"Staking", testStaking},
+
 		// Clean up and ensure the registry is empty for the following tests.
 		{"DeregisterTestEntityRuntime", testDeregisterEntityRuntime},
 
@@ -205,7 +208,6 @@ func TestNode(t *testing.T) {
 		{"Storage", testStorage},
 		{"Registry", testRegistry},
 		{"Scheduler", testScheduler},
-		{"Staking", testStaking},
 		{"RootHash", testRootHash},
 
 		// TestStorageClient runs storage tests against a storage client connected to this node.
@@ -309,7 +311,7 @@ func testScheduler(t *testing.T, node *testNode) {
 func testStaking(t *testing.T, node *testNode) {
 	timeSource := (node.Epochtime).(epochtime.SetableBackend)
 
-	stakingTests.StakingImplementationTests(t, node.Staking, timeSource)
+	stakingTests.StakingImplementationTests(t, node.Staking, timeSource, node.Identity, node.entity)
 }
 
 func testRootHash(t *testing.T, node *testNode) {

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -156,6 +156,9 @@ type Backend interface {
 	// GetNode gets a node by ID.
 	GetNode(context.Context, signature.PublicKey, int64) (*node.Node, error)
 
+	// GetNodeStatus returns a node's status.
+	GetNodeStatus(context.Context, signature.PublicKey, int64) (*NodeStatus, error)
+
 	// GetNodes gets a list of all registered nodes.
 	GetNodes(context.Context, int64) ([]*node.Node, error)
 

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -54,6 +54,10 @@ var (
 	// runtime registation in the genesis document.
 	RegisterGenesisRuntimeSignatureContext = []byte("EkRunGen")
 
+	// RegisterUnfreezeNodeSignatureContext is the context used for
+	// unfreezing nodes.
+	RegisterUnfreezeNodeSignatureContext = []byte("EkUzNReg")
+
 	// ErrInvalidArgument is the error returned on malformed argument(s).
 	ErrInvalidArgument = errors.New("registry: invalid argument")
 
@@ -100,6 +104,10 @@ var (
 	// ErrNodeExpired is the error returned when a node is expired.
 	ErrNodeExpired = errors.New("registry: node expired")
 
+	// ErrNodeCannotBeUnfrozen is the error returned when a node cannot yet be
+	// unfrozen due to the freeze period not being over yet.
+	ErrNodeCannotBeUnfrozen = errors.New("registry: node cannot be unfrozen yet")
+
 	// ErrForbidden is the error returned when an operation is forbiden by
 	// policy.
 	ErrForbidden = errors.New("registry: forbidden by policy")
@@ -134,6 +142,12 @@ type Backend interface {
 	//
 	// The signature should be made using RegisterNodeSignatureContext.
 	RegisterNode(context.Context, *node.SignedNode) error
+
+	// UnfreezeNode unfreezes a previously frozen node.
+	//
+	// The signature should be made using RegisterUnfreezeNodeSignatureContext
+	// and must be made by the owning entity key.
+	UnfreezeNode(context.Context, *SignedUnfreezeNode) error
 
 	// GetNode gets a node by ID.
 	GetNode(context.Context, signature.PublicKey, int64) (*node.Node, error)
@@ -196,6 +210,7 @@ type NodeList struct {
 	Nodes []*node.Node
 }
 
+// Timestamp is a UNIX timestamp.
 type Timestamp uint64
 
 // MarshalCBOR serializes the Timestamp type into a CBOR byte vector.
@@ -798,6 +813,9 @@ type Genesis struct {
 	// KeyManagerOperator is the ID of the entity that is allowed to operate
 	// key manager nodes.
 	KeyManagerOperator signature.PublicKey `json:"km_operator"`
+
+	// NodeStatuses is a set of node statuses.
+	NodeStatuses map[signature.MapKey]*NodeStatus `json:"node_statuses,omitempty"`
 }
 
 // Config is the per-backend common configuration.

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -177,13 +177,6 @@ type Backend interface {
 	Cleanup()
 }
 
-// NodeTransport is a registered node's transport information required to
-// establish a secure connection with the node.
-type NodeTransport struct {
-	Addresses   []node.Address
-	Certificate []byte
-}
-
 // EntityEvent is the event that is returned via WatchEntities to signify
 // entity registration changes and updates.
 type EntityEvent struct {

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -108,6 +108,10 @@ var (
 	// unfrozen due to the freeze period not being over yet.
 	ErrNodeCannotBeUnfrozen = errors.New("registry: node cannot be unfrozen yet")
 
+	// ErrEntityHasNodes is the error returned when an entity cannot be deregistered
+	// as it still has nodes.
+	ErrEntityHasNodes = errors.New("registry: entity still has nodes")
+
 	// ErrForbidden is the error returned when an operation is forbiden by
 	// policy.
 	ErrForbidden = errors.New("registry: forbidden by policy")

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -690,7 +690,7 @@ func VerifyNodeUpdate(logger *logging.Logger, currentNode, newNode *node.Node) e
 		)
 		return ErrNodeUpdateNotAllowed
 	}
-	if currentNode.RegistrationTime >= newNode.RegistrationTime {
+	if currentNode.RegistrationTime > newNode.RegistrationTime {
 		logger.Error("RegisterNode: current node registration time greater than new",
 			"current_registration_time", currentNode.RegistrationTime,
 			"new_registration_time", newNode.RegistrationTime,

--- a/go/registry/api/status.go
+++ b/go/registry/api/status.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"github.com/oasislabs/oasis-core/go/common/cbor"
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
+)
+
+// FreezeForever is an epoch that can be used to freeze a node for
+// all (practical) time.
+const FreezeForever epochtime.EpochTime = 0xffffffffffffffff
+
+// NodeStatus is live status of a node.
+type NodeStatus struct {
+	// FreezeEndTime is the epoch when a frozen node can become unfrozen.
+	//
+	// After the specified epoch passes, this flag needs to be explicitly
+	// cleared (set to zero) in order for the node to become unfrozen.
+	FreezeEndTime epochtime.EpochTime `json:"freeze_end_time"`
+}
+
+// IsFrozen returns true if the node is currently frozen (prevented
+// from being considered in scheduling decisions).
+func (ns NodeStatus) IsFrozen() bool {
+	return ns.FreezeEndTime > 0
+}
+
+// Unfreeze makes the node unfrozen.
+func (ns *NodeStatus) Unfreeze() {
+	ns.FreezeEndTime = 0
+}
+
+// UnfreezeNode is a request to unfreeze a frozen node.
+type UnfreezeNode struct {
+	NodeID    signature.PublicKey `json:"node_id"`
+	Timestamp uint64              `json:"timestamp"`
+}
+
+// MarshalCBOR serializes the UnfreezeNode type into a CBOR byte vector.
+func (u *UnfreezeNode) MarshalCBOR() []byte {
+	return cbor.Marshal(u)
+}
+
+// UnmarshalCBOR deserializes a CBOR byte vector into a UnfreezeNode.
+func (u *UnfreezeNode) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, u)
+}
+
+// SignedUnfreezeNode is a signed UnfreezeNode.
+type SignedUnfreezeNode struct {
+	signature.Signed
+}
+
+// Open first verifies the blob signature and then unmarshals the blob.
+func (s *SignedUnfreezeNode) Open(context []byte, unfreeze *UnfreezeNode) error { // nolint: interfacer
+	return s.Signed.Open(context, unfreeze)
+}
+
+// SignUnfreezeNode serializes the UnfreezeNode and signs the result.
+func SignUnfreezeNode(signer signature.Signer, context []byte, unfreeze *UnfreezeNode) (*SignedUnfreezeNode, error) {
+	signed, err := signature.SignSigned(signer, context, unfreeze)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SignedUnfreezeNode{
+		Signed: *signed,
+	}, nil
+}

--- a/go/registry/api/status.go
+++ b/go/registry/api/status.go
@@ -12,6 +12,12 @@ const FreezeForever epochtime.EpochTime = 0xffffffffffffffff
 
 // NodeStatus is live status of a node.
 type NodeStatus struct {
+	// ExpirationProcessed is a flag specifying whether the node expiration
+	// has already been processed.
+	//
+	// If you want to check whether a node has expired, check the node
+	// descriptor directly instead of this flag.
+	ExpirationProcessed bool `json:"expiration_processed"`
 	// FreezeEndTime is the epoch when a frozen node can become unfrozen.
 	//
 	// After the specified epoch passes, this flag needs to be explicitly

--- a/go/registry/tendermint/tendermint.go
+++ b/go/registry/tendermint/tendermint.go
@@ -324,15 +324,6 @@ func (tb *tendermintBackend) onABCIEvents(ctx context.Context, events []abcitype
 					Entity:         &dereg.Entity,
 					IsRegistration: false,
 				})
-
-				// Node deregistrations.
-				for _, node := range dereg.Nodes {
-					nodeCopy := node
-					tb.nodeNotifier.Broadcast(&api.NodeEvent{
-						Node:           &nodeCopy,
-						IsRegistration: false,
-					})
-				}
 			} else if bytes.Equal(pair.GetKey(), app.KeyRegistryNodeListEpoch) {
 				nl, err := tb.getNodeList(ctx, height)
 				if err != nil {

--- a/go/registry/tendermint/tendermint.go
+++ b/go/registry/tendermint/tendermint.go
@@ -73,7 +73,7 @@ func (tb *tendermintBackend) DeregisterEntity(ctx context.Context, sigTimestamp 
 }
 
 func (tb *tendermintBackend) GetEntity(ctx context.Context, id signature.PublicKey, height int64) (*entity.Entity, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (tb *tendermintBackend) GetEntity(ctx context.Context, id signature.PublicK
 }
 
 func (tb *tendermintBackend) GetEntities(ctx context.Context, height int64) ([]*entity.Entity, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (tb *tendermintBackend) UnfreezeNode(ctx context.Context, sigUnfreeze *api.
 }
 
 func (tb *tendermintBackend) GetNode(ctx context.Context, id signature.PublicKey, height int64) (*node.Node, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (tb *tendermintBackend) GetNode(ctx context.Context, id signature.PublicKey
 }
 
 func (tb *tendermintBackend) GetNodes(ctx context.Context, height int64) ([]*node.Node, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func (tb *tendermintBackend) RegisterRuntime(ctx context.Context, sigCon *api.Si
 }
 
 func (tb *tendermintBackend) GetRuntime(ctx context.Context, id signature.PublicKey, height int64) (*api.Runtime, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (tb *tendermintBackend) Cleanup() {
 }
 
 func (tb *tendermintBackend) GetRuntimes(ctx context.Context, height int64) ([]*api.Runtime, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (tb *tendermintBackend) GetRuntimes(ctx context.Context, height int64) ([]*
 }
 
 func (tb *tendermintBackend) ToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +363,7 @@ func (tb *tendermintBackend) onABCIEvents(ctx context.Context, events []abcitype
 
 func (tb *tendermintBackend) getNodeList(ctx context.Context, height int64) (*api.NodeList, error) {
 	// Generate the nodelist.
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/registry/tendermint/tendermint.go
+++ b/go/registry/tendermint/tendermint.go
@@ -135,6 +135,15 @@ func (tb *tendermintBackend) GetNode(ctx context.Context, id signature.PublicKey
 	return q.Node(ctx, id)
 }
 
+func (tb *tendermintBackend) GetNodeStatus(ctx context.Context, id signature.PublicKey, height int64) (*api.NodeStatus, error) {
+	q, err := tb.querier.QueryAt(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+
+	return q.NodeStatus(ctx, id)
+}
+
 func (tb *tendermintBackend) GetNodes(ctx context.Context, height int64) ([]*node.Node, error) {
 	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {

--- a/go/registry/tendermint/tendermint.go
+++ b/go/registry/tendermint/tendermint.go
@@ -112,6 +112,20 @@ func (tb *tendermintBackend) RegisterNode(ctx context.Context, sigNode *node.Sig
 	return nil
 }
 
+func (tb *tendermintBackend) UnfreezeNode(ctx context.Context, sigUnfreeze *api.SignedUnfreezeNode) error {
+	tx := app.Tx{
+		TxUnfreezeNode: &app.TxUnfreezeNode{
+			UnfreezeNode: *sigUnfreeze,
+		},
+	}
+
+	if err := tb.service.BroadcastTx(ctx, app.TransactionTag, tx, true); err != nil {
+		return errors.Wrap(err, "registry: unfreeze node failed")
+	}
+
+	return nil
+}
+
 func (tb *tendermintBackend) GetNode(ctx context.Context, id signature.PublicKey, height int64) (*node.Node, error) {
 	q, err := tb.querier.QueryAt(height)
 	if err != nil {

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -205,6 +205,12 @@ func testRegistryEntityNodes(t *testing.T, backend api.Backend, timeSource epoch
 		ctx, cancel := context.WithTimeout(context.Background(), recvTimeout)
 		defer cancel()
 
+		// Get node status.
+		nodeStatus, err := backend.GetNodeStatus(ctx, node.Node.ID, 0)
+		require.NoError(err, "GetNodeStatus")
+		require.False(nodeStatus.ExpirationProcessed, "ExpirationProcessed should be false")
+		require.False(nodeStatus.IsFrozen(), "IsFrozen() should return false")
+
 		// Try to unfreeze a node.
 		unfreeze := api.UnfreezeNode{
 			NodeID:    node.Node.ID,

--- a/go/roothash/api/block/header.go
+++ b/go/roothash/api/block/header.go
@@ -34,6 +34,7 @@ const (
 	// EpochTransition is a header resulting from an epoch transition.
 	// Such a header contains no transactions but advances the round as
 	// normal.
+	// TODO: Consider renaming this to CommitteeTransition.
 	EpochTransition HeaderType = 2
 )
 

--- a/go/roothash/tendermint/tendermint.go
+++ b/go/roothash/tendermint/tendermint.go
@@ -439,7 +439,8 @@ func (tb *tendermintBackend) worker(ctx context.Context) { // nolint: gocyclo
 		switch ev := event.(type) {
 		case tmtypes.EventDataNewBlock:
 			height = ev.Block.Header.Height
-			tmEvents = append(ev.ResultBeginBlock.GetEvents(), ev.ResultEndBlock.GetEvents()...)
+			tmEvents = append([]types.Event{}, ev.ResultBeginBlock.GetEvents()...)
+			tmEvents = append(tmEvents, ev.ResultEndBlock.GetEvents()...)
 		case tmtypes.EventDataTx:
 			height = ev.Height
 			tmEvents = ev.Result.GetEvents()

--- a/go/roothash/tendermint/tendermint.go
+++ b/go/roothash/tendermint/tendermint.go
@@ -96,7 +96,7 @@ func (tb *tendermintBackend) GetGenesisBlock(ctx context.Context, id signature.P
 	}
 	tb.RUnlock()
 
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (tb *tendermintBackend) GetLatestBlock(ctx context.Context, id signature.Pu
 }
 
 func (tb *tendermintBackend) getLatestBlockAt(ctx context.Context, id signature.PublicKey, height int64) (*block.Block, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +243,7 @@ func (tb *tendermintBackend) ComputeCommit(ctx context.Context, id signature.Pub
 }
 
 func (tb *tendermintBackend) ToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -536,7 +536,7 @@ func New(
 	roundTimeout time.Duration,
 ) (api.Backend, error) {
 	// Initialize and register the tendermint service component.
-	a := app.New(ctx, timeSource, beac, roundTimeout)
+	a := app.New(timeSource, beac, roundTimeout)
 	if err := service.RegisterApplication(a); err != nil {
 		return nil, err
 	}

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -56,7 +56,7 @@ func RootHashImplementationTests(t *testing.T, backend api.Backend, epochtime ep
 		if len(rtStates) > 0 {
 			// This is entity deregistration based, and all of the
 			// runtimes used in this test share the entity.
-			rtStates[0].rt.Cleanup(t, registry)
+			rtStates[0].rt.Cleanup(t, registry, epochtime)
 		}
 
 		registryTests.EnsureRegistryEmpty(t, registry)
@@ -78,7 +78,7 @@ func RootHashImplementationTests(t *testing.T, backend api.Backend, epochtime ep
 		})
 		runtimes = append(runtimes, rt)
 	}
-	registryTests.BulkPopulate(t, registry, runtimes, seedBase)
+	registryTests.BulkPopulate(t, registry, epochtime, runtimes, seedBase)
 	for _, rt := range runtimes {
 		rt.MustRegister(t, registry)
 	}
@@ -343,7 +343,9 @@ func (s *runtimeState) testSuccessfulRound(t *testing.T, backend api.Backend, st
 		mergeCommits = append(mergeCommits, *commit)
 	}
 
-	err = backend.MergeCommit(context.Background(), rt.Runtime.ID, mergeCommits)
+	ctx, cancel := context.WithTimeout(context.Background(), recvTimeout)
+	defer cancel()
+	err = backend.MergeCommit(ctx, rt.Runtime.ID, mergeCommits)
 	require.NoError(err, "MergeCommit")
 
 	// Ensure that the round was finalized.
@@ -616,7 +618,9 @@ func testRoothashMessages(t *testing.T, backend api.Backend, states []*runtimeSt
 				mergeCommits = append(mergeCommits, *commit)
 			}
 
-			err = backend.MergeCommit(context.Background(), rt.Runtime.ID, mergeCommits)
+			ctx, cancel := context.WithTimeout(context.Background(), recvTimeout)
+			defer cancel()
+			err = backend.MergeCommit(ctx, rt.Runtime.ID, mergeCommits)
 			require.NoError(err, "MergeCommit")
 
 			// Ensure that the round was finalized.

--- a/go/scheduler/tendermint/tendermint.go
+++ b/go/scheduler/tendermint/tendermint.go
@@ -38,7 +38,7 @@ func (tb *tendermintBackend) Cleanup() {
 }
 
 func (tb *tendermintBackend) GetCommittees(ctx context.Context, id signature.PublicKey, height int64) ([]*api.Committee, error) {
-	q, err := tb.querier.QueryAt(0)
+	q, err := tb.querier.QueryAt(ctx, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func (tb *tendermintBackend) WatchCommittees() (<-chan *api.Committee, *pubsub.S
 }
 
 func (tb *tendermintBackend) getCurrentCommittees() ([]*api.Committee, error) {
-	q, err := tb.querier.QueryAt(0)
+	q, err := tb.querier.QueryAt(context.TODO(), 0)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (tb *tendermintBackend) onEventDataNewBlock(ctx context.Context, ev tmtypes
 					continue
 				}
 
-				q, err := tb.querier.QueryAt(ev.Block.Header.Height)
+				q, err := tb.querier.QueryAt(ctx, ev.Block.Header.Height)
 				if err != nil {
 					tb.logger.Error("worker: couldn't query elected committees",
 						"err", err,
@@ -141,7 +141,7 @@ func (tb *tendermintBackend) onEventDataNewBlock(ctx context.Context, ev tmtypes
 					continue
 				}
 
-				committees, err := q.KindsCommittees(context.TODO(), kinds)
+				committees, err := q.KindsCommittees(ctx, kinds)
 				if err != nil {
 					tb.logger.Error("worker: couldn't query elected committees",
 						"err", err,

--- a/go/scheduler/tests/tester.go
+++ b/go/scheduler/tests/tester.go
@@ -31,7 +31,7 @@ func SchedulerImplementationTests(t *testing.T, backend api.Backend, epochtime e
 	require.NoError(err, "NewTestRuntime")
 
 	// Populate the registry with an entity and nodes.
-	nodes := rt.Populate(t, registry, rt, seed)
+	nodes := rt.Populate(t, registry, epochtime, rt, seed)
 	rt.MustRegister(t, registry)
 
 	ch, sub := backend.WatchCommittees()
@@ -121,7 +121,7 @@ func SchedulerImplementationTests(t *testing.T, backend api.Backend, epochtime e
 	ensureValidCommittees(3, 1, int(rt.Runtime.TransactionSchedulerGroupSize))
 
 	// Cleanup the registry.
-	rt.Cleanup(t, registry)
+	rt.Cleanup(t, registry, epochtime)
 }
 
 func requireValidCommitteeMembers(t *testing.T, committee *api.Committee, runtime *registry.Runtime, nodes []*node.Node) {

--- a/go/staking/api/slashing.go
+++ b/go/staking/api/slashing.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"math/big"
+
+	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
+)
+
+// SlashReason is the reason why a node was slashed.
+type SlashReason int
+
+const (
+	// SlashDoubleSigning is slashing due to double signing.
+	SlashDoubleSigning SlashReason = 0
+
+	SlashMax = SlashDoubleSigning
+)
+
+// String returns a string representation of a SlashReason.
+func (s SlashReason) String() string {
+	switch s {
+	case SlashDoubleSigning:
+		return "double-signing"
+	default:
+		return "[unknown slash reason]"
+	}
+}
+
+// Slash is the per-reason slashing configuration.
+type Slash struct {
+	Share          Quantity            `json:"share"`
+	FreezeInterval epochtime.EpochTime `json:"freeze_interval"`
+}
+
+// SlashAmountDenominator is the denominator for the slash share.
+var SlashAmountDenominator *Quantity
+
+// EvidenceKind is kind of evindence of a node misbehaving.
+type EvidenceKind int
+
+const (
+	// EvidenceKindConsensus is consensus-layer specific evidence.
+	EvidenceKindConsensus EvidenceKind = 0
+
+	EvidenceKindMax = EvidenceKindConsensus
+)
+
+// String returns a string representation of an EvidenceKind.
+func (k EvidenceKind) String() string {
+	switch k {
+	case EvidenceKindConsensus:
+		return "consensus"
+	default:
+		return "[unknown evidence kind]"
+	}
+}
+
+// Evidence is evidence of a node misbehaving.
+type Evidence interface {
+	// Kind returns the evidence kind.
+	Kind() EvidenceKind
+	// Unwrap returns the unwrapped evidence (if any).
+	Unwrap() interface{}
+}
+
+// ConsensusEvidence is consensus backend-specific evidence.
+type ConsensusEvidence struct {
+	inner interface{}
+}
+
+var _ Evidence = (*ConsensusEvidence)(nil)
+
+// Kind returns the evidence kind.
+func (ce ConsensusEvidence) Kind() EvidenceKind {
+	return EvidenceKindConsensus
+}
+
+// Unwrap returns the unwrapped evidence (if any).
+func (ce ConsensusEvidence) Unwrap() interface{} {
+	return ce.inner
+}
+
+// NewConsensusEvidence creates new consensus backend-specific evidence.
+func NewConsensusEvidence(inner interface{}) ConsensusEvidence {
+	return ConsensusEvidence{inner: inner}
+}
+
+func init() {
+	// Denominated in 1000th of a percent.
+	SlashAmountDenominator = NewQuantity()
+	err := SlashAmountDenominator.FromBigInt(big.NewInt(100_000))
+	if err != nil {
+		panic(err)
+	}
+}

--- a/go/staking/tendermint/tendermint.go
+++ b/go/staking/tendermint/tendermint.go
@@ -48,7 +48,7 @@ func (tb *tendermintBackend) Symbol() string {
 }
 
 func (tb *tendermintBackend) TotalSupply(ctx context.Context, height int64) (*api.Quantity, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (tb *tendermintBackend) TotalSupply(ctx context.Context, height int64) (*ap
 }
 
 func (tb *tendermintBackend) CommonPool(ctx context.Context, height int64) (*api.Quantity, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (tb *tendermintBackend) CommonPool(ctx context.Context, height int64) (*api
 }
 
 func (tb *tendermintBackend) Threshold(ctx context.Context, kind api.ThresholdKind, height int64) (*api.Quantity, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (tb *tendermintBackend) Threshold(ctx context.Context, kind api.ThresholdKi
 }
 
 func (tb *tendermintBackend) Accounts(ctx context.Context, height int64) ([]signature.PublicKey, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (tb *tendermintBackend) Accounts(ctx context.Context, height int64) ([]sign
 }
 
 func (tb *tendermintBackend) AccountInfo(ctx context.Context, owner signature.PublicKey, height int64) (*api.Account, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (tb *tendermintBackend) AccountInfo(ctx context.Context, owner signature.Pu
 }
 
 func (tb *tendermintBackend) DebondingDelegations(ctx context.Context, owner signature.PublicKey, height int64) (map[signature.MapKey][]*api.DebondingDelegation, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (tb *tendermintBackend) WatchEscrows() (<-chan interface{}, *pubsub.Subscri
 }
 
 func (tb *tendermintBackend) ToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
-	q, err := tb.querier.QueryAt(height)
+	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err
 	}

--- a/go/staking/tendermint/tendermint.go
+++ b/go/staking/tendermint/tendermint.go
@@ -153,6 +153,23 @@ func (tb *tendermintBackend) ReclaimEscrow(ctx context.Context, signedReclaim *a
 	return nil
 }
 
+func (tb *tendermintBackend) SubmitEvidence(ctx context.Context, evidence api.Evidence) error {
+	if evidence.Kind() != api.EvidenceKindConsensus {
+		return errors.New("staking: unsupported evidence kind")
+	}
+
+	tmEvidence, ok := evidence.Unwrap().(tmtypes.Evidence)
+	if !ok {
+		return errors.New("staking: expected tendermint evidence, got something else")
+	}
+
+	if err := tb.service.BroadcastEvidence(ctx, tmEvidence); err != nil {
+		return errors.Wrap(err, "staking: broadcast evidence failed")
+	}
+
+	return nil
+}
+
 func (tb *tendermintBackend) WatchTransfers() (<-chan *api.TransferEvent, *pubsub.Subscription) {
 	typedCh := make(chan *api.TransferEvent)
 	sub := tb.transferNotifier.Subscribe()

--- a/go/staking/tests/tendermint.go
+++ b/go/staking/tests/tendermint.go
@@ -1,0 +1,148 @@
+package tests
+
+// NOTE: This file contains Tendermint-specific tests.
+
+import (
+	"context"
+	"io/ioutil"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	tmtypes "github.com/tendermint/tendermint/types"
+
+	"github.com/oasislabs/oasis-core/go/common/entity"
+	"github.com/oasislabs/oasis-core/go/common/identity"
+	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
+	"github.com/oasislabs/oasis-core/go/staking/api"
+	tmcrypto "github.com/oasislabs/oasis-core/go/tendermint/crypto"
+)
+
+func testSlashDoubleSigning(
+	t *testing.T,
+	backend api.Backend,
+	timeSource epochtime.SetableBackend,
+	ident *identity.Identity,
+	ent *entity.Entity,
+) {
+	require := require.New(t)
+
+	// Delegate some stake to the validator so we can check if slashing works.
+	srcAcc, err := backend.AccountInfo(context.Background(), SrcID, 0)
+	require.NoError(err, "AccountInfo")
+
+	escrowCh, escrowSub := backend.WatchEscrows()
+	defer escrowSub.Close()
+
+	escrow := &api.Escrow{
+		Nonce:   srcAcc.General.Nonce,
+		Account: ent.ID,
+		Tokens:  QtyFromInt(math.MaxUint32),
+	}
+	signed, err := api.SignEscrow(srcSigner, escrow)
+	require.NoError(err, "Sign escrow")
+
+	err = backend.AddEscrow(context.Background(), signed)
+	require.NoError(err, "AddEscrow")
+
+	select {
+	case rawEv := <-escrowCh:
+		ev := rawEv.(*api.EscrowEvent)
+		require.Equal(SrcID, ev.Owner, "Event: owner")
+		require.Equal(ent.ID, ev.Escrow, "Event: escrow")
+		require.Equal(escrow.Tokens, ev.Tokens, "Event: tokens")
+	case <-time.After(recvTimeout):
+		t.Fatalf("failed to receive escrow event")
+	}
+
+	// Create empty directory for private validator metadata.
+	tmpDir, err := ioutil.TempDir("", "oasis-slash-test")
+	require.NoError(err, "TempDir")
+	defer os.RemoveAll(tmpDir)
+
+	// Create two private validators that share the same key as otherwise
+	// double signing will fail.
+	pv1Path := filepath.Join(tmpDir, "pv1")
+	err = os.Mkdir(pv1Path, 0700)
+	require.NoError(err, "Mkdir")
+	pv1, err := tmcrypto.LoadOrGeneratePrivVal(pv1Path, ident.ConsensusSigner)
+	require.NoError(err, "LoadOrGeneratePrivVal")
+	pv2Path := filepath.Join(tmpDir, "pv2")
+	err = os.Mkdir(pv2Path, 0700)
+	require.NoError(err, "Mkdir")
+	pv2, err := tmcrypto.LoadOrGeneratePrivVal(pv2Path, ident.ConsensusSigner)
+	require.NoError(err, "LoadOrGeneratePrivVal")
+
+	// Generate fake Tendermint-specific double-signing evidence for the
+	// current node (as this node is the only validator during tests).
+	//
+	// This means that the vote is for the same height/round/step but for
+	// different block IDs.
+	blockID1 := tmtypes.BlockID{
+		Hash: []byte("blockhashblockhashblockhashbloc1"),
+		PartsHeader: tmtypes.PartSetHeader{
+			Total: 1000,
+			Hash:  []byte("partshashpartshashpartshashpart1"),
+		},
+	}
+	blockID2 := tmtypes.BlockID{
+		Hash: []byte("blockhashblockhashblockhashbloc1"),
+		PartsHeader: tmtypes.PartSetHeader{
+			Total: 1000,
+			Hash:  []byte("partshashpartshashpartshashpart2"),
+		},
+	}
+	ev := &tmtypes.DuplicateVoteEvidence{
+		PubKey: pv1.GetPubKey(),
+		// NOTE: ChainID must match the unit test genesis block.
+		VoteA: makeVote(pv1, "oasis-test-chain", 0, 1, 2, 1, blockID1),
+		VoteB: makeVote(pv2, "oasis-test-chain", 0, 1, 2, 1, blockID2),
+	}
+
+	// Subscribe to slash events.
+	slashCh, slashSub := backend.WatchEscrows()
+	defer slashSub.Close()
+
+	// Broadcast evidence.
+	err = backend.SubmitEvidence(context.Background(), api.NewConsensusEvidence(ev))
+	require.NoError(err, "SubmitEvidence")
+
+	// Wait for the node to get slashed.
+WaitLoop:
+	for {
+		select {
+		case ev := <-slashCh:
+			if e, ok := ev.(*api.TakeEscrowEvent); ok {
+				require.Equal(ent.ID, e.Owner, "TakeEscrowEvent - owner must be entity")
+				// All tokens must be slashed as defined in debugGenesisState.
+				require.Equal(escrow.Tokens, e.Tokens, "TakeEscrowEvent - all tokens slashed")
+				break WaitLoop
+			}
+		case <-time.After(recvTimeout):
+			t.Fatalf("failed to receive slash event")
+		}
+	}
+
+	// TODO: Make sure the node is frozen.
+}
+
+// makeVote copied from Tendermint test suite.
+func makeVote(val tmtypes.PrivValidator, chainID string, valIndex int, height int64, round, step int, blockID tmtypes.BlockID) *tmtypes.Vote {
+	addr := val.GetPubKey().Address()
+	v := &tmtypes.Vote{
+		ValidatorAddress: addr,
+		ValidatorIndex:   valIndex,
+		Height:           height,
+		Round:            round,
+		Type:             tmtypes.SignedMsgType(step),
+		BlockID:          blockID,
+	}
+	err := val.SignVote(chainID, v)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/go/storage/client/tests/tests.go
+++ b/go/storage/client/tests/tests.go
@@ -71,7 +71,12 @@ func ClientWorkerTests(
 	}
 
 	// Storage should not yet be available.
-	r, err := client.SyncGet(ctx, &api.GetRequest{})
+	r, err := client.SyncGet(ctx, &api.GetRequest{
+		Tree: api.TreeID{
+			Root:     root,
+			Position: root.Hash,
+		},
+	})
 	require.EqualError(err, storageClient.ErrStorageNotAvailable.Error(), "storage client get before initialization")
 	require.Nil(r, "result should be nil")
 

--- a/go/tendermint/abci/context.go
+++ b/go/tendermint/abci/context.go
@@ -1,6 +1,7 @@
 package abci
 
 import (
+	"bytes"
 	"context"
 	"time"
 
@@ -99,6 +100,24 @@ func (c *Context) EmitEvent(bld *api.EventBuilder) {
 // GetEvents returns the ABCI event vector corresponding to the tags.
 func (c *Context) GetEvents() []types.Event {
 	return c.events
+}
+
+// HasEvent checks if a specific event has been emitted.
+func (c *Context) HasEvent(evType string, key []byte) bool {
+	evType = api.EventTypeForApp(evType)
+
+	for _, ev := range c.events {
+		if ev.Type != evType {
+			continue
+		}
+
+		for _, pair := range ev.Attributes {
+			if bytes.Equal(pair.GetKey(), key) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Now returns the current tendermint time.

--- a/go/tendermint/abci/context.go
+++ b/go/tendermint/abci/context.go
@@ -99,6 +99,11 @@ func (c *Context) State() *iavl.MutableTree {
 	return c.state.DeliverTxTree()
 }
 
+// BlockHeight returns the current block height.
+func (c *Context) BlockHeight() int64 {
+	return c.state.BlockHeight()
+}
+
 // NewStateCheckpoint creates a new state checkpoint.
 func (c *Context) NewStateCheckpoint() *StateCheckpoint {
 	return &StateCheckpoint{

--- a/go/tendermint/abci/context.go
+++ b/go/tendermint/abci/context.go
@@ -1,6 +1,7 @@
 package abci
 
 import (
+	"context"
 	"time"
 
 	"github.com/tendermint/iavl"
@@ -8,6 +9,8 @@ import (
 
 	"github.com/oasislabs/oasis-core/go/tendermint/api"
 )
+
+type contextKey struct{}
 
 // ContextType is a context type.
 type ContextType uint
@@ -43,6 +46,18 @@ func NewContext(outputType ContextType, now time.Time, state *ApplicationState) 
 		currentTime: now,
 		state:       state,
 	}
+}
+
+// FromCtx extracts an ABCI context from a context.Context if one has been
+// set. Otherwise it returns nil.
+func FromCtx(ctx context.Context) *Context {
+	abciCtx, _ := ctx.Value(contextKey{}).(*Context)
+	return abciCtx
+}
+
+// Ctx returns a context.Context that is associated with this ABCI context.
+func (c *Context) Ctx() context.Context {
+	return context.WithValue(c.state.ctx, contextKey{}, c)
 }
 
 // Type returns the type of this output.

--- a/go/tendermint/abci/mux.go
+++ b/go/tendermint/abci/mux.go
@@ -734,14 +734,14 @@ func (s *ApplicationState) CheckTxTree() *iavl.MutableTree {
 // EpochChanged returns true iff the current epoch has changed since the
 // last block.  As a matter of convenience, the current epoch is returned
 // iff it has changed.
-func (s *ApplicationState) EpochChanged(timeSource epochtime.Backend) (bool, epochtime.EpochTime) {
+func (s *ApplicationState) EpochChanged(ctx *Context, timeSource epochtime.Backend) (bool, epochtime.EpochTime) {
 	blockHeight := s.BlockHeight()
 	if blockHeight == 0 {
 		return false, epochtime.EpochInvalid
 	} else if blockHeight == 1 {
 		// There is no block before the first block. For historic reasons, this is defined as not
 		// having had a transition.
-		currentEpoch, err := timeSource.GetEpoch(s.ctx, blockHeight)
+		currentEpoch, err := timeSource.GetEpoch(ctx.Ctx(), blockHeight)
 		if err != nil {
 			s.logger.Error("EpochChanged: failed to get current epoch",
 				"err", err,
@@ -751,14 +751,14 @@ func (s *ApplicationState) EpochChanged(timeSource epochtime.Backend) (bool, epo
 		return false, currentEpoch
 	}
 
-	previousEpoch, err := timeSource.GetEpoch(s.ctx, blockHeight-1)
+	previousEpoch, err := timeSource.GetEpoch(ctx.Ctx(), blockHeight)
 	if err != nil {
 		s.logger.Error("EpochChanged: failed to get previous epoch",
 			"err", err,
 		)
 		return false, epochtime.EpochInvalid
 	}
-	currentEpoch, err := timeSource.GetEpoch(s.ctx, blockHeight)
+	currentEpoch, err := timeSource.GetEpoch(ctx.Ctx(), blockHeight+1)
 	if err != nil {
 		s.logger.Error("EpochChanged: failed to get current epoch",
 			"err", err,

--- a/go/tendermint/abci/mux.go
+++ b/go/tendermint/abci/mux.go
@@ -732,8 +732,7 @@ func (s *ApplicationState) CheckTxTree() *iavl.MutableTree {
 }
 
 // EpochChanged returns true iff the current epoch has changed since the
-// last block.  As a matter of convenience, the current epoch is returned
-// iff it has changed.
+// last block.  As a matter of convenience, the current epoch is returned.
 func (s *ApplicationState) EpochChanged(ctx *Context, timeSource epochtime.Backend) (bool, epochtime.EpochTime) {
 	blockHeight := s.BlockHeight()
 	if blockHeight == 0 {
@@ -767,7 +766,7 @@ func (s *ApplicationState) EpochChanged(ctx *Context, timeSource epochtime.Backe
 	}
 
 	if previousEpoch == currentEpoch {
-		return false, epochtime.EpochInvalid
+		return false, currentEpoch
 	}
 
 	s.logger.Debug("EpochChanged: epoch transition detected",

--- a/go/tendermint/apps/beacon/beacon.go
+++ b/go/tendermint/apps/beacon/beacon.go
@@ -75,7 +75,7 @@ func (app *beaconApplication) InitChain(ctx *abci.Context, req types.RequestInit
 }
 
 func (app *beaconApplication) BeginBlock(ctx *abci.Context, req types.RequestBeginBlock) error {
-	if changed, beaconEpoch := app.state.EpochChanged(app.timeSource); changed {
+	if changed, beaconEpoch := app.state.EpochChanged(ctx, app.timeSource); changed {
 		return app.onBeaconEpochChange(ctx, beaconEpoch, req)
 	}
 	return nil
@@ -104,7 +104,7 @@ func (app *beaconApplication) onBeaconEpochChange(ctx *abci.Context, epoch epoch
 	case false:
 		entropyCtx = prodEntropyCtx
 
-		height := app.state.BlockHeight()
+		height := ctx.BlockHeight()
 		if height <= 1 {
 			// No meaningful previous commit, use the block hash.  This isn't
 			// fantastic, but it's only for one epoch.
@@ -136,7 +136,7 @@ func (app *beaconApplication) onBeaconEpochChange(ctx *abci.Context, epoch epoch
 		"epoch", epoch,
 		"beacon", hex.EncodeToString(b),
 		"block_hash", hex.EncodeToString(entropy),
-		"height", app.state.BlockHeight(),
+		"height", ctx.BlockHeight(),
 	)
 
 	return app.onNewBeacon(ctx, b)

--- a/go/tendermint/apps/epochtime_mock/epochtime_mock.go
+++ b/go/tendermint/apps/epochtime_mock/epochtime_mock.go
@@ -65,7 +65,7 @@ func (app *epochTimeMockApplication) BeginBlock(ctx *abci.Context, request types
 	}
 	defer state.clearFutureEpoch()
 
-	height := app.state.BlockHeight()
+	height := ctx.BlockHeight()
 	if future.Height != height {
 		app.logger.Error("BeginBlock: height mismatch in defered set",
 			"height", height,
@@ -119,7 +119,7 @@ func (app *epochTimeMockApplication) setEpoch(
 	state *mutableState,
 	epoch epochtime.EpochTime,
 ) error {
-	height := app.state.BlockHeight()
+	height := ctx.BlockHeight()
 
 	app.logger.Info("scheduling epoch transition",
 		"epoch", epoch,

--- a/go/tendermint/apps/keymanager/keymanager.go
+++ b/go/tendermint/apps/keymanager/keymanager.go
@@ -58,7 +58,7 @@ func (app *keymanagerApplication) SetOption(request types.RequestSetOption) type
 }
 
 func (app *keymanagerApplication) BeginBlock(ctx *abci.Context, request types.RequestBeginBlock) error {
-	if changed, epoch := app.state.EpochChanged(app.timeSource); changed {
+	if changed, epoch := app.state.EpochChanged(ctx, app.timeSource); changed {
 		return app.onEpochChange(ctx, epoch)
 	}
 	return nil

--- a/go/tendermint/apps/registry/api.go
+++ b/go/tendermint/apps/registry/api.go
@@ -91,11 +91,8 @@ type TxRegisterRuntime struct {
 	Runtime registry.SignedRuntime `json:"runtime"`
 }
 
-// EntityDeregistration is a entity deregistration.
+// EntityDeregistration is an entity deregistration.
 type EntityDeregistration struct {
 	// Deregistered entity.
 	Entity entity.Entity `json:"entity"`
-
-	// Deregistered nodes (if any).
-	Nodes []node.Node `json:"nodes"`
 }

--- a/go/tendermint/apps/registry/api.go
+++ b/go/tendermint/apps/registry/api.go
@@ -47,6 +47,10 @@ var (
 	// vector of node descriptors).
 	KeyNodesExpired = []byte("nodes.expired")
 
+	// KeyNodeUnfrozen is the ABCI event attribute for when nodes
+	// become unfrozen (value is CBOR serialized node ID).
+	KeyNodeUnfrozen = []byte("nodes.unfrozen")
+
 	// KeyRegistryNodeListEpoch is the ABCI event attribute for
 	// registry epochs.
 	KeyRegistryNodeListEpoch = []byte("nodes.epoch")
@@ -57,35 +61,41 @@ type Tx struct {
 	*TxRegisterEntity   `json:"RegisterEntity,omitempty"`
 	*TxDeregisterEntity `json:"DeregisterEntity,omitempty"`
 	*TxRegisterNode     `json:"RegisterNode,omitempty"`
+	*TxUnfreezeNode     `json:"UnfreezeNode,omitempty"`
 
 	*TxRegisterRuntime `json:"RegisterRuntime,omitempty"`
 }
 
 // TxRegisterEntity is a transaction for registering a new entity.
 type TxRegisterEntity struct {
-	Entity entity.SignedEntity
+	Entity entity.SignedEntity `json:"entity"`
 }
 
 // TxDeregisterEntity is a transaction for deregistering an entity.
 type TxDeregisterEntity struct {
-	Timestamp signature.Signed
+	Timestamp signature.Signed `json:"timestamp"`
 }
 
 // TxRegisterNode is a transaction for registering a new node.
 type TxRegisterNode struct {
-	Node node.SignedNode
+	Node node.SignedNode `json:"node"`
+}
+
+// TxUnfreezeNode is a transaction for unfreezing a node.
+type TxUnfreezeNode struct {
+	UnfreezeNode registry.SignedUnfreezeNode `json:"unfreeze_node"`
 }
 
 // TxRegisterRuntime is a transaction for registering a new runtime.
 type TxRegisterRuntime struct {
-	Runtime registry.SignedRuntime
+	Runtime registry.SignedRuntime `json:"runtime"`
 }
 
 // EntityDeregistration is a entity deregistration.
 type EntityDeregistration struct {
 	// Deregistered entity.
-	Entity entity.Entity
+	Entity entity.Entity `json:"entity"`
 
 	// Deregistered nodes (if any).
-	Nodes []node.Node
+	Nodes []node.Node `json:"nodes"`
 }

--- a/go/tendermint/apps/registry/query.go
+++ b/go/tendermint/apps/registry/query.go
@@ -17,6 +17,7 @@ type Query interface {
 	Entity(context.Context, signature.PublicKey) (*entity.Entity, error)
 	Entities(context.Context) ([]*entity.Entity, error)
 	Node(context.Context, signature.PublicKey) (*node.Node, error)
+	NodeStatus(context.Context, signature.PublicKey) (*registry.NodeStatus, error)
 	Nodes(context.Context) ([]*node.Node, error)
 	Runtime(context.Context, signature.PublicKey) (*registry.Runtime, error)
 	Runtimes(context.Context) ([]*registry.Runtime, error)
@@ -73,6 +74,10 @@ func (rq *registryQuerier) Node(ctx context.Context, id signature.PublicKey) (*n
 		return nil, registry.ErrNoSuchNode
 	}
 	return node, nil
+}
+
+func (rq *registryQuerier) NodeStatus(ctx context.Context, id signature.PublicKey) (*registry.NodeStatus, error) {
+	return rq.state.NodeStatus(id)
 }
 
 func (rq *registryQuerier) Nodes(ctx context.Context) ([]*node.Node, error) {

--- a/go/tendermint/apps/registry/registry.go
+++ b/go/tendermint/apps/registry/registry.go
@@ -110,6 +110,7 @@ func (app *registryApplication) FireTimer(*abci.Context, *abci.Timer) error {
 
 func (app *registryApplication) onRegistryEpochChanged(ctx *abci.Context, registryEpoch epochtime.EpochTime) error {
 	state := registryState.NewMutableState(ctx.State())
+	stakeState := stakingState.NewMutableState(ctx.State())
 
 	nodes, err := state.Nodes()
 	if err != nil {
@@ -119,13 +120,48 @@ func (app *registryApplication) onRegistryEpochChanged(ctx *abci.Context, regist
 		return errors.Wrap(err, "registry: onRegistryEpochChanged: failed to get nodes")
 	}
 
+	debondingInterval, err := stakeState.DebondingInterval()
+	if err != nil {
+		app.logger.Error("onRegistryEpochChanged: failed to get debonding interval",
+			"err", err,
+		)
+		return errors.Wrap(err, "registry: onRegistryEpochChanged: failed to get debonding interval")
+	}
+
+	// When a node expires, it is kept around for up to the debonding
+	// period and then removed. This is required so that expired nodes
+	// can still get slashed while inside the debonding interval as
+	// otherwise the nodes could not be resolved.
 	var expiredNodes []*node.Node
 	for _, node := range nodes {
-		if epochtime.EpochTime(node.Expiration) >= registryEpoch {
+		if !node.IsExpired(uint64(registryEpoch)) {
 			continue
 		}
-		expiredNodes = append(expiredNodes, node)
-		state.RemoveNode(node)
+
+		// Fetch node status to check whether we have already processed the
+		// node expiration (this is required so that we don't emit expiration
+		// events every epoch).
+		var status *registry.NodeStatus
+		status, err = state.NodeStatus(node.ID)
+		if err != nil {
+			return errors.Wrap(err, "registry: onRegistryEpochChanged: couldn't get node status")
+		}
+
+		if !status.ExpirationProcessed {
+			expiredNodes = append(expiredNodes, node)
+			status.ExpirationProcessed = true
+			if err = state.SetNodeStatus(node.ID, status); err != nil {
+				return errors.Wrap(err, "registry: onRegistryEpochChanged: couldn't set node status")
+			}
+		}
+
+		// If node has been expired for the debonding interval, finally remove it.
+		if node.Expiration+debondingInterval < uint64(registryEpoch) {
+			app.logger.Debug("removing expired node",
+				"node_id", node.ID,
+			)
+			state.RemoveNode(node)
+		}
 	}
 
 	// Emit the RegistryNodeListEpoch notification event.
@@ -211,7 +247,25 @@ func (app *registryApplication) deregisterEntity(
 		}
 	}
 
-	removedEntity, removedNodes := state.RemoveEntity(id)
+	// Prevent entity deregistration if there are any registered nodes.
+	hasNodes, err := state.HasEntityNodes(id)
+	if err != nil {
+		app.logger.Error("DeregisterEntity: failed to check for nodes",
+			"err", err,
+		)
+		return err
+	}
+	if hasNodes {
+		app.logger.Error("DeregisterEntity: entity still has nodes",
+			"entity_id", id,
+		)
+		return registry.ErrEntityHasNodes
+	}
+
+	removedEntity, err := state.RemoveEntity(id)
+	if err != nil {
+		return err
+	}
 
 	if !ctx.IsCheckOnly() {
 		app.logger.Debug("DeregisterEntity: complete",
@@ -219,8 +273,7 @@ func (app *registryApplication) deregisterEntity(
 		)
 
 		tagV := &EntityDeregistration{
-			Entity: removedEntity,
-			Nodes:  removedNodes,
+			Entity: *removedEntity,
 		}
 		ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyEntityDeregistered, cbor.Marshal(tagV)))
 	}
@@ -294,15 +347,15 @@ func (app *registryApplication) registerNode(
 	if err != nil {
 		return err
 	}
-	if epochtime.EpochTime(newNode.Expiration) < epoch {
+	if newNode.IsExpired(uint64(epoch)) {
 		return registry.ErrNodeExpired
 	}
 
 	// Check if node exists.
 	existingNode, err := state.Node(newNode.ID)
-	if err != nil {
-		if err == registry.ErrNoSuchNode {
-			// Node doesn't exist. Create node.
+	if err != nil || existingNode.IsExpired(uint64(epoch)) {
+		if err == registry.ErrNoSuchNode || existingNode.IsExpired(uint64(epoch)) {
+			// Node doesn't exist (or is expired). Create node.
 			if err = state.CreateNode(newNode, sigNode); err != nil {
 				app.logger.Error("RegisterNode: failed to create node",
 					"err", err,
@@ -312,7 +365,24 @@ func (app *registryApplication) registerNode(
 				return registry.ErrBadEntityForNode
 			}
 
-			if err = state.SetNodeStatus(newNode.ID, &registry.NodeStatus{}); err != nil {
+			var status *registry.NodeStatus
+			if existingNode != nil {
+				// Node exists but is expired, fetch existing status.
+				if status, err = state.NodeStatus(newNode.ID); err != nil {
+					app.logger.Error("RegisterNode: failed to get node status",
+						"err", err,
+					)
+					return registry.ErrInvalidArgument
+				}
+
+				// Reset expiration processed flag as the node is live again.
+				status.ExpirationProcessed = false
+			} else {
+				// Node doesn't exist, create empty status.
+				status = &registry.NodeStatus{}
+			}
+
+			if err = state.SetNodeStatus(newNode.ID, status); err != nil {
 				app.logger.Error("RegisterNode: failed to set node status",
 					"err", err,
 				)

--- a/go/tendermint/apps/registry/registry.go
+++ b/go/tendermint/apps/registry/registry.go
@@ -2,7 +2,6 @@
 package registry
 
 import (
-	"context"
 	"encoding/hex"
 
 	"github.com/pkg/errors"
@@ -63,7 +62,7 @@ func (app *registryApplication) SetOption(request types.RequestSetOption) types.
 
 func (app *registryApplication) BeginBlock(ctx *abci.Context, request types.RequestBeginBlock) error {
 	// XXX: With PR#1889 this can be a differnet interval.
-	if changed, registryEpoch := app.state.EpochChanged(app.timeSource); changed {
+	if changed, registryEpoch := app.state.EpochChanged(ctx, app.timeSource); changed {
 		return app.onRegistryEpochChanged(ctx, registryEpoch)
 	}
 	return nil
@@ -291,7 +290,7 @@ func (app *registryApplication) registerNode(
 	}
 
 	// Ensure node is not expired.
-	epoch, err := app.timeSource.GetEpoch(context.Background(), ctx.BlockHeight())
+	epoch, err := app.timeSource.GetEpoch(ctx.Ctx(), ctx.BlockHeight()+1)
 	if err != nil {
 		return err
 	}
@@ -407,7 +406,7 @@ func (app *registryApplication) unfreezeNode(
 	}
 
 	// Ensure if we can actually unfreeze.
-	epoch, err := app.timeSource.GetEpoch(context.Background(), ctx.BlockHeight())
+	epoch, err := app.timeSource.GetEpoch(ctx.Ctx(), ctx.BlockHeight()+1)
 	if err != nil {
 		return err
 	}

--- a/go/tendermint/apps/roothash/query.go
+++ b/go/tendermint/apps/roothash/query.go
@@ -6,6 +6,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
+	"github.com/oasislabs/oasis-core/go/tendermint/abci"
 	roothashState "github.com/oasislabs/oasis-core/go/tendermint/apps/roothash/state"
 )
 
@@ -22,10 +23,16 @@ type QueryFactory struct {
 }
 
 // QueryAt returns the roothash query interface for a specific height.
-func (sf *QueryFactory) QueryAt(height int64) (Query, error) {
+func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
 	state, err := roothashState.NewImmutableState(sf.app.state, height)
 	if err != nil {
 		return nil, err
+	}
+
+	// If this request was made from an ABCI app, make sure to use the associated
+	// context for querying state instead of the default one.
+	if abciCtx := abci.FromCtx(ctx); abciCtx != nil && height == abciCtx.BlockHeight()+1 {
+		state.Snapshot = abciCtx.State().ImmutableTree
 	}
 	return &rootHashQuerier{state}, nil
 }

--- a/go/tendermint/apps/roothash/roothash.go
+++ b/go/tendermint/apps/roothash/roothash.go
@@ -3,7 +3,6 @@ package roothash
 
 import (
 	"bytes"
-	"context"
 	"encoding/hex"
 	"time"
 
@@ -58,7 +57,6 @@ func (ctx *timerContext) UnmarshalCBOR(data []byte) error {
 }
 
 type rootHashApplication struct {
-	ctx    context.Context
 	logger *logging.Logger
 	state  *abci.ApplicationState
 
@@ -119,7 +117,7 @@ func (app *rootHashApplication) InitChain(ctx *abci.Context, request types.Reque
 
 func (app *rootHashApplication) BeginBlock(ctx *abci.Context, request types.RequestBeginBlock) error {
 	// Only perform checks on epoch changes.
-	if changed, epoch := app.state.EpochChanged(app.timeSource); changed {
+	if changed, epoch := app.state.EpochChanged(ctx, app.timeSource); changed {
 		return app.onEpochChange(ctx, epoch)
 	}
 	return nil
@@ -833,13 +831,11 @@ func (app *rootHashApplication) tryFinalizeBlock(
 
 // New constructs a new roothash application instance.
 func New(
-	ctx context.Context,
 	timeSource epochtime.Backend,
 	beacon beacon.Backend,
 	roundTimeout time.Duration,
 ) abci.Application {
 	return &rootHashApplication{
-		ctx:          ctx,
 		logger:       logging.GetLogger("tendermint/roothash"),
 		timeSource:   timeSource,
 		beacon:       beacon,

--- a/go/tendermint/apps/roothash/state/round.go
+++ b/go/tendermint/apps/roothash/state/round.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/oasislabs/oasis-core/go/common/cbor"
+	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
 	"github.com/oasislabs/oasis-core/go/roothash/api/commitment"
 )
@@ -16,6 +17,7 @@ var (
 
 // Round is a roothash round.
 type Round struct {
+	CommitteeID hash.Hash             `json:"committee_id"`
 	ComputePool *commitment.MultiPool `json:"compute_pool"`
 	MergePool   *commitment.Pool      `json:"merge_pool"`
 
@@ -67,11 +69,13 @@ func (r *Round) UnmarshalCBOR(data []byte) error {
 }
 
 func NewRound(
+	committeeID hash.Hash,
 	computePool *commitment.MultiPool,
 	mergePool *commitment.Pool,
 	blk *block.Block,
 ) *Round {
 	r := &Round{
+		CommitteeID:  committeeID,
 		CurrentBlock: blk,
 		ComputePool:  computePool,
 		MergePool:    mergePool,

--- a/go/tendermint/apps/scheduler/scheduler.go
+++ b/go/tendermint/apps/scheduler/scheduler.go
@@ -249,6 +249,10 @@ func (app *schedulerApplication) BeginBlock(ctx *abci.Context, request types.Req
 			if status.IsFrozen() {
 				continue
 			}
+			// Expired nodes cannot be scheduled (nodes can be expired and not yet removed).
+			if node.IsExpired(uint64(epoch)) {
+				continue
+			}
 
 			nodes = append(nodes, node)
 		}

--- a/go/tendermint/apps/scheduler/scheduler.go
+++ b/go/tendermint/apps/scheduler/scheduler.go
@@ -210,7 +210,7 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 
 func (app *schedulerApplication) BeginBlock(ctx *abci.Context, request types.RequestBeginBlock) error {
 	// TODO: We'll later have this for each type of committee.
-	if changed, epoch := app.state.EpochChanged(app.timeSource); changed {
+	if changed, epoch := app.state.EpochChanged(ctx, app.timeSource); changed {
 		// The 0th epoch will not have suitable entropy for elections, nor
 		// will it have useful node registrations.
 		if epoch == app.baseEpoch {

--- a/go/tendermint/apps/staking/genesis.go
+++ b/go/tendermint/apps/staking/genesis.go
@@ -19,6 +19,7 @@ import (
 func (app *stakingApplication) initParameters(state *stakingState.MutableState, st *staking.Genesis) {
 	state.SetDebondingInterval(uint64(st.DebondingInterval))
 	state.SetAcceptableTransferPeers(st.AcceptableTransferPeers)
+	state.SetSlashing(st.Slashing)
 }
 
 func (app *stakingApplication) initThresholds(state *stakingState.MutableState, st *staking.Genesis) error {
@@ -335,6 +336,11 @@ func (sq *stakingQuerier) Genesis(ctx context.Context) (*staking.Genesis, error)
 		return nil, err
 	}
 
+	slashing, err := sq.state.Slashing()
+	if err != nil {
+		return nil, err
+	}
+
 	gen := staking.Genesis{
 		TotalSupply:             *totalSupply,
 		CommonPool:              *commonPool,
@@ -344,6 +350,7 @@ func (sq *stakingQuerier) Genesis(ctx context.Context) (*staking.Genesis, error)
 		Ledger:                  ledger,
 		Delegations:             delegations,
 		DebondingDelegations:    debondingDelegations,
+		Slashing:                slashing,
 	}
 	return &gen, nil
 }

--- a/go/tendermint/apps/staking/slashing.go
+++ b/go/tendermint/apps/staking/slashing.go
@@ -103,7 +103,5 @@ func (app *stakingApplication) onEvidenceDoubleSign(
 		"entity_id", node.EntityID,
 	)
 
-	// TODO: Trigger early validator re-election?
-
 	return nil
 }

--- a/go/tendermint/apps/staking/slashing.go
+++ b/go/tendermint/apps/staking/slashing.go
@@ -24,7 +24,9 @@ func (app *stakingApplication) onEvidenceDoubleSign(
 	regState := registryState.NewMutableState(ctx.State())
 	stakeState := stakingState.NewMutableState(ctx.State())
 
-	// Resolve consensus node.
+	// Resolve consensus node. Note that in order for this to work even in light
+	// of node expirations, the node descriptor must be available for at least
+	// the debonding period after expiration.
 	node, err := regState.NodeByConsensusAddress(addr)
 	if err != nil {
 		app.logger.Warn("failed to get validator node",

--- a/go/tendermint/apps/staking/slashing.go
+++ b/go/tendermint/apps/staking/slashing.go
@@ -68,7 +68,7 @@ func (app *stakingApplication) onEvidenceDoubleSign(
 	// validator from being scheduled in the next epoch.
 	if penalty.FreezeInterval > 0 {
 		var epoch epochtime.EpochTime
-		epoch, err = app.timeSource.GetEpoch(context.Background(), ctx.BlockHeight())
+		epoch, err = app.timeSource.GetEpoch(context.Background(), ctx.BlockHeight()+1)
 		if err != nil {
 			return err
 		}

--- a/go/tendermint/apps/staking/slashing.go
+++ b/go/tendermint/apps/staking/slashing.go
@@ -1,0 +1,107 @@
+package staking
+
+import (
+	"context"
+	"encoding/hex"
+	"time"
+
+	tmcrypto "github.com/tendermint/tendermint/crypto"
+
+	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
+	staking "github.com/oasislabs/oasis-core/go/staking/api"
+	"github.com/oasislabs/oasis-core/go/tendermint/abci"
+	registryState "github.com/oasislabs/oasis-core/go/tendermint/apps/registry/state"
+	stakingState "github.com/oasislabs/oasis-core/go/tendermint/apps/staking/state"
+)
+
+func (app *stakingApplication) onEvidenceDoubleSign(
+	ctx *abci.Context,
+	addr tmcrypto.Address,
+	height int64,
+	time time.Time,
+	power int64,
+) error {
+	regState := registryState.NewMutableState(ctx.State())
+	stakeState := stakingState.NewMutableState(ctx.State())
+
+	// Resolve consensus node.
+	node, err := regState.NodeByConsensusAddress(addr)
+	if err != nil {
+		app.logger.Warn("failed to get validator node",
+			"err", err,
+			"address", hex.EncodeToString(addr),
+		)
+		return nil
+	}
+
+	nodeStatus, err := regState.NodeStatus(node.ID)
+	if err != nil {
+		app.logger.Warn("failed to get validator node status",
+			"err", err,
+			"node_id", node.ID,
+		)
+		return nil
+	}
+
+	// Do not slash a frozen validator.
+	if nodeStatus.IsFrozen() {
+		app.logger.Debug("not slashing frozen validator",
+			"node_id", node.ID,
+			"entity_id", node.EntityID,
+			"freeze_end_time", nodeStatus.FreezeEndTime,
+		)
+		return nil
+	}
+
+	// Retrieve the slash procedure for double signing.
+	st, err := stakeState.Slashing()
+	if err != nil {
+		app.logger.Error("failed to get slashing table entry for double signing",
+			"err", err,
+		)
+		return err
+	}
+
+	penalty := st[staking.SlashDoubleSigning]
+
+	// Freeze validator to prevent it being slashed again. This also prevents the
+	// validator from being scheduled in the next epoch.
+	if penalty.FreezeInterval > 0 {
+		var epoch epochtime.EpochTime
+		epoch, err = app.timeSource.GetEpoch(context.Background(), ctx.BlockHeight())
+		if err != nil {
+			return err
+		}
+
+		nodeStatus.FreezeEndTime = epoch + penalty.FreezeInterval
+	}
+
+	// Slash validator.
+	_, err = stakeState.SlashEscrow(ctx, node.EntityID, &penalty.Share)
+	if err != nil {
+		app.logger.Error("failed to slash validator entity",
+			"err", err,
+			"node_id", node.ID,
+			"entity_id", node.EntityID,
+		)
+		return err
+	}
+
+	if err = regState.SetNodeStatus(node.ID, nodeStatus); err != nil {
+		app.logger.Error("failed to set validator node status",
+			"err", err,
+			"node_id", node.ID,
+			"entity_id", node.EntityID,
+		)
+		return err
+	}
+
+	app.logger.Warn("slashed validator for double signing",
+		"node_id", node.ID,
+		"entity_id", node.EntityID,
+	)
+
+	// TODO: Trigger early validator re-election?
+
+	return nil
+}

--- a/go/tendermint/apps/staking/staking.go
+++ b/go/tendermint/apps/staking/staking.go
@@ -2,7 +2,6 @@
 package staking
 
 import (
-	"context"
 	"encoding/hex"
 
 	"github.com/pkg/errors"
@@ -106,7 +105,7 @@ func (app *stakingApplication) ForeignExecuteTx(ctx *abci.Context, other abci.Ap
 }
 
 func (app *stakingApplication) EndBlock(ctx *abci.Context, request types.RequestEndBlock) (types.ResponseEndBlock, error) {
-	if changed, epoch := app.state.EpochChanged(app.timeSource); changed {
+	if changed, epoch := app.state.EpochChanged(ctx, app.timeSource); changed {
 		return types.ResponseEndBlock{}, app.onEpochChange(ctx, epoch)
 	}
 	return types.ResponseEndBlock{}, nil
@@ -421,7 +420,7 @@ func (app *stakingApplication) reclaimEscrow(ctx *abci.Context, state *stakingSt
 		)
 		return err
 	}
-	epoch, err := app.timeSource.GetEpoch(context.Background(), ctx.BlockHeight())
+	epoch, err := app.timeSource.GetEpoch(ctx.Ctx(), ctx.BlockHeight()+1)
 	if err != nil {
 		return err
 	}

--- a/go/tendermint/service/service.go
+++ b/go/tendermint/service/service.go
@@ -67,6 +67,9 @@ type TendermintService interface {
 	// sure to cancel the context.
 	BroadcastTx(ctx context.Context, tag byte, tx interface{}, wait bool) error
 
+	// BroadcastEvidence broadcasts evidence of Tendermint node misbehavior.
+	BroadcastEvidence(ctx context.Context, evidence tmtypes.Evidence) error
+
 	// Subscribe subscribes to tendermint events.
 	Subscribe(subscriber string, query tmpubsub.Query) (tmtypes.Subscription, error)
 

--- a/go/tendermint/tendermint.go
+++ b/go/tendermint/tendermint.go
@@ -350,6 +350,11 @@ func (t *tendermintService) broadcastTx(ctx context.Context, tag byte, tx interf
 	}
 }
 
+func (t *tendermintService) BroadcastEvidence(ctx context.Context, evidence tmtypes.Evidence) error {
+	_, err := t.client.BroadcastEvidence(evidence)
+	return err
+}
+
 func (t *tendermintService) Subscribe(subscriber string, query tmpubsub.Query) (tmtypes.Subscription, error) {
 	// Note: The tendermint documentation claims using SubscribeUnbuffered can
 	// freeze the server, however, the buffered Subscribe can drop events, and
@@ -591,8 +596,9 @@ func genesisToTendermint(d *genesis.Document) (*tmtypes.GenesisDoc, error) {
 		return nil, errors.Wrap(err, "tendermint: failed to serialize genesis doc")
 	}
 	doc := tmtypes.GenesisDoc{
-		ChainID:         d.ChainID,
-		GenesisTime:     d.Time,
+		ChainID:     d.ChainID,
+		GenesisTime: d.Time,
+		// TODO: Configure Evidence.MaxAge once these are in genesis.
 		ConsensusParams: tmtypes.DefaultConsensusParams(),
 		AppState:        b,
 	}


### PR DESCRIPTION
Based on #2301 
Fixes #1901 
Fixes #2272 

TODO
* [x] Add registry transaction to unfreeze node (if freeze period has passed).
* [x] Test double signing.
* [x] Bump protocol version number.
* [x] Trigger early validator election.