### PR TITLE
oasis-node stake tests and docs

### DIFF
--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -604,7 +604,7 @@ func (mux *abciMux) CheckTx(req types.RequestCheckTx) types.ResponseCheckTx {
 	if err := mux.executeTx(ctx, req.Tx); err != nil {
 		return types.ResponseCheckTx{
 			Code:      api.CodeTransactionFailed.ToInt(),
-			Info:      err.Error(),
+			Log:       err.Error(),
 			GasWanted: int64(ctx.Gas().GasWanted()),
 			GasUsed:   int64(ctx.Gas().GasUsed()),
 		}
@@ -623,7 +623,7 @@ func (mux *abciMux) DeliverTx(req types.RequestDeliverTx) types.ResponseDeliverT
 	if err := mux.executeTx(ctx, req.Tx); err != nil {
 		return types.ResponseDeliverTx{
 			Code:      api.CodeTransactionFailed.ToInt(),
-			Info:      err.Error(),
+			Log:       err.Error(),
 			GasWanted: int64(ctx.Gas().GasWanted()),
 			GasUsed:   int64(ctx.Gas().GasUsed()),
 		}

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -436,7 +436,7 @@ func (t *tendermintService) broadcastTxRaw(data []byte) error {
 	}
 
 	if response.Code != api.CodeOK.ToInt() {
-		return fmt.Errorf("broadcast tx: check tx failed: %d", response.Code)
+		return fmt.Errorf("broadcast tx: check tx failed: %d: %s", response.Code, response.Log)
 	}
 
 	return nil
@@ -476,7 +476,7 @@ func (t *tendermintService) broadcastTx(ctx context.Context, tag byte, tx interf
 	select {
 	case v := <-txSub.Out():
 		if result := v.Data().(tmtypes.EventDataTx).Result; !result.IsOK() {
-			return errors.New(result.GetInfo())
+			return errors.New(result.GetLog())
 		}
 		return nil
 	case <-txSub.Cancelled():

--- a/go/oasis-node/cmd/common/grpc/grpc.go
+++ b/go/oasis-node/cmd/common/grpc/grpc.go
@@ -20,7 +20,8 @@ const (
 	CfgServerPort = "grpc.port"
 	// CfgDebugPort configures the internal debug port.
 	CfgDebugPort = "grpc.debug.port"
-	cfgAddress   = "address"
+	// CfgDebugPort configures the remote address.
+	CfgAddress = "address"
 
 	defaultAddress      = "127.0.0.1:42261"
 	localSocketFilename = "internal.sock"
@@ -76,7 +77,7 @@ func NewServerLocal(installWrapper bool) (*cmnGrpc.Server, error) {
 
 // NewClient connects to a remote gRPC server.
 func NewClient(cmd *cobra.Command) (*grpc.ClientConn, error) {
-	addr, _ := cmd.Flags().GetString(cfgAddress)
+	addr, _ := cmd.Flags().GetString(CfgAddress)
 
 	conn, err := grpc.Dial(addr, grpc.WithInsecure()) // TODO: TLS?
 	if err != nil {
@@ -95,6 +96,6 @@ func init() {
 	_ = viper.BindPFlags(ServerLocalFlags)
 	ServerLocalFlags.AddFlagSet(cmnGrpc.Flags)
 
-	ClientFlags.StringP(cfgAddress, "a", defaultAddress, "remote gRPC address")
+	ClientFlags.StringP(CfgAddress, "a", defaultAddress, "remote gRPC address")
 	_ = viper.BindPFlags(ClientFlags)
 }

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -550,6 +550,19 @@ func AppendStakingState(doc *genesis.Document, state string, l *logging.Logger) 
 		// escrow balances.
 		_ = stakingSt.TotalSupply.Add(&q)
 		_ = stakingSt.TotalSupply.Add(&q)
+
+		// Set zero thresholds for all staking kinds, if none set.
+		if len(stakingSt.Parameters.Thresholds) == 0 {
+			var sq quantity.Quantity
+			_ = sq.FromBigInt(big.NewInt(0))
+			stakingSt.Parameters.Thresholds =
+				map[staking.ThresholdKind]quantity.Quantity{
+					staking.KindEntity:    sq,
+					staking.KindValidator: sq,
+					staking.KindCompute:   sq,
+					staking.KindStorage:   sq,
+				}
+		}
 	}
 
 	doc.Staking = stakingSt

--- a/go/oasis-node/cmd/stake/stake.go
+++ b/go/oasis-node/cmd/stake/stake.go
@@ -206,15 +206,23 @@ func doList(cmd *cobra.Command, args []string) {
 	}
 }
 
-type accountInfo struct {
-	ID             signature.PublicKey `json:"id"`
-	GeneralBalance quantity.Quantity   `json:"general_balance"`
-	EscrowBalance  quantity.Quantity   `json:"escrow_balance"`
-	Nonce          uint64              `json:"nonce"`
+// AccountInfo contains aggregated information of a single account.
+type AccountInfo struct {
+	// ID is the address of account.
+	ID signature.PublicKey `json:"id"`
+
+	// GeneralBalance is the spendable balance by the account.
+	GeneralBalance quantity.Quantity `json:"general_balance"`
+
+	// EscrowBalance is the current escrow balance on this account.
+	EscrowBalance quantity.Quantity `json:"escrow_balance"`
+
+	// Nonce is a number increased each time there is an outgoing txn from this account.
+	Nonce uint64 `json:"nonce"`
 }
 
-func getAccountInfo(ctx context.Context, cmd *cobra.Command, id signature.PublicKey, client grpcStaking.StakingClient) *accountInfo {
-	var ai accountInfo
+func getAccountInfo(ctx context.Context, cmd *cobra.Command, id signature.PublicKey, client grpcStaking.StakingClient) *AccountInfo {
+	var ai AccountInfo
 	doWithRetries(cmd, "query account "+id.String(), func() error {
 		rawID, _ := id.MarshalBinary()
 		resp, err := client.GetAccountInfo(ctx, &grpcStaking.GetAccountInfoRequest{

--- a/go/oasis-test-runner/scenario/e2e/common.go
+++ b/go/oasis-test-runner/scenario/e2e/common.go
@@ -2,7 +2,9 @@
 package e2e
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"math"
 	"os/exec"
 	"path/filepath"
@@ -104,35 +106,35 @@ func startClient(env *env.Env, net *oasis.Network, clientBinary string, clientAr
 	return cmd, nil
 }
 
-func startSubCommand(env *env.Env, name, binary string, args []string) (*exec.Cmd, error) {
-	d, err := env.NewSubDir(name)
-	if err != nil {
-		return nil, err
-	}
-
-	w, err := d.NewLogWriter("command.log")
-	if err != nil {
-		return nil, err
-	}
-
+func startSubCommand(env *env.Env, name, binary string, args []string, stdout io.Writer, stderr io.Writer) (*exec.Cmd, error) {
 	cmd := exec.Command(binary, args...)
 	cmd.SysProcAttr = oasis.CmdAttrs
-	cmd.Stdout = w
-	cmd.Stderr = w
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
 	logger.Info("launching subcommand",
 		"binary", binary,
 		"args", strings.Join(args, " "),
 	)
 
-	if err = cmd.Start(); err != nil {
+	if err := cmd.Start(); err != nil {
 		return nil, err
 	}
 	return cmd, nil
 }
 
 func runSubCommand(env *env.Env, name, binary string, args []string) error {
-	cmd, err := startSubCommand(env, name, binary, args)
+	d, err := env.NewSubDir(name)
+	if err != nil {
+		return err
+	}
+
+	w, err := d.NewLogWriter("command.log")
+	if err != nil {
+		return err
+	}
+
+	cmd, err := startSubCommand(env, name, binary, args, w, w)
 	if err != nil {
 		return err
 	}
@@ -140,6 +142,18 @@ func runSubCommand(env *env.Env, name, binary string, args []string) error {
 		return err
 	}
 	return nil
+}
+
+func runSubCommandWithOutput(env *env.Env, name, binary string, args []string) (bytes.Buffer, error) {
+	var b bytes.Buffer
+	cmd, err := startSubCommand(env, name, binary, args, &b, &b)
+	if err != nil {
+		return b, err
+	}
+	if err = cmd.Wait(); err != nil {
+		return b, err
+	}
+	return b, nil
 }
 
 func init() {

--- a/go/oasis-test-runner/scenario/e2e/stake_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/stake_cli.go
@@ -1,0 +1,445 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common/logging"
+	"github.com/oasislabs/oasis-core/go/common/quantity"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/grpc"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/stake"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/scenario"
+)
+
+const (
+	// Init balance in the genesis block.
+	initBalance = 100_000_000_000
+
+	// Test transfer amount.
+	transferAmount = 1000
+
+	// Test burn amount.
+	burnAmount = 2000
+
+	// Test escrow amount.
+	escrowAmount = 3000
+
+	// Transaction fee amount.
+	feeAmount = 10
+
+	// Transaction fee gas.
+	feeGas = 10
+
+	// Source address in the genesis block.
+	srcAddress = "4ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35"
+
+	// Test transfer destination address.
+	transferAddress = "5ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35"
+
+	// Test escrow address.
+	escrowAddress = "6ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35"
+)
+
+var (
+	// StakeCLI is the staking scenario.
+	StakeCLI scenario.Scenario = &stakeCLIImpl{
+		basicImpl: basicImpl{},
+		logger:    logging.GetLogger("scenario/e2e/stake"),
+	}
+)
+
+type stakeCLIImpl struct {
+	basicImpl
+
+	logger *logging.Logger
+}
+
+func (s *stakeCLIImpl) Name() string {
+	return "stake-cli"
+}
+
+func (s *stakeCLIImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := s.basicImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	// We will mock epochs for reclaiming the escrow.
+	f.Network.EpochtimeMock = true
+
+	return f, nil
+}
+
+func (s *stakeCLIImpl) Run(childEnv *env.Env) error {
+	if err := s.net.Start(); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	logger.Info("waiting for nodes to register")
+	if err := s.net.Controller().WaitNodesRegistered(ctx, 3); err != nil {
+		return fmt.Errorf("waiting for nodes to register: %w", err)
+	}
+	logger.Info("nodes registered")
+
+	// Account list.
+	accounts, err := s.listAccounts(childEnv)
+	if err != nil {
+		return err
+	}
+	// In the genesis block, only one account should have a balance.
+	if len(accounts) < 1 {
+		return fmt.Errorf("scenario/e2e/stake: initial stake list wrong number of accounts: %d, expected at least: %d. Accounts: %s", len(accounts), 1, accounts)
+	}
+
+	// Let the first and the only account in the list be the source account.
+	var src signature.PublicKey
+	if err = src.UnmarshalHex(srcAddress); err != nil {
+		return err
+	}
+	if !bytes.Equal(accounts[0], src) {
+		return fmt.Errorf("scenario/e2e/stake: wrong src account: %s expected: %s", accounts[0].String(), src.String())
+	}
+	// Define a new destination account.
+	var dst signature.PublicKey
+	if err = dst.UnmarshalHex(transferAddress); err != nil {
+		return err
+	}
+	// Define escrow account.
+	var escrow signature.PublicKey
+	if err = escrow.UnmarshalHex(escrowAddress); err != nil {
+		return err
+	}
+
+	// Run the tests
+	// Transfer
+	if err = s.testTransfer(childEnv, src, dst); err != nil {
+		return fmt.Errorf("scenario/e2e/stake: error while running Transfer test: %w", err)
+	}
+
+	// Burn
+	if err = s.testBurn(childEnv, src); err != nil {
+		return fmt.Errorf("scenario/e2e/stake: error while running Burn test: %w", err)
+	}
+
+	// Escrow
+	if err = s.testEscrow(childEnv, src, escrow); err != nil {
+		return fmt.Errorf("scenario/e2e/stake: error while running Escrow test: %w", err)
+	}
+
+	// ReclaimEscrow
+	if err = s.testReclaimEscrow(childEnv, src, escrow); err != nil {
+		return fmt.Errorf("scenario/e2e/stake: error while running ReclaimEscrow test: %w", err)
+	}
+
+	// Stop the network.
+	s.logger.Info("stopping the network")
+	s.net.Stop()
+
+	return nil
+}
+
+// testTransfer tests transfer of 1000 tokens from src to dst.
+func (s *stakeCLIImpl) testTransfer(childEnv *env.Env, src signature.PublicKey, dst signature.PublicKey) error {
+	transferTxPath := filepath.Join(childEnv.Dir(), "stake_transfer.json")
+	if err := s.genTransferTx(childEnv, transferAmount, 0, dst, transferTxPath); err != nil {
+		return err
+	}
+	if err := s.checkBalance(childEnv, src, initBalance); err != nil {
+		return err
+	}
+	if err := s.checkBalance(childEnv, dst, 0); err != nil {
+		return err
+	}
+
+	if err := s.submitTx(childEnv, src, transferTxPath); err != nil {
+		return err
+	}
+
+	if err := s.checkBalance(childEnv, src, initBalance-transferAmount-feeAmount); err != nil {
+		return err
+	}
+	if err := s.checkBalance(childEnv, dst, transferAmount); err != nil {
+		return err
+	}
+	accounts, err := s.listAccounts(childEnv)
+	if err != nil {
+		return err
+	}
+	if len(accounts) < 2 {
+		return fmt.Errorf("scenario/e2e/stake: post-transfer stake list wrong number of accounts: %d, expected at least: %d. Accounts: %s", len(accounts), 2, accounts)
+	}
+
+	return nil
+}
+
+// testBurn tests burning of 2000 tokens owned by src.
+func (s *stakeCLIImpl) testBurn(childEnv *env.Env, src signature.PublicKey) error {
+	burnTxPath := filepath.Join(childEnv.Dir(), "stake_burn.json")
+	if err := s.genBurnTx(childEnv, burnAmount, 1, burnTxPath); err != nil {
+		return err
+	}
+
+	if err := s.submitTx(childEnv, src, burnTxPath); err != nil {
+		return err
+	}
+
+	if err := s.checkBalance(childEnv, src, initBalance-transferAmount-burnAmount-2*feeAmount); err != nil {
+		return err
+	}
+	accounts, err := s.listAccounts(childEnv)
+	if err != nil {
+		return err
+	}
+	if len(accounts) < 2 {
+		return fmt.Errorf("scenario/e2e/stake: post-burn stake list wrong number of accounts: %d, expected at least: %d", len(accounts), 2)
+	}
+
+	return nil
+}
+
+// testEscrow tests escrowing of 3000 tokens from src to dst.
+func (s *stakeCLIImpl) testEscrow(childEnv *env.Env, src signature.PublicKey, escrow signature.PublicKey) error {
+	escrowTxPath := filepath.Join(childEnv.Dir(), "stake_escrow.json")
+	if err := s.genEscrowTx(childEnv, escrowAmount, 2, escrow, escrowTxPath); err != nil {
+		return err
+	}
+
+	if err := s.submitTx(childEnv, src, escrowTxPath); err != nil {
+		return err
+	}
+
+	if err := s.checkBalance(childEnv, src, initBalance-transferAmount-burnAmount-escrowAmount-3*feeAmount); err != nil {
+		return err
+	}
+	if err := s.checkEscrowBalance(childEnv, escrow, escrowAmount); err != nil {
+		return err
+	}
+	accounts, err := s.listAccounts(childEnv)
+	if err != nil {
+		return err
+	}
+	if len(accounts) < 3 {
+		return fmt.Errorf("scenario/e2e/stake: post-escrow stake list wrong number of accounts: %d, expected at least: %d", len(accounts), 3)
+	}
+
+	return nil
+}
+
+// testReclaimEscrow test reclaiming an escrow of 3000 tokens from escrow account.
+func (s *stakeCLIImpl) testReclaimEscrow(childEnv *env.Env, src signature.PublicKey, escrow signature.PublicKey) error {
+	reclaimEscrowTxPath := filepath.Join(childEnv.Dir(), "stake_reclaim_escrow.json")
+	if err := s.genReclaimEscrowTx(childEnv, escrowAmount, 3, escrow, reclaimEscrowTxPath); err != nil {
+		return err
+	}
+
+	if err := s.submitTx(childEnv, src, reclaimEscrowTxPath); err != nil {
+		return err
+
+	}
+	// Advance epochs to trigger reclaim processing.
+	if err := s.net.Controller().SetEpoch(context.Background(), 1); err != nil {
+		return fmt.Errorf("failed to set epoch: %w", err)
+	}
+
+	if err := s.checkBalance(childEnv, src, initBalance-transferAmount-burnAmount-4*feeAmount); err != nil {
+		return err
+	}
+	if err := s.checkEscrowBalance(childEnv, escrow, 0); err != nil {
+		return err
+	}
+	accounts, err := s.listAccounts(childEnv)
+	if err != nil {
+		return err
+	}
+	if len(accounts) < 3 {
+		return fmt.Errorf("scenario/e2e/stake: post-reclaim-escrow stake list wrong number of accounts: %d, expected: %d", len(accounts), 3)
+	}
+
+	return nil
+}
+
+func (s *stakeCLIImpl) listAccounts(childEnv *env.Env) ([]signature.PublicKey, error) {
+	s.logger.Info("listing all accounts")
+	args := []string{
+		"stake", "list",
+		"--" + grpc.CfgAddress, "unix:" + s.basicImpl.net.Validators()[0].SocketPath(),
+	}
+	b, err := runSubCommandWithOutput(childEnv, "list", s.basicImpl.net.Config().NodeBinary, args)
+	if err != nil {
+		return nil, fmt.Errorf("scenario/e2e/stake: failed to list accounts: %s error: %w", b.String(), err)
+	}
+	accountsStr := strings.Split(b.String(), "\n")
+
+	var accounts []signature.PublicKey
+	for _, accStr := range accountsStr {
+		// Ignore last newline.
+		if accStr == "" {
+			continue
+		}
+
+		var acc signature.PublicKey
+		if err = acc.UnmarshalHex(accStr); err != nil {
+			return nil, err
+		}
+		accounts = append(accounts, acc)
+	}
+
+	return accounts, nil
+}
+
+func (s *stakeCLIImpl) submitTx(childEnv *env.Env, src signature.PublicKey, txPath string) error {
+	s.logger.Info("submitting tx", stake.CfgTxFile, txPath)
+	args := []string{
+		"stake", "account", "submit",
+		"--" + stake.CfgAccountID, src.String(),
+		"--" + stake.CfgTxFile, txPath,
+		"--" + grpc.CfgAddress, "unix:" + s.basicImpl.net.Validators()[0].SocketPath(),
+		"--" + common.CfgDebugAllowTestKeys,
+	}
+	if err := runSubCommand(childEnv, "submit", s.basicImpl.net.Config().NodeBinary, args); err != nil {
+		return fmt.Errorf("scenario/e2e/stake: failed to submit transfer tx: %w", err)
+	}
+	return nil
+}
+
+func (s *stakeCLIImpl) getAccountInfo(childEnv *env.Env, src signature.PublicKey) (*stake.AccountInfo, error) {
+	s.logger.Info("checking account balance", stake.CfgAccountID, src.String())
+	args := []string{
+		"stake", "account", "info",
+		"--" + stake.CfgAccountID, src.String(),
+		"--" + grpc.CfgAddress, "unix:" + s.basicImpl.net.Validators()[0].SocketPath(),
+	}
+
+	b, err := runSubCommandWithOutput(childEnv, "info", s.basicImpl.net.Config().NodeBinary, args)
+	if err != nil {
+		return nil, fmt.Errorf("scenario/e2e/stake: failed to check account info: %w", err)
+	}
+
+	ai := stake.AccountInfo{}
+	if err = json.Unmarshal(b.Bytes(), &ai); err != nil {
+		return nil, err
+	}
+
+	return &ai, nil
+}
+
+func (s *stakeCLIImpl) checkBalance(childEnv *env.Env, src signature.PublicKey, expected int64) error {
+	ai, err := s.getAccountInfo(childEnv, src)
+	if err != nil {
+		return err
+	}
+
+	var q quantity.Quantity
+	if err = q.FromBigInt(big.NewInt(expected)); err != nil {
+		return err
+	}
+	if ai.GeneralBalance.Cmp(&q) != 0 {
+		return fmt.Errorf("checkBalance: wrong general balance of account. Expected %s got %s", q.String(), ai.GeneralBalance.String())
+	}
+
+	return nil
+}
+
+func (s *stakeCLIImpl) checkEscrowBalance(childEnv *env.Env, src signature.PublicKey, expected int64) error {
+	ai, err := s.getAccountInfo(childEnv, src)
+	if err != nil {
+		return err
+	}
+
+	var q quantity.Quantity
+	if err = q.FromBigInt(big.NewInt(expected)); err != nil {
+		return err
+	}
+	if ai.EscrowBalance.Cmp(&q) != 0 {
+		return fmt.Errorf("checkEscrowBalance: wrong escrow balance of account. Expected %s got %s", q.String(), ai.EscrowBalance.String())
+	}
+
+	return nil
+}
+
+func (s *stakeCLIImpl) genTransferTx(childEnv *env.Env, amount int, nonce int, dst signature.PublicKey, txPath string) error {
+	s.logger.Info("generating stake transfer tx", stake.CfgTransferDestination, dst)
+
+	args := []string{
+		"stake", "account", "gen_transfer",
+		"--" + stake.CfgTxAmount, strconv.Itoa(amount),
+		"--" + stake.CfgTxNonce, strconv.Itoa(nonce),
+		"--" + stake.CfgTxFile, txPath,
+		"--" + stake.CfgTransferDestination, dst.String(),
+		"--" + stake.CfgTxFeeAmount, strconv.Itoa(feeAmount),
+		"--" + stake.CfgTxFeeGas, strconv.Itoa(feeGas),
+		"--" + flags.CfgDebugTestEntity,
+	}
+	if err := runSubCommand(childEnv, "gen_transfer", s.basicImpl.net.Config().NodeBinary, args); err != nil {
+		return fmt.Errorf("genTransferTx: failed to generate transfer tx: %w", err)
+	}
+	return nil
+}
+
+func (s *stakeCLIImpl) genBurnTx(childEnv *env.Env, amount int, nonce int, txPath string) error {
+	s.logger.Info("generating stake burn tx")
+
+	args := []string{
+		"stake", "account", "gen_burn",
+		"--" + stake.CfgTxAmount, strconv.Itoa(amount),
+		"--" + stake.CfgTxNonce, strconv.Itoa(nonce),
+		"--" + stake.CfgTxFile, txPath,
+		"--" + stake.CfgTxFeeAmount, strconv.Itoa(feeAmount),
+		"--" + stake.CfgTxFeeGas, strconv.Itoa(feeGas),
+		"--" + flags.CfgDebugTestEntity,
+	}
+	if err := runSubCommand(childEnv, "gen_burn", s.basicImpl.net.Config().NodeBinary, args); err != nil {
+		return fmt.Errorf("genBurnTx: failed to generate burn tx: %w", err)
+	}
+	return nil
+}
+
+func (s *stakeCLIImpl) genEscrowTx(childEnv *env.Env, amount int, nonce int, escrow signature.PublicKey, txPath string) error {
+	s.logger.Info("generating stake escrow tx", "stake.CfgEscrowAccount", escrow)
+
+	args := []string{
+		"stake", "account", "gen_escrow",
+		"--" + stake.CfgTxAmount, strconv.Itoa(amount),
+		"--" + stake.CfgTxNonce, strconv.Itoa(nonce),
+		"--" + stake.CfgTxFile, txPath,
+		"--" + stake.CfgEscrowAccount, escrow.String(),
+		"--" + stake.CfgTxFeeAmount, strconv.Itoa(feeAmount),
+		"--" + stake.CfgTxFeeGas, strconv.Itoa(feeGas),
+		"--" + flags.CfgDebugTestEntity,
+	}
+	if err := runSubCommand(childEnv, "gen_escrow", s.basicImpl.net.Config().NodeBinary, args); err != nil {
+		return fmt.Errorf("genEscrowTx: failed to generate escrow tx: %w", err)
+	}
+	return nil
+}
+
+func (s *stakeCLIImpl) genReclaimEscrowTx(childEnv *env.Env, amount int, nonce int, escrow signature.PublicKey, txPath string) error {
+	s.logger.Info("generating stake reclaim escrow tx", stake.CfgEscrowAccount, escrow)
+
+	args := []string{
+		"stake", "account", "gen_reclaim_escrow",
+		"--" + stake.CfgTxAmount, strconv.Itoa(amount),
+		"--" + stake.CfgTxNonce, strconv.Itoa(nonce),
+		"--" + stake.CfgTxFile, txPath,
+		"--" + stake.CfgEscrowAccount, escrow.String(),
+		"--" + stake.CfgTxFeeAmount, strconv.Itoa(feeAmount),
+		"--" + stake.CfgTxFeeGas, strconv.Itoa(feeGas),
+		"--" + flags.CfgDebugTestEntity,
+	}
+	if err := runSubCommand(childEnv, "gen_reclaim_escrow", s.basicImpl.net.Config().NodeBinary, args); err != nil {
+		return fmt.Errorf("genReclaimEscrowTx: failed to generate reclaim escrow tx: %w", err)
+	}
+	return nil
+}

--- a/go/oasis-test-runner/test-runner.go
+++ b/go/oasis-test-runner/test-runner.go
@@ -39,6 +39,8 @@ func main() {
 	_ = cmd.Register(e2e.HaltRestore)
 	// Roothash messages test.
 	_ = cmd.Register(e2e.RoothashMessages)
+	// Stake CLI test.
+	_ = cmd.Register(e2e.StakeCLI)
 	// Node shutdown test.
 	_ = cmd.Register(e2e.NodeShutdown)
 	// Gas fees test.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -72,7 +72,7 @@ type Backend interface {
 	// Symbol is the symbol of the token.
 	Symbol() string
 
-	// TotalSupply returns the total nmber of tokens.
+	// TotalSupply returns the total number of tokens.
 	TotalSupply(ctx context.Context, height int64) (*quantity.Quantity, error)
 
 	// CommonPool returns the common pool balance.


### PR DESCRIPTION
PR for https://github.com/oasislabs/oasis-core/issues/2275

This PR:
- adds new `stake` e2e test based on basic test,
- adds e2e tests for `oasis-node` commands `stake list`, `stake account info`, `stake account gen_transfer`, `stake account gen_burn`, `stake account gen_escrow`, `stake account gen_reclaim_escrow`, and `stake account submit`,
- adds `runCommandWithOutput()` helper to `oasis-test-runner` which executes external command and returns its stdout/stderr for further parsing (e.g. for reading list of stake accounts).

For documentation on stake management, see https://github.com/oasislabs/docs/pull/105.