### PR TITLE
P2P fixes

### DIFF
--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -412,21 +412,13 @@ func VerifyRegisterNodeArgs(cfg *Config, logger *logging.Logger, sigNode *node.S
 		}
 	}
 
-	// If node is a worker, ensure it has CommitteeInfo and P2PInfo.
+	// If node is a worker, ensure it has CommitteeInfo.
 	if n.HasRoles(node.RoleComputeWorker | node.RoleStorageWorker | node.RoleTransactionScheduler | node.RoleKeyManager | node.RoleMergeWorker) {
 		if err := verifyAddresses(cfg, n.Committee.Addresses); err != nil {
 			addrs, _ := json.Marshal(n.Committee.Addresses)
 			logger.Error("RegisterNode: missing/invalid committee addresses",
 				"node", n,
 				"committee_addrs", addrs,
-			)
-			return nil, err
-		}
-		if err := verifyAddresses(cfg, n.P2P.Addresses); err != nil {
-			addrs, _ := json.Marshal(n.P2P.Addresses)
-			logger.Error("RegisterNode: missing/invald P2P addresses",
-				"node", n,
-				"p2p_addrs", addrs,
 			)
 			return nil, err
 		}
@@ -438,6 +430,18 @@ func VerifyRegisterNodeArgs(cfg *Config, logger *logging.Logger, sigNode *node.S
 				"err", err,
 			)
 			return nil, ErrInvalidArgument
+		}
+	}
+
+	// If node is a compute/txnscheduler/merge worker, ensure it has P2PInfo.
+	if n.HasRoles(node.RoleComputeWorker | node.RoleTransactionScheduler | node.RoleMergeWorker) {
+		if err := verifyAddresses(cfg, n.P2P.Addresses); err != nil {
+			addrs, _ := json.Marshal(n.P2P.Addresses)
+			logger.Error("RegisterNode: missing/invald P2P addresses",
+				"node", n,
+				"p2p_addrs", addrs,
+			)
+			return nil, err
 		}
 	}
 

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -118,8 +118,11 @@ func testRegistryEntityNodes(t *testing.T, backend api.Backend, timeSource epoch
 
 		for _, vec := range nodes {
 			for _, v := range vec {
-				err := backend.RegisterNode(context.Background(), v.SignedInvalidRegistration1)
-				require.Error(err, "register committee node without P2P addresses")
+				var err error
+				if v.Node.Roles&node.RoleComputeWorker != 0 {
+					err = backend.RegisterNode(context.Background(), v.SignedInvalidRegistration1)
+					require.Error(err, "register committee node without P2P addresses")
+				}
 
 				err = backend.RegisterNode(context.Background(), v.SignedInvalidRegistration2)
 				require.Error(err, "register committee node without committee addresses")

--- a/go/tendermint/abci/timer.go
+++ b/go/tendermint/abci/timer.go
@@ -41,6 +41,11 @@ func (s *timerState) fromKeyValue(key, value []byte) {
 		panic("timer: corrupted key: " + hex.EncodeToString(key))
 	}
 
+	// Disarmed timers have no associated data.
+	if value == nil && deadline == deadlineDisarmed {
+		value = []byte{}
+	}
+
 	*s = timerState{
 		app:      app,
 		kind:     kind,
@@ -144,6 +149,8 @@ func (t *Timer) Reset(ctx *Context, duration time.Duration, data []byte) {
 }
 
 // Stop stops the timer.
+//
+// This removes any data associated with the timer.
 func (t *Timer) Stop(ctx *Context) {
 	// Remove previous timer entry (if any).
 	t.remove(ctx)

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -437,8 +437,7 @@ func (g *Group) IsPeerAuthorized(peerID signature.PublicKey) bool {
 
 	// If we are in the merge committee, we accept messages from any compute committee member.
 	if g.activeEpoch.mergeCommittee.Role != scheduler.Invalid {
-		_, ok := g.activeEpoch.computeCommitteesByPeer[peerID.ToMapKey()]
-		authorized = authorized || ok
+		authorized = authorized || g.activeEpoch.computeCommitteesByPeer[peerID.ToMapKey()]
 	}
 
 	return authorized

--- a/go/worker/common/p2p/p2p.go
+++ b/go/worker/common/p2p/p2p.go
@@ -94,6 +94,10 @@ func peerIDToPublicKey(peerID core.PeerID) (signature.PublicKey, error) {
 // Info returns the information needed to establish connections to this
 // node via the P2P transport.
 func (p *P2P) Info() node.P2PInfo {
+	if p == nil {
+		return node.P2PInfo{}
+	}
+
 	var addrs []multiaddr.Multiaddr
 	if len(p.registerAddresses) == 0 {
 		addrs = p.host.Addrs()

--- a/go/worker/common/p2p/p2p.go
+++ b/go/worker/common/p2p/p2p.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/cenkalti/backoff"
 	"github.com/libp2p/go-libp2p"
@@ -14,6 +15,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
+	"github.com/libp2p/go-libp2p-core/transport"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multiaddr-net"
 	"github.com/spf13/viper"
@@ -425,4 +427,9 @@ func New(ctx context.Context, identity *identity.Identity) (*P2P, error) {
 	)
 
 	return p, nil
+}
+
+func init() {
+	// Make sure to decrease (global!) transport timeouts.
+	transport.AcceptTimeout = 5 * time.Second
 }


### PR DESCRIPTION
* Close connections for unknown peers.
* Do not start P2P if not needed.
* Decrease default accept timeout.
* (unrelated) Stop round timer when blocks are emitted and make spurious timeouts a hard fail.