### PR TITLE
go/tendermint/abci: Drink the ABCI event flavor-aid

### DIFF
--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -65,7 +65,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	BackendProtocol = Version{Major: 0, Minor: 9, Patch: 0}
+	BackendProtocol = Version{Major: 0, Minor: 10, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)

--- a/go/epochtime/tendermint_mock/tendermint_mock.go
+++ b/go/epochtime/tendermint_mock/tendermint_mock.go
@@ -14,7 +14,6 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
 	"github.com/oasislabs/oasis-core/go/epochtime/api"
-	tmapi "github.com/oasislabs/oasis-core/go/tendermint/api"
 	app "github.com/oasislabs/oasis-core/go/tendermint/apps/epochtime_mock"
 	"github.com/oasislabs/oasis-core/go/tendermint/service"
 )
@@ -174,12 +173,12 @@ func (t *tendermintMockBackend) onEventDataNewBlock(ctx context.Context, ev tmty
 	events := ev.ResultBeginBlock.GetEvents()
 
 	for _, tmEv := range events {
-		if tmEv.GetType() != tmapi.EventTypeOasis {
+		if tmEv.GetType() != app.EventType {
 			continue
 		}
 
 		for _, pair := range tmEv.GetAttributes() {
-			if bytes.Equal(pair.GetKey(), app.TagEpoch) {
+			if bytes.Equal(pair.GetKey(), app.KeyEpoch) {
 				var epoch api.EpochTime
 				if err := cbor.Unmarshal(pair.GetValue(), &epoch); err != nil {
 					t.logger.Error("worker: malformed mock epoch",

--- a/go/keymanager/tendermint/tendermint.go
+++ b/go/keymanager/tendermint/tendermint.go
@@ -103,12 +103,12 @@ func (tb *tendermintBackend) onEventDataNewBlock(ev tmtypes.EventDataNewBlock) {
 	events = append(events, ev.ResultEndBlock.GetEvents()...)
 
 	for _, tmEv := range events {
-		if tmEv.GetType() != tmapi.EventTypeOasis {
+		if tmEv.GetType() != app.EventType {
 			continue
 		}
 
 		for _, pair := range tmEv.GetAttributes() {
-			if bytes.Equal(pair.GetKey(), app.TagStatusUpdate) {
+			if bytes.Equal(pair.GetKey(), app.KeyStatusUpdate) {
 				var statuses []*api.Status
 				if err := cbor.Unmarshal(pair.GetValue(), &statuses); err != nil {
 					tb.logger.Error("worker: failed to get statuses from tag",

--- a/go/oasis-node/cmd/debug/byzantine/scheduler.go
+++ b/go/oasis-node/cmd/debug/byzantine/scheduler.go
@@ -12,7 +12,6 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	scheduler "github.com/oasislabs/oasis-core/go/scheduler/api"
-	tmapi "github.com/oasislabs/oasis-core/go/tendermint/api"
 	schedulerapp "github.com/oasislabs/oasis-core/go/tendermint/apps/scheduler"
 	"github.com/oasislabs/oasis-core/go/tendermint/service"
 	"github.com/oasislabs/oasis-core/go/worker/common/p2p"
@@ -32,12 +31,12 @@ func schedulerNextElectionHeight(svc service.TendermintService, kind scheduler.C
 	for {
 		ev := (<-sub.Out()).Data().(tmtypes.EventDataNewBlock)
 		for _, tmEv := range ev.ResultBeginBlock.GetEvents() {
-			if tmEv.GetType() != tmapi.EventTypeOasis {
+			if tmEv.GetType() != schedulerapp.EventType {
 				continue
 			}
 
 			for _, pair := range tmEv.GetAttributes() {
-				if bytes.Equal(pair.GetKey(), schedulerapp.TagElected) {
+				if bytes.Equal(pair.GetKey(), schedulerapp.KeyElected) {
 					var kinds []scheduler.CommitteeKind
 					if err := cbor.Unmarshal(pair.GetValue(), &kinds); err != nil {
 						return 0, errors.Wrap(err, "CBOR Unmarshal kinds")

--- a/go/scheduler/tendermint/tendermint.go
+++ b/go/scheduler/tendermint/tendermint.go
@@ -119,12 +119,12 @@ func (tb *tendermintBackend) onEventDataNewBlock(ctx context.Context, ev tmtypes
 	events := ev.ResultBeginBlock.GetEvents()
 
 	for _, tmEv := range events {
-		if tmEv.GetType() != tmapi.EventTypeOasis {
+		if tmEv.GetType() != app.EventType {
 			continue
 		}
 
 		for _, pair := range tmEv.GetAttributes() {
-			if bytes.Equal(pair.GetKey(), app.TagElected) {
+			if bytes.Equal(pair.GetKey(), app.KeyElected) {
 				var kinds []api.CommitteeKind
 				if err := cbor.Unmarshal(pair.GetValue(), &kinds); err != nil {
 					tb.logger.Error("worker: malformed elected committee types list",

--- a/go/tendermint/abci/mux.go
+++ b/go/tendermint/abci/mux.go
@@ -455,9 +455,6 @@ func (mux *abciMux) executeTx(ctx *Context, tx []byte) error {
 		"tx", base64.StdEncoding.EncodeToString(tx),
 	)
 
-	// Append application name tag.
-	ctx.EmitTag([]byte(app.Name()), api.TagAppNameValue)
-
 	if err = app.ExecuteTx(ctx, tx[1:]); err != nil {
 		return err
 	}

--- a/go/tendermint/apps/beacon/api.go
+++ b/go/tendermint/apps/beacon/api.go
@@ -13,11 +13,14 @@ const (
 )
 
 var (
-	// TagGenerated is an ABCI begin block tag for new beacons.
-	// (value is a CBOR serialized beacon.GenerateEvent).
-	TagGenerated = []byte("beacon.generated")
+	// EventType is the ABCI event type for beacon events.
+	EventType = api.EventTypeForApp(AppName)
 
 	// QueryApp is a query for filtering events processed by the
 	// beacon application.
-	QueryApp = api.QueryForEvent([]byte(AppName), api.TagAppNameValue)
+	QueryApp = api.QueryForApp(AppName)
+
+	// KeyGenerated is the ABCI event attribute key for the new
+	// beacons (value is a CBOR serialized beacon.GenerateEvent).
+	KeyGenerated = []byte("generated")
 )

--- a/go/tendermint/apps/beacon/beacon.go
+++ b/go/tendermint/apps/beacon/beacon.go
@@ -155,8 +155,7 @@ func (app *beaconApplication) onNewBeacon(ctx *abci.Context, beacon []byte) erro
 		return errors.Wrap(err, "tendermint/beacon: failed to set beacon")
 	}
 
-	ctx.EmitTag([]byte(app.Name()), api.TagAppNameValue)
-	ctx.EmitTag(TagGenerated, beacon)
+	ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyGenerated, beacon))
 
 	return nil
 }

--- a/go/tendermint/apps/epochtime_mock/api.go
+++ b/go/tendermint/apps/epochtime_mock/api.go
@@ -18,12 +18,15 @@ const (
 )
 
 var (
-	// TagEpoch is an ABCI begin block tag for specifying the set epoch.
-	TagEpoch = []byte("epochtime_mock.epoch")
+	// EventType is the ABCI event type for mock epochtime events.
+	EventType = api.EventTypeForApp(AppName)
 
 	// QueryApp is a query for filtering events processed by
 	// the mock epochtime application.
-	QueryApp = api.QueryForEvent([]byte(AppName), api.TagAppNameValue)
+	QueryApp = api.QueryForApp(AppName)
+
+	// KeyEpoch is an ABCI event attribute for specifying the set epoch.
+	KeyEpoch = []byte("epoch")
 )
 
 // Tx is a transaction to be accepted by the mock epochtime app.

--- a/go/tendermint/apps/epochtime_mock/epochtime_mock.go
+++ b/go/tendermint/apps/epochtime_mock/epochtime_mock.go
@@ -84,8 +84,7 @@ func (app *epochTimeMockApplication) BeginBlock(ctx *abci.Context, request types
 	)
 
 	state.setEpoch(future.Epoch, height)
-	ctx.EmitTag([]byte(app.Name()), api.TagAppNameValue)
-	ctx.EmitTag(TagEpoch, cbor.Marshal(future.Epoch))
+	ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyEpoch, cbor.Marshal(future.Epoch)))
 
 	return nil
 }

--- a/go/tendermint/apps/keymanager/api.go
+++ b/go/tendermint/apps/keymanager/api.go
@@ -1,7 +1,7 @@
 // Package keymanager implementes the key manager management applicaiton.
 package keymanager
 
-import tmapi "github.com/oasislabs/oasis-core/go/tendermint/api"
+import api "github.com/oasislabs/oasis-core/go/tendermint/api"
 
 const (
 	// TransactionTag is a unique byte to identify transactions for
@@ -13,11 +13,14 @@ const (
 )
 
 var (
-	// TagStatusUpdate is an ABCI transaction tag for a key manager status
-	// update (value is a CBOR serialized key manager status).
-	TagStatusUpdate = []byte("keymanager.status")
+	// EventType is the ABCI event type for key manager events.
+	EventType = api.EventTypeForApp(AppName)
 
 	// QueryApp is a query for filtering transactions processed by the
 	// key manager application.
-	QueryApp = tmapi.QueryForEvent([]byte(AppName), tmapi.TagAppNameValue)
+	QueryApp = api.QueryForApp(AppName)
+
+	// KeyStatusUpdate is an ABCI event attribute key for a key manager
+	// status update (value is a CBOR serialized key manager status).
+	KeyStatusUpdate = []byte("status")
 )

--- a/go/tendermint/apps/keymanager/genesis.go
+++ b/go/tendermint/apps/keymanager/genesis.go
@@ -72,8 +72,7 @@ func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.Req
 	}
 
 	if len(toEmit) > 0 {
-		ctx.EmitTag([]byte(app.Name()), tmapi.TagAppNameValue)
-		ctx.EmitTag(TagStatusUpdate, cbor.Marshal(toEmit))
+		ctx.EmitEvent(tmapi.NewEventBuilder(app.Name()).Attribute(KeyStatusUpdate, cbor.Marshal(toEmit)))
 	}
 
 	return nil

--- a/go/tendermint/apps/keymanager/keymanager.go
+++ b/go/tendermint/apps/keymanager/keymanager.go
@@ -139,8 +139,7 @@ func (app *keymanagerApplication) onEpochChange(ctx *abci.Context, epoch epochti
 
 	// Emit the update event if required.
 	if len(toEmit) > 0 {
-		ctx.EmitTag([]byte(app.Name()), tmapi.TagAppNameValue)
-		ctx.EmitTag(TagStatusUpdate, cbor.Marshal(toEmit))
+		ctx.EmitEvent(tmapi.NewEventBuilder(app.Name()).Attribute(KeyStatusUpdate, cbor.Marshal(toEmit)))
 	}
 
 	return nil

--- a/go/tendermint/apps/registry/api.go
+++ b/go/tendermint/apps/registry/api.go
@@ -18,25 +18,38 @@ const (
 )
 
 var (
-	// TagRuntimeRegistered is an ABCI tag for new runtime
-	// registrations (value is runtime id).
-	TagRuntimeRegistered = []byte("registry.runtime.registered")
-
-	// TagEntityRegistered is an ABCI tag for new entity
-	// registrations (value is entity id).
-	TagEntityRegistered = []byte("registry.entity.registered")
-
-	// TagNodesExpired is an ABCI tag for node deregistrations
-	// due to expiration (value is a CBOR serialized vector of node
-	// descriptors).
-	TagNodesExpired = []byte("registry.nodes.expired")
-
-	// TagRegistryNodeListEpoch is an ABCI tag for registry epochs.
-	TagRegistryNodeListEpoch = []byte("registry.nodes.epoch")
+	// EventType is the ABCI event type for registry events.
+	EventType = api.EventTypeForApp(AppName)
 
 	// QueryApp is a query for filtering events processed by
 	// the registry application.
-	QueryApp = api.QueryForEvent([]byte(AppName), api.TagAppNameValue)
+	QueryApp = api.QueryForApp(AppName)
+
+	// KeyRuntimeRegistered is the ABCI event attribute for new
+	// runtime registrations (value is the CBOR serialized runtime
+	// descriptor).
+	KeyRuntimeRegistered = []byte("runtime.registered")
+
+	// KeyEntityRegistered is the ABCI event attribute for new entity
+	// registrations (value is the CBOR serialized entity descriptor).
+	KeyEntityRegistered = []byte("entity.registered")
+
+	// KeyEntityDeregistered is the ABCI event attribute for entity
+	// deregistrations (value is a CBOR serialized EntityDeregistration).
+	KeyEntityDeregistered = []byte("entity.deregistered")
+
+	// KeyNodeRegistered is the ABCI event attribute for new node
+	// registrations (value is the CBOR serialized node descriptor).
+	KeyNodeRegistered = []byte("nodes.registered")
+
+	// KeyNodesExpired is the ABCI event attribute for node
+	// deregistrations due to expiration (value is a CBOR serialized
+	// vector of node descriptors).
+	KeyNodesExpired = []byte("nodes.expired")
+
+	// KeyRegistryNodeListEpoch is the ABCI event attribute for
+	// registry epochs.
+	KeyRegistryNodeListEpoch = []byte("nodes.epoch")
 )
 
 // Tx is a transaction to be accepted by the registry app.
@@ -68,38 +81,11 @@ type TxRegisterRuntime struct {
 	Runtime registry.SignedRuntime
 }
 
-// Output is an output of an registry app transaction.
-type Output struct {
-	*OutputRegisterEntity   `json:"RegisterEntity.omitempty"`
-	*OutputDeregisterEntity `json:"DeregisterEntity,omitempty"`
-	*OutputRegisterNode     `json:"RegisterNode,omitempty"`
-
-	*OutputRegisterRuntime `json:"RegisterRuntime,omitempty"`
-}
-
-// OutputRegisterEntity is an output of registering a new entity.
-type OutputRegisterEntity struct {
-	// Registered entity.
-	Entity entity.Entity
-}
-
-// OutputDeregisterEntity is an output of deregistering an entity.
-type OutputDeregisterEntity struct {
+// EntityDeregistration is a entity deregistration.
+type EntityDeregistration struct {
 	// Deregistered entity.
 	Entity entity.Entity
 
 	// Deregistered nodes (if any).
 	Nodes []node.Node
-}
-
-// OutputRegisterNode is an output of registering a new node.
-type OutputRegisterNode struct {
-	// Registered node.
-	Node node.Node
-}
-
-// OutputRegisterRuntime is an output of registering a new node.
-type OutputRegisterRuntime struct {
-	// Registered runtime.
-	Runtime registry.Runtime
 }

--- a/go/tendermint/apps/registry/genesis.go
+++ b/go/tendermint/apps/registry/genesis.go
@@ -12,7 +12,6 @@ import (
 	genesis "github.com/oasislabs/oasis-core/go/genesis/api"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
 	"github.com/oasislabs/oasis-core/go/tendermint/abci"
-	"github.com/oasislabs/oasis-core/go/tendermint/api"
 )
 
 func (app *registryApplication) InitChain(ctx *abci.Context, request types.RequestInitChain, doc *genesis.Document) error {
@@ -65,10 +64,6 @@ func (app *registryApplication) InitChain(ctx *abci.Context, request types.Reque
 			)
 			return errors.Wrap(err, "registry: genesis node registration failure")
 		}
-	}
-
-	if len(st.Entities) > 0 || len(st.Runtimes) > 0 || len(st.Nodes) > 0 {
-		ctx.EmitTag([]byte(app.Name()), api.TagAppNameValue)
 	}
 
 	return nil

--- a/go/tendermint/apps/roothash/api.go
+++ b/go/tendermint/apps/roothash/api.go
@@ -18,27 +18,24 @@ const (
 )
 
 var (
-	// TagUpdate is an ABCI transaction tag for marking transactions
-	// which have been processed by roothash (value is TagUpdateValue).
-	TagUpdate = []byte("roothash.update")
-	// TagUpdateValue is the only allowed value for TagUpdate.
-	TagUpdateValue = []byte{0x01}
+	// EventType is the ABCI event type for roothash events.
+	EventType = api.EventTypeForApp(AppName)
 
-	// TagMergeDiscrepancyDetected is an ABCI transaction tag for merge discrepancy
-	// detected events (value is a CBOR serialized ValueMergeDiscrepancyDetected).
-	TagMergeDiscrepancyDetected = []byte("roothash.merge-discrepancy")
-	// TagComputeDiscrepancyDetected is an ABCI transaction tag for merge discrepancy
-	// detected events (value is a CBOR serialized ValueComputeDiscrepancyDetected).
-	TagComputeDiscrepancyDetected = []byte("roothash.compute-discrepancy")
+	// QueryApp is a query for filtering transactions processed by the
+	// roothash application.
+	QueryApp = api.QueryForApp(AppName)
 
-	// TagFinalized is an ABCI transaction tag for finalized blocks
+	// KeyMergeDiscrepancyDetected is an ABCI event attribute key for
+	// merge discrepancy detected events (value is a CBOR serialized
+	// ValueMergeDiscrepancyDetected).
+	KeyMergeDiscrepancyDetected = []byte("merge-discrepancy")
+	// KeyComputeDiscrepancyDetected is an ABCI event attribute key for
+	// merge discrepancy detected events (value is a CBOR serialized
+	// ValueComputeDiscrepancyDetected).
+	KeyComputeDiscrepancyDetected = []byte("compute-discrepancy")
+	// KeyFinalized is an ABCI event attribute key for finalized blocks
 	// (value is a CBOR serialized ValueFinalized).
-	TagFinalized = []byte("roothash.finalized")
-
-	// QueryUpdate is a query for filtering transactions where root hash
-	// application state has been updated. This is required as state can
-	// change as part of foreign application transactions.
-	QueryUpdate = api.QueryForEvent(TagUpdate, TagUpdateValue)
+	KeyFinalized = []byte("finalized")
 )
 
 // Tx is a transaction to be accepted by the roothash app.

--- a/go/tendermint/apps/scheduler/api.go
+++ b/go/tendermint/apps/scheduler/api.go
@@ -14,10 +14,14 @@ const (
 )
 
 var (
-	// TagElected is an ABCI begin block tag with which committee types were elected.
-	TagElected = []byte("scheduler.elected")
+	// EventType is the ABCI event type for scheduler events.
+	EventType = api.EventTypeForApp(AppName)
 
-	// QueryApp is a query for filtering events processed by
-	// the scheduler application.
-	QueryApp = api.QueryForEvent([]byte(AppName), api.TagAppNameValue)
+	// QueryApp is a query for filtering events processed by the
+	// scheduler application.
+	QueryApp = api.QueryForApp(AppName)
+
+	// KeyElected is the ABCI event attribute key for the elected
+	// committee types.
+	KeyElected = []byte("elected")
 )

--- a/go/tendermint/apps/scheduler/scheduler.go
+++ b/go/tendermint/apps/scheduler/scheduler.go
@@ -258,8 +258,7 @@ func (app *schedulerApplication) BeginBlock(ctx *abci.Context, request types.Req
 				return errors.Wrap(err, fmt.Sprintf("tendermint/scheduler: couldn't elect %s committees", kind))
 			}
 		}
-		ctx.EmitTag([]byte(app.Name()), api.TagAppNameValue)
-		ctx.EmitTag(TagElected, cbor.Marshal(kinds))
+		ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyElected, cbor.Marshal(kinds)))
 
 		var kindNames []string
 		for _, kind := range kinds {

--- a/go/tendermint/apps/staking/api.go
+++ b/go/tendermint/apps/staking/api.go
@@ -15,28 +15,32 @@ const (
 )
 
 var (
-	// TagUpdate is an ABCI transaction tag for marking transactions
-	// which have been processed by staking (value is TagUpdateValue).
-	TagUpdate = []byte("staking.update")
-	// TagUpdateValue is the only allowed value for TagUpdate.
-	TagUpdateValue = []byte{0x01}
+	//EventType is the ABCI event type for staking events.
+	EventType = api.EventTypeForApp(AppName)
 
-	// TagTakeEscrow is an ABCI transaction tag for TakeEscrow calls
+	// QueryApp is a query for filtering events processed by the
+	// staking application.
+	QueryApp = api.QueryForApp(AppName)
+
+	// KeyTakeEscrow is an ABCI event attribute key for TakeEscrow calls
 	// (value is an app.TakeEscrowEvent).
-	TagTakeEscrow = []byte("staking.take_escrow")
+	KeyTakeEscrow = []byte("take_escrow")
 
-	// TagReclaimEscrow is an ABCI trasnsaction tag for ReclaimEscrow
+	// KeyReclaimEscrow is an ABCI event attribute key for ReclaimEscrow
 	// calls (value is an app.ReclaimEscrowEvent).
-	TagReclaimEscrow = []byte("staking.reclaim_escrow")
+	KeyReclaimEscrow = []byte("reclaim_escrow")
 
-	// TagTransfer is an ABCI transaction tag for Transfers that happen
-	// in a non-staking app (value is an app.TransferEvent).
-	TagTransfer = []byte("staking.transfer")
+	// KeyTransfer is an ABCI event attribute key for Transfers (value is
+	// an app.TransferEvent).
+	KeyTransfer = []byte("transfer")
 
-	// QueryUpdate is a query for filtering transactions/blocks where staking
-	// application state has been updated. This is required as state can
-	// change as part of timers firing.
-	QueryUpdate = api.QueryForEvent(TagUpdate, TagUpdateValue)
+	// KeyBurn is an ABCI event attribute key for Burn calls (value is
+	// an app.BurnEvent).
+	KeyBurn = []byte("burn")
+
+	// KeyAddEscrow is an ABCI event attribute key for AddEscrow calls
+	// (value is an app.EscrowEvent).
+	KeyAddEscrow = []byte("add_escrow")
 )
 
 // Tx is a transaction to be accepted by the staking app.
@@ -65,11 +69,4 @@ type TxAddEscrow struct {
 // TxReclaimEscrow is a transaction for a ReclaimEscrow.
 type TxReclaimEscrow struct {
 	SignedReclaimEscrow staking.SignedReclaimEscrow
-}
-
-// Output is an output of a staking transaction.
-type Output struct {
-	OutputTransfer  *staking.TransferEvent `json:"Transfer,omitempty"`
-	OutputBurn      *staking.BurnEvent     `json:"Burn,omitempty"`
-	OutputAddEscrow *staking.EscrowEvent   `json:"AddEscrow,omitempty"`
 }

--- a/go/tendermint/apps/staking/staking.go
+++ b/go/tendermint/apps/staking/staking.go
@@ -14,6 +14,7 @@ import (
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	staking "github.com/oasislabs/oasis-core/go/staking/api"
 	"github.com/oasislabs/oasis-core/go/tendermint/abci"
+	"github.com/oasislabs/oasis-core/go/tendermint/api"
 )
 
 var (
@@ -164,13 +165,12 @@ func (app *stakingApplication) onEpochChange(ctx *abci.Context, epoch epochtime.
 			"amount", tokens,
 		)
 
-		ctx.EmitTag(TagUpdate, TagUpdateValue)
 		evt := staking.ReclaimEscrowEvent{
 			Owner:  e.delegatorID,
 			Escrow: e.escrowID,
 			Tokens: *tokens,
 		}
-		ctx.EmitTag(TagReclaimEscrow, cbor.Marshal(evt))
+		ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyReclaimEscrow, cbor.Marshal(evt)))
 	}
 	return nil
 }
@@ -238,14 +238,12 @@ func (app *stakingApplication) transfer(ctx *abci.Context, state *MutableState, 
 			"amount", xfer.Tokens,
 		)
 
-		ctx.EmitTag(TagUpdate, TagUpdateValue)
-		ctx.EmitData(&Output{
-			OutputTransfer: &staking.TransferEvent{
-				From:   fromID,
-				To:     xfer.To,
-				Tokens: xfer.Tokens,
-			},
-		})
+		evt := &staking.TransferEvent{
+			From:   fromID,
+			To:     xfer.To,
+			Tokens: xfer.Tokens,
+		}
+		ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyTransfer, cbor.Marshal(evt)))
 	}
 
 	return nil
@@ -293,13 +291,11 @@ func (app *stakingApplication) burn(ctx *abci.Context, state *MutableState, sign
 			"amount", burn.Tokens,
 		)
 
-		ctx.EmitTag(TagUpdate, TagUpdateValue)
-		ctx.EmitData(&Output{
-			OutputBurn: &staking.BurnEvent{
-				Owner:  id,
-				Tokens: burn.Tokens,
-			},
-		})
+		evt := &staking.BurnEvent{
+			Owner:  id,
+			Tokens: burn.Tokens,
+		}
+		ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyBurn, cbor.Marshal(evt)))
 	}
 
 	return nil
@@ -368,14 +364,12 @@ func (app *stakingApplication) addEscrow(ctx *abci.Context, state *MutableState,
 			"amount", escrow.Tokens,
 		)
 
-		ctx.EmitTag(TagUpdate, TagUpdateValue)
-		ctx.EmitData(&Output{
-			OutputAddEscrow: &staking.EscrowEvent{
-				Owner:  id,
-				Escrow: escrow.Account,
-				Tokens: escrow.Tokens,
-			},
-		})
+		evt := &staking.EscrowEvent{
+			Owner:  id,
+			Escrow: escrow.Account,
+			Tokens: escrow.Tokens,
+		}
+		ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyAddEscrow, cbor.Marshal(evt)))
 	}
 
 	return nil

--- a/go/tendermint/apps/staking/state.go
+++ b/go/tendermint/apps/staking/state.go
@@ -15,6 +15,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
 	staking "github.com/oasislabs/oasis-core/go/staking/api"
 	"github.com/oasislabs/oasis-core/go/tendermint/abci"
+	"github.com/oasislabs/oasis-core/go/tendermint/api"
 )
 
 var (
@@ -451,7 +452,7 @@ func (s *MutableState) SlashEscrow(ctx *abci.Context, fromID signature.PublicKey
 				Owner:  fromID,
 				Tokens: *slashed,
 			})
-			ctx.EmitTag(TagTakeEscrow, ev)
+			ctx.EmitEvent(api.NewEventBuilder(AppName).Attribute(KeyTakeEscrow, ev))
 		}
 	}
 
@@ -487,7 +488,7 @@ func (s *MutableState) TransferFromCommon(ctx *abci.Context, toID signature.Publ
 				To:     toID,
 				Tokens: *transfered,
 			})
-			ctx.EmitTag(TagTransfer, ev)
+			ctx.EmitEvent(api.NewEventBuilder(AppName).Attribute(KeyTransfer, ev))
 		}
 	}
 


### PR DESCRIPTION
Use tendermint ABCI events "properly", instead of retrofitting something that resembles the old tag system onto the new API.

 * [x] Add the new abstractions for event generation.
 * [x] Change existing tag/data calls to the new hotness.
   * [x] Beacon
   * [x] Key manager
   * [x] Roothash
   * [x] Scheduler
   * [x] Epochtime
   * [x] Staking
   * [x] Registry
 * [x] Remove the old APIs.

Fixes #1853 