### PR TITLE
go/tendermint/apps: Move state to its own module

### DIFF
--- a/go/tendermint/apps/beacon/beacon.go
+++ b/go/tendermint/apps/beacon/beacon.go
@@ -52,10 +52,6 @@ func (app *beaconApplication) Dependencies() []string {
 	return nil
 }
 
-func (app *beaconApplication) GetState(height int64) (interface{}, error) {
-	return newImmutableState(app.state, height)
-}
-
 func (app *beaconApplication) OnRegister(state *abci.ApplicationState) {
 	app.state = state
 }

--- a/go/tendermint/apps/beacon/beacon.go
+++ b/go/tendermint/apps/beacon/beacon.go
@@ -15,6 +15,7 @@ import (
 	genesis "github.com/oasislabs/oasis-core/go/genesis/api"
 	"github.com/oasislabs/oasis-core/go/tendermint/abci"
 	"github.com/oasislabs/oasis-core/go/tendermint/api"
+	beaconState "github.com/oasislabs/oasis-core/go/tendermint/apps/beacon/state"
 )
 
 var (
@@ -142,9 +143,9 @@ func (app *beaconApplication) onBeaconEpochChange(ctx *abci.Context, epoch epoch
 }
 
 func (app *beaconApplication) onNewBeacon(ctx *abci.Context, beacon []byte) error {
-	state := NewMutableState(ctx.State())
+	state := beaconState.NewMutableState(ctx.State())
 
-	if err := state.setBeacon(beacon); err != nil {
+	if err := state.SetBeacon(beacon); err != nil {
 		app.logger.Error("onNewBeacon: failed to set beacon",
 			"err", err,
 		)

--- a/go/tendermint/apps/beacon/query.go
+++ b/go/tendermint/apps/beacon/query.go
@@ -2,6 +2,8 @@ package beacon
 
 import (
 	"context"
+
+	beaconState "github.com/oasislabs/oasis-core/go/tendermint/apps/beacon/state"
 )
 
 // Query is the beacon query interface.
@@ -16,7 +18,7 @@ type QueryFactory struct {
 
 // QueryAt returns the beacon query interface for a specific height.
 func (sf *QueryFactory) QueryAt(height int64) (Query, error) {
-	state, err := newImmutableState(sf.app.state, height)
+	state, err := beaconState.NewImmutableState(sf.app.state, height)
 	if err != nil {
 		return nil, err
 	}
@@ -24,11 +26,11 @@ func (sf *QueryFactory) QueryAt(height int64) (Query, error) {
 }
 
 type beaconQuerier struct {
-	state *immutableState
+	state *beaconState.ImmutableState
 }
 
 func (bq *beaconQuerier) Beacon(ctx context.Context) ([]byte, error) {
-	return bq.state.GetBeacon()
+	return bq.state.Beacon()
 }
 
 func (app *beaconApplication) QueryFactory() interface{} {

--- a/go/tendermint/apps/epochtime_mock/epochtime_mock.go
+++ b/go/tendermint/apps/epochtime_mock/epochtime_mock.go
@@ -49,10 +49,6 @@ func (app *epochTimeMockApplication) SetOption(request types.RequestSetOption) t
 	return types.ResponseSetOption{}
 }
 
-func (app *epochTimeMockApplication) GetState(height int64) (interface{}, error) {
-	return newImmutableState(app.state, height)
-}
-
 func (app *epochTimeMockApplication) InitChain(ctx *abci.Context, request types.RequestInitChain, doc *genesis.Document) error {
 	return nil
 }

--- a/go/tendermint/apps/keymanager/genesis.go
+++ b/go/tendermint/apps/keymanager/genesis.go
@@ -14,6 +14,7 @@ import (
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
 	"github.com/oasislabs/oasis-core/go/tendermint/abci"
 	tmapi "github.com/oasislabs/oasis-core/go/tendermint/api"
+	keymanagerState "github.com/oasislabs/oasis-core/go/tendermint/apps/keymanager/state"
 )
 
 func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.RequestInitChain, doc *genesis.Document) error {
@@ -44,7 +45,7 @@ func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.Req
 	}
 
 	var toEmit []*keymanager.Status
-	state := NewMutableState(ctx.State())
+	state := keymanagerState.NewMutableState(ctx.State())
 	for _, v := range st.Statuses {
 		rt := rtMap[v.ID.ToMapKey()]
 		if rt == nil {
@@ -67,7 +68,7 @@ func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.Req
 		}
 
 		// Set, enqueue for emit.
-		state.setStatus(v)
+		state.SetStatus(v)
 		toEmit = append(toEmit, v)
 	}
 
@@ -79,7 +80,7 @@ func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.Req
 }
 
 func (kq *keymanagerQuerier) Genesis(ctx context.Context) (*keymanager.Genesis, error) {
-	statuses, err := kq.state.GetStatuses()
+	statuses, err := kq.state.Statuses()
 	if err != nil {
 		return nil, err
 	}

--- a/go/tendermint/apps/keymanager/keymanager.go
+++ b/go/tendermint/apps/keymanager/keymanager.go
@@ -45,10 +45,6 @@ func (app *keymanagerApplication) Dependencies() []string {
 	return []string{registryapp.AppName}
 }
 
-func (app *keymanagerApplication) GetState(height int64) (interface{}, error) {
-	return newImmutableState(app.state, height)
-}
-
 func (app *keymanagerApplication) OnRegister(state *abci.ApplicationState) {
 	app.state = state
 }

--- a/go/tendermint/apps/keymanager/query.go
+++ b/go/tendermint/apps/keymanager/query.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	keymanager "github.com/oasislabs/oasis-core/go/keymanager/api"
+	keymanagerState "github.com/oasislabs/oasis-core/go/tendermint/apps/keymanager/state"
 )
 
 // Query is the key manager query interface.
@@ -21,7 +22,7 @@ type QueryFactory struct {
 
 // QueryAt returns the key manager query interface for a specific height.
 func (sf *QueryFactory) QueryAt(height int64) (Query, error) {
-	state, err := newImmutableState(sf.app.state, height)
+	state, err := keymanagerState.NewImmutableState(sf.app.state, height)
 	if err != nil {
 		return nil, err
 	}
@@ -29,15 +30,15 @@ func (sf *QueryFactory) QueryAt(height int64) (Query, error) {
 }
 
 type keymanagerQuerier struct {
-	state *immutableState
+	state *keymanagerState.ImmutableState
 }
 
 func (kq *keymanagerQuerier) Status(ctx context.Context, id signature.PublicKey) (*keymanager.Status, error) {
-	return kq.state.GetStatus(id)
+	return kq.state.Status(id)
 }
 
 func (kq *keymanagerQuerier) Statuses(ctx context.Context) ([]*keymanager.Status, error) {
-	return kq.state.GetStatuses()
+	return kq.state.Statuses()
 }
 
 func (app *keymanagerApplication) QueryFactory() interface{} {

--- a/go/tendermint/apps/registry/genesis.go
+++ b/go/tendermint/apps/registry/genesis.go
@@ -12,6 +12,7 @@ import (
 	genesis "github.com/oasislabs/oasis-core/go/genesis/api"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
 	"github.com/oasislabs/oasis-core/go/tendermint/abci"
+	registryState "github.com/oasislabs/oasis-core/go/tendermint/apps/registry/state"
 )
 
 func (app *registryApplication) InitChain(ctx *abci.Context, request types.RequestInitChain, doc *genesis.Document) error {
@@ -22,9 +23,9 @@ func (app *registryApplication) InitChain(ctx *abci.Context, request types.Reque
 		"state", string(b),
 	)
 
-	state := NewMutableState(ctx.State())
+	state := registryState.NewMutableState(ctx.State())
 
-	state.setKeyManagerOperator(st.KeyManagerOperator)
+	state.SetKeyManagerOperator(st.KeyManagerOperator)
 	app.logger.Debug("InitChain: Registering key manager operator",
 		"id", st.KeyManagerOperator,
 	)
@@ -71,15 +72,15 @@ func (app *registryApplication) InitChain(ctx *abci.Context, request types.Reque
 
 func (rq *registryQuerier) Genesis(ctx context.Context) (*registry.Genesis, error) {
 	// Fetch entities, runtimes, and nodes from state.
-	signedEntities, err := rq.state.getSignedEntities()
+	signedEntities, err := rq.state.SignedEntities()
 	if err != nil {
 		return nil, err
 	}
-	signedRuntimes, err := rq.state.getSignedRuntimes()
+	signedRuntimes, err := rq.state.SignedRuntimes()
 	if err != nil {
 		return nil, err
 	}
-	signedNodes, err := rq.state.getSignedNodes()
+	signedNodes, err := rq.state.SignedNodes()
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +102,7 @@ func (rq *registryQuerier) Genesis(ctx context.Context) (*registry.Genesis, erro
 		Entities:           signedEntities,
 		Runtimes:           signedRuntimes,
 		Nodes:              validatorNodes,
-		KeyManagerOperator: rq.state.getKeyManagerOperator(),
+		KeyManagerOperator: rq.state.KeyManagerOperator(),
 	}
 	return &gen, nil
 }

--- a/go/tendermint/apps/registry/query.go
+++ b/go/tendermint/apps/registry/query.go
@@ -7,6 +7,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/entity"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
+	registryState "github.com/oasislabs/oasis-core/go/tendermint/apps/registry/state"
 )
 
 // Query is the registry query interface.
@@ -27,7 +28,7 @@ type QueryFactory struct {
 
 // QueryAt returns the registry query interface for a specific height.
 func (sf *QueryFactory) QueryAt(height int64) (Query, error) {
-	state, err := newImmutableState(sf.app.state, height)
+	state, err := registryState.NewImmutableState(sf.app.state, height)
 	if err != nil {
 		return nil, err
 	}
@@ -35,31 +36,31 @@ func (sf *QueryFactory) QueryAt(height int64) (Query, error) {
 }
 
 type registryQuerier struct {
-	state *immutableState
+	state *registryState.ImmutableState
 }
 
 func (rq *registryQuerier) Entity(ctx context.Context, id signature.PublicKey) (*entity.Entity, error) {
-	return rq.state.getEntity(id)
+	return rq.state.Entity(id)
 }
 
 func (rq *registryQuerier) Entities(ctx context.Context) ([]*entity.Entity, error) {
-	return rq.state.getEntities()
+	return rq.state.Entities()
 }
 
 func (rq *registryQuerier) Node(ctx context.Context, id signature.PublicKey) (*node.Node, error) {
-	return rq.state.GetNode(id)
+	return rq.state.Node(id)
 }
 
 func (rq *registryQuerier) Nodes(ctx context.Context) ([]*node.Node, error) {
-	return rq.state.GetNodes()
+	return rq.state.Nodes()
 }
 
 func (rq *registryQuerier) Runtime(ctx context.Context, id signature.PublicKey) (*registry.Runtime, error) {
-	return rq.state.GetRuntime(id)
+	return rq.state.Runtime(id)
 }
 
 func (rq *registryQuerier) Runtimes(ctx context.Context) ([]*registry.Runtime, error) {
-	return rq.state.GetRuntimes()
+	return rq.state.Runtimes()
 }
 
 func (app *registryApplication) QueryFactory() interface{} {

--- a/go/tendermint/apps/registry/registry.go
+++ b/go/tendermint/apps/registry/registry.go
@@ -18,7 +18,9 @@ import (
 	staking "github.com/oasislabs/oasis-core/go/staking/api"
 	"github.com/oasislabs/oasis-core/go/tendermint/abci"
 	"github.com/oasislabs/oasis-core/go/tendermint/api"
+	registryState "github.com/oasislabs/oasis-core/go/tendermint/apps/registry/state"
 	stakingapp "github.com/oasislabs/oasis-core/go/tendermint/apps/staking"
+	stakingState "github.com/oasislabs/oasis-core/go/tendermint/apps/staking/state"
 )
 
 var _ abci.Application = (*registryApplication)(nil)
@@ -76,7 +78,7 @@ func (app *registryApplication) ExecuteTx(ctx *abci.Context, rawTx []byte) error
 		return errors.Wrap(err, "registry: failed to unmarshal")
 	}
 
-	state := NewMutableState(ctx.State())
+	state := registryState.NewMutableState(ctx.State())
 
 	if tx.TxRegisterEntity != nil {
 		return app.registerEntity(ctx, state, &tx.TxRegisterEntity.Entity)
@@ -106,9 +108,9 @@ func (app *registryApplication) FireTimer(*abci.Context, *abci.Timer) error {
 }
 
 func (app *registryApplication) onRegistryEpochChanged(ctx *abci.Context, registryEpoch epochtime.EpochTime) error {
-	state := NewMutableState(ctx.State())
+	state := registryState.NewMutableState(ctx.State())
 
-	nodes, err := state.GetNodes()
+	nodes, err := state.Nodes()
 	if err != nil {
 		app.logger.Error("onRegistryEpochChanged: failed to get nodes",
 			"err", err,
@@ -122,7 +124,7 @@ func (app *registryApplication) onRegistryEpochChanged(ctx *abci.Context, regist
 			continue
 		}
 		expiredNodes = append(expiredNodes, node)
-		state.removeNode(node)
+		state.RemoveNode(node)
 	}
 
 	// Emit the RegistryNodeListEpoch notification event.
@@ -144,7 +146,7 @@ func (app *registryApplication) onRegistryEpochChanged(ctx *abci.Context, regist
 // Perform actual entity registration.
 func (app *registryApplication) registerEntity(
 	ctx *abci.Context,
-	state *MutableState,
+	state *registryState.MutableState,
 	sigEnt *entity.SignedEntity,
 ) error {
 	ent, err := registry.VerifyRegisterEntityArgs(app.logger, sigEnt, ctx.IsInitChain())
@@ -164,7 +166,7 @@ func (app *registryApplication) registerEntity(
 	}
 
 	if !app.cfg.DebugBypassStake {
-		if err = stakingapp.EnsureSufficientStake(ctx, ent.ID, []staking.ThresholdKind{staking.KindEntity}); err != nil {
+		if err = stakingState.EnsureSufficientStake(ctx, ent.ID, []staking.ThresholdKind{staking.KindEntity}); err != nil {
 			app.logger.Error("RegisterEntity: Insufficent stake",
 				"err", err,
 				"id", ent.ID,
@@ -173,7 +175,7 @@ func (app *registryApplication) registerEntity(
 		}
 	}
 
-	state.createEntity(ent, sigEnt)
+	state.CreateEntity(ent, sigEnt)
 
 	if !ctx.IsCheckOnly() {
 		app.logger.Debug("RegisterEntity: registered",
@@ -189,7 +191,7 @@ func (app *registryApplication) registerEntity(
 // Perform actual entity deregistration.
 func (app *registryApplication) deregisterEntity(
 	ctx *abci.Context,
-	state *MutableState,
+	state *registryState.MutableState,
 	sigTimestamp *signature.Signed,
 ) error {
 	id, timestamp, err := registry.VerifyDeregisterEntityArgs(app.logger, sigTimestamp)
@@ -208,7 +210,7 @@ func (app *registryApplication) deregisterEntity(
 		}
 	}
 
-	removedEntity, removedNodes := state.removeEntity(id)
+	removedEntity, removedNodes := state.RemoveEntity(id)
 
 	if !ctx.IsCheckOnly() {
 		app.logger.Debug("DeregisterEntity: complete",
@@ -228,7 +230,7 @@ func (app *registryApplication) deregisterEntity(
 // Perform actual node registration.
 func (app *registryApplication) registerNode(
 	ctx *abci.Context,
-	state *MutableState,
+	state *registryState.MutableState,
 	sigNode *node.SignedNode,
 ) error {
 	// Peek into the to-be-verified node to pull out the owning entity ID.
@@ -240,7 +242,7 @@ func (app *registryApplication) registerNode(
 		)
 		return err
 	}
-	untrustedEntity, err := state.getEntity(untrustedNode.EntityID)
+	untrustedEntity, err := state.Entity(untrustedNode.EntityID)
 	if err != nil {
 		app.logger.Error("RegisterNode: failed to query owning entity",
 			"err", err,
@@ -249,8 +251,8 @@ func (app *registryApplication) registerNode(
 		return err
 	}
 
-	kmOperator := state.getKeyManagerOperator()
-	regRuntimes, err := state.GetRuntimes()
+	kmOperator := state.KeyManagerOperator()
+	regRuntimes, err := state.Runtimes()
 	if err != nil {
 		app.logger.Error("RegisterNode: failed to obtain registry runtimes",
 			"err", err,
@@ -277,7 +279,7 @@ func (app *registryApplication) registerNode(
 	// Re-check that the entity has at least sufficient stake to still be an
 	// entity.  The node thresholds should be enforced in the scheduler.
 	if !app.cfg.DebugBypassStake {
-		if err = stakingapp.EnsureSufficientStake(ctx, newNode.EntityID, []staking.ThresholdKind{staking.KindEntity}); err != nil {
+		if err = stakingState.EnsureSufficientStake(ctx, newNode.EntityID, []staking.ThresholdKind{staking.KindEntity}); err != nil {
 			app.logger.Error("RegisterNode: Insufficent stake",
 				"err", err,
 				"id", newNode.EntityID,
@@ -295,13 +297,12 @@ func (app *registryApplication) registerNode(
 		return registry.ErrNodeExpired
 	}
 
-	// Check if node exists
-	existingNode, err := state.GetNode(newNode.ID)
+	// Check if node exists.
+	existingNode, err := state.Node(newNode.ID)
 	if err != nil {
 		if err == registry.ErrNoSuchNode {
 			// Node doesn't exist. Create node.
-			err = state.createNode(newNode, sigNode)
-			if err != nil {
+			if err = state.CreateNode(newNode, sigNode); err != nil {
 				app.logger.Error("RegisterNode: failed to create node",
 					"err", err,
 					"node", newNode,
@@ -328,7 +329,7 @@ func (app *registryApplication) registerNode(
 			)
 			return err
 		}
-		err = state.createNode(newNode, sigNode)
+		err = state.CreateNode(newNode, sigNode)
 		if err != nil {
 			app.logger.Error("RegisterNode: failed to update node",
 				"err", err,
@@ -354,7 +355,7 @@ func (app *registryApplication) registerNode(
 // Perform actual runtime registration.
 func (app *registryApplication) registerRuntime(
 	ctx *abci.Context,
-	state *MutableState,
+	state *registryState.MutableState,
 	sigRt *registry.SignedRuntime,
 ) error {
 	rt, err := registry.VerifyRegisterRuntimeArgs(app.logger, sigRt, ctx.IsInitChain())
@@ -387,7 +388,7 @@ func (app *registryApplication) registerRuntime(
 		}
 	}
 
-	if err = state.createRuntime(rt, sigRt); err != nil {
+	if err = state.CreateRuntime(rt, sigRt); err != nil {
 		app.logger.Error("RegisterRuntime: failed to create runtime",
 			"err", err,
 			"runtime", rt,

--- a/go/tendermint/apps/registry/registry.go
+++ b/go/tendermint/apps/registry/registry.go
@@ -59,10 +59,6 @@ func (app *registryApplication) SetOption(request types.RequestSetOption) types.
 	return types.ResponseSetOption{}
 }
 
-func (app *registryApplication) GetState(height int64) (interface{}, error) {
-	return newImmutableState(app.state, height)
-}
-
 func (app *registryApplication) BeginBlock(ctx *abci.Context, request types.RequestBeginBlock) error {
 	// XXX: With PR#1889 this can be a differnet interval.
 	if changed, registryEpoch := app.state.EpochChanged(app.timeSource); changed {

--- a/go/tendermint/apps/roothash/query.go
+++ b/go/tendermint/apps/roothash/query.go
@@ -6,6 +6,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
+	roothashState "github.com/oasislabs/oasis-core/go/tendermint/apps/roothash/state"
 )
 
 // Query is the roothash query interface.
@@ -22,7 +23,7 @@ type QueryFactory struct {
 
 // QueryAt returns the roothash query interface for a specific height.
 func (sf *QueryFactory) QueryAt(height int64) (Query, error) {
-	state, err := newImmutableState(sf.app.state, height)
+	state, err := roothashState.NewImmutableState(sf.app.state, height)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +31,11 @@ func (sf *QueryFactory) QueryAt(height int64) (Query, error) {
 }
 
 type rootHashQuerier struct {
-	state *immutableState
+	state *roothashState.ImmutableState
 }
 
 func (rq *rootHashQuerier) LatestBlock(ctx context.Context, id signature.PublicKey) (*block.Block, error) {
-	runtime, err := rq.state.getRuntimeState(id)
+	runtime, err := rq.state.RuntimeState(id)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +47,7 @@ func (rq *rootHashQuerier) LatestBlock(ctx context.Context, id signature.PublicK
 }
 
 func (rq *rootHashQuerier) GenesisBlock(ctx context.Context, id signature.PublicKey) (*block.Block, error) {
-	runtime, err := rq.state.getRuntimeState(id)
+	runtime, err := rq.state.RuntimeState(id)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +59,7 @@ func (rq *rootHashQuerier) GenesisBlock(ctx context.Context, id signature.Public
 }
 
 func (rq *rootHashQuerier) Genesis(ctx context.Context) (*roothash.Genesis, error) {
-	runtimes := rq.state.getRuntimes()
+	runtimes := rq.state.Runtimes()
 
 	// Get per-runtime blocks.
 	blocks := make(map[signature.MapKey]*block.Block)

--- a/go/tendermint/apps/roothash/roothash.go
+++ b/go/tendermint/apps/roothash/roothash.go
@@ -26,8 +26,12 @@ import (
 	"github.com/oasislabs/oasis-core/go/tendermint/abci"
 	tmapi "github.com/oasislabs/oasis-core/go/tendermint/api"
 	registryapp "github.com/oasislabs/oasis-core/go/tendermint/apps/registry"
+	registryState "github.com/oasislabs/oasis-core/go/tendermint/apps/registry/state"
+	roothashState "github.com/oasislabs/oasis-core/go/tendermint/apps/roothash/state"
 	schedulerapp "github.com/oasislabs/oasis-core/go/tendermint/apps/scheduler"
+	schedulerState "github.com/oasislabs/oasis-core/go/tendermint/apps/scheduler/state"
 	stakingapp "github.com/oasislabs/oasis-core/go/tendermint/apps/staking"
+	stakingState "github.com/oasislabs/oasis-core/go/tendermint/apps/staking/state"
 )
 
 // timerKindRound is the round timer kind.
@@ -101,8 +105,8 @@ func (app *rootHashApplication) InitChain(ctx *abci.Context, request types.Reque
 	// Note: This could use the genesis state, but the registry has already
 	// carved out it's entries by this point.
 
-	regState := registryapp.NewMutableState(ctx.State())
-	runtimes, _ := regState.GetRuntimes()
+	regState := registryState.NewMutableState(ctx.State())
+	runtimes, _ := regState.Runtimes()
 	for _, v := range runtimes {
 		app.logger.Info("InitChain: allocating per-runtime state",
 			"runtime", v.ID,
@@ -122,11 +126,11 @@ func (app *rootHashApplication) BeginBlock(ctx *abci.Context, request types.Requ
 }
 
 func (app *rootHashApplication) onEpochChange(ctx *abci.Context, epoch epochtime.EpochTime) error { // nolint: gocyclo
-	state := newMutableState(ctx.State())
+	state := roothashState.NewMutableState(ctx.State())
 
 	// Query the updated runtime list.
-	regState := registryapp.NewMutableState(ctx.State())
-	runtimes, _ := regState.GetRuntimes()
+	regState := registryState.NewMutableState(ctx.State())
+	runtimes, _ := regState.Runtimes()
 	newDescriptors := make(map[signature.MapKey]*registry.Runtime)
 	for _, v := range runtimes {
 		if v.Kind == registry.KindCompute {
@@ -134,8 +138,8 @@ func (app *rootHashApplication) onEpochChange(ctx *abci.Context, epoch epochtime
 		}
 	}
 
-	schedState := schedulerapp.NewMutableState(ctx.State())
-	for _, rtState := range state.getRuntimes() {
+	schedState := schedulerState.NewMutableState(ctx.State())
+	for _, rtState := range state.Runtimes() {
 		rtID := rtState.Runtime.ID
 
 		if !rtState.Runtime.IsCompute() {
@@ -146,7 +150,7 @@ func (app *rootHashApplication) onEpochChange(ctx *abci.Context, epoch epochtime
 		}
 
 		// There will later be multiple compute committees.
-		computeCommittee, err := schedState.GetCommittee(scheduler.KindCompute, rtID)
+		computeCommittee, err := schedState.Committee(scheduler.KindCompute, rtID)
 		if err != nil {
 			app.logger.Error("checkCommittees: failed to get compute committee from scheduler",
 				"err", err,
@@ -163,7 +167,7 @@ func (app *rootHashApplication) onEpochChange(ctx *abci.Context, epoch epochtime
 		computeNodeInfo := make(map[signature.MapKey]commitment.NodeInfo)
 		for idx, n := range computeCommittee.Members {
 			var nodeRuntime *node.Runtime
-			node, err1 := regState.GetNode(n.PublicKey)
+			node, err1 := regState.Node(n.PublicKey)
 			if err1 != nil {
 				return errors.Wrap(err1, "checkCommittees: failed to query node")
 			}
@@ -197,7 +201,7 @@ func (app *rootHashApplication) onEpochChange(ctx *abci.Context, epoch epochtime
 			},
 		}
 
-		mergeCommittee, err := schedState.GetCommittee(scheduler.KindMerge, rtID)
+		mergeCommittee, err := schedState.Committee(scheduler.KindMerge, rtID)
 		if err != nil {
 			app.logger.Error("checkCommittees: failed to get merge committee from scheduler",
 				"err", err,
@@ -248,7 +252,7 @@ func (app *rootHashApplication) onEpochChange(ctx *abci.Context, epoch epochtime
 		)
 
 		rtState.Timer.Stop(ctx)
-		rtState.Round = newRound(computePool, mergePool, blk)
+		rtState.Round = roothashState.NewRound(computePool, mergePool, blk)
 
 		// Emit an empty epoch transition block in the new round. This is required so that
 		// the clients can be sure what state is final when an epoch transition occurs.
@@ -261,13 +265,13 @@ func (app *rootHashApplication) onEpochChange(ctx *abci.Context, epoch epochtime
 			delete(newDescriptors, mk)
 		}
 
-		state.updateRuntimeState(rtState)
+		state.SetRuntimeState(rtState)
 	}
 
 	// Just because a runtime didn't have committees, it doesn't mean that
 	// it's state does not need to be updated. Do so now where possible.
 	for _, v := range newDescriptors {
-		rtState, err := state.getRuntimeState(v.ID)
+		rtState, err := state.RuntimeState(v.ID)
 		if err != nil {
 			app.logger.Warn("onEpochChange: unknown runtime in update pass",
 				"runtime", v,
@@ -276,13 +280,13 @@ func (app *rootHashApplication) onEpochChange(ctx *abci.Context, epoch epochtime
 		}
 
 		rtState.Runtime = v
-		state.updateRuntimeState(rtState)
+		state.SetRuntimeState(rtState)
 	}
 
 	return nil
 }
 
-func (app *rootHashApplication) emitEmptyBlock(ctx *abci.Context, runtime *runtimeState, hdrType block.HeaderType) {
+func (app *rootHashApplication) emitEmptyBlock(ctx *abci.Context, runtime *roothashState.RuntimeState, hdrType block.HeaderType) {
 	blk := block.NewEmptyBlock(runtime.CurrentBlock, uint64(ctx.Now().Unix()), hdrType)
 
 	runtime.Timer.Stop(ctx)
@@ -304,7 +308,7 @@ func (app *rootHashApplication) ExecuteTx(ctx *abci.Context, rawTx []byte) error
 		return errors.Wrap(err, "roothash: failed to unmarshal")
 	}
 
-	state := newMutableState(ctx.State())
+	state := roothashState.NewMutableState(ctx.State())
 
 	if tx.TxMergeCommit != nil {
 		return app.commit(ctx, state, tx.TxMergeCommit.ID, &tx)
@@ -349,7 +353,7 @@ func (app *rootHashApplication) ForeignExecuteTx(ctx *abci.Context, other abci.A
 }
 
 func (app *rootHashApplication) onNewRuntime(ctx *abci.Context, runtime *registry.Runtime, genesis *roothash.Genesis) {
-	state := newMutableState(ctx.State())
+	state := roothashState.NewMutableState(ctx.State())
 
 	if !runtime.IsCompute() {
 		app.logger.Warn("onNewRuntime: ignoring non-compute runtime",
@@ -359,7 +363,7 @@ func (app *rootHashApplication) onNewRuntime(ctx *abci.Context, runtime *registr
 	}
 
 	// Check if state already exists for the given runtime.
-	rtState, _ := state.getRuntimeState(runtime.ID)
+	rtState, _ := state.RuntimeState(runtime.ID)
 	if rtState != nil {
 		// Do not propagate the error as this would fail the transaction.
 		app.logger.Warn("onNewRuntime: state for runtime already exists",
@@ -380,7 +384,7 @@ func (app *rootHashApplication) onNewRuntime(ctx *abci.Context, runtime *registr
 
 	// Create new state containing the genesis block.
 	timerCtx := &timerContext{ID: runtime.ID}
-	state.updateRuntimeState(&runtimeState{
+	state.SetRuntimeState(&roothashState.RuntimeState{
 		Runtime:      runtime,
 		CurrentBlock: genesisBlock,
 		GenesisBlock: genesisBlock,
@@ -418,8 +422,8 @@ func (app *rootHashApplication) FireTimer(ctx *abci.Context, timer *abci.Timer) 
 		logging.LogEvent, roothash.LogEventTimerFired,
 	)
 
-	state := newMutableState(ctx.State())
-	rtState, err := state.getRuntimeState(tCtx.ID)
+	state := roothashState.NewMutableState(ctx.State())
+	rtState, err := state.RuntimeState(tCtx.ID)
 	if err != nil {
 		app.logger.Error("FireTimer: failed to get state associated with timer",
 			"err", err,
@@ -447,7 +451,7 @@ func (app *rootHashApplication) FireTimer(ctx *abci.Context, timer *abci.Timer) 
 		"timer_round", tCtx.Round,
 	)
 
-	defer state.updateRuntimeState(rtState)
+	defer state.SetRuntimeState(rtState)
 
 	if rtState.Round.MergePool.IsTimeout(ctx.Now()) {
 		if err := app.tryFinalizeBlock(ctx, runtime, rtState, true); err != nil {
@@ -466,7 +470,7 @@ func (app *rootHashApplication) FireTimer(ctx *abci.Context, timer *abci.Timer) 
 
 type roothashSignatureVerifier struct {
 	runtimeID signature.PublicKey
-	scheduler *schedulerapp.MutableState
+	scheduler *schedulerState.MutableState
 }
 
 // VerifyCommitteeSignatures verifies that the given signatures come from
@@ -478,7 +482,7 @@ func (sv *roothashSignatureVerifier) VerifyCommitteeSignatures(kind scheduler.Co
 		return nil
 	}
 
-	committee, err := sv.scheduler.GetCommittee(kind, sv.runtimeID)
+	committee, err := sv.scheduler.Committee(kind, sv.runtimeID)
 	if err != nil {
 		return err
 	}
@@ -502,13 +506,13 @@ func (sv *roothashSignatureVerifier) VerifyCommitteeSignatures(kind scheduler.Co
 
 func (app *rootHashApplication) commit(
 	ctx *abci.Context,
-	state *mutableState,
+	state *roothashState.MutableState,
 	id signature.PublicKey,
 	tx *Tx,
 ) error {
 	logger := app.logger.With("is_check_only", ctx.IsCheckOnly())
 
-	rtState, err := state.getRuntimeState(id)
+	rtState, err := state.RuntimeState(id)
 	if err != nil {
 		return errors.Wrap(err, "roothash: failed to fetch runtime state")
 	}
@@ -525,7 +529,7 @@ func (app *rootHashApplication) commit(
 	latestBlock := rtState.CurrentBlock
 	blockNr := latestBlock.Header.Round
 
-	defer state.updateRuntimeState(rtState)
+	defer state.SetRuntimeState(rtState)
 
 	// If the round was finalized, transition.
 	if rtState.Round.CurrentBlock.Header.Round != latestBlock.Header.Round {
@@ -533,20 +537,20 @@ func (app *rootHashApplication) commit(
 			"round", blockNr,
 		)
 
-		rtState.Round.transition(latestBlock)
+		rtState.Round.Transition(latestBlock)
 	}
 
 	// Create storage signature verifier.
 	sv := &roothashSignatureVerifier{
 		runtimeID: id,
-		scheduler: schedulerapp.NewMutableState(ctx.State()),
+		scheduler: schedulerState.NewMutableState(ctx.State()),
 	}
 
 	// Add the commitments.
 	switch {
 	case tx.TxMergeCommit != nil:
 		for _, commit := range tx.TxMergeCommit.Commits {
-			if err = rtState.Round.addMergeCommitment(&commit, sv); err != nil {
+			if err = rtState.Round.AddMergeCommitment(&commit, sv); err != nil {
 				logger.Error("failed to add merge commitment to round",
 					"err", err,
 					"round", blockNr,
@@ -568,7 +572,7 @@ func (app *rootHashApplication) commit(
 		pools := make(map[*commitment.Pool]bool)
 		for _, commit := range tx.TxComputeCommit.Commits {
 			var pool *commitment.Pool
-			if pool, err = rtState.Round.addComputeCommitment(&commit, sv); err != nil {
+			if pool, err = rtState.Round.AddComputeCommitment(&commit, sv); err != nil {
 				logger.Error("failed to add compute commitment to round",
 					"err", err,
 					"round", blockNr,
@@ -595,7 +599,7 @@ func (app *rootHashApplication) commit(
 func (app *rootHashApplication) updateTimer(
 	ctx *abci.Context,
 	runtime *registry.Runtime,
-	rtState *runtimeState,
+	rtState *roothashState.RuntimeState,
 	blockNr uint64,
 ) {
 	// Do not re-arm the timer if the round has already changed.
@@ -603,7 +607,7 @@ func (app *rootHashApplication) updateTimer(
 		return
 	}
 
-	nextTimeout := rtState.Round.getNextTimeout()
+	nextTimeout := rtState.Round.GetNextTimeout()
 	if nextTimeout.IsZero() {
 		// Disarm timer.
 		app.logger.Debug("disarming round timeout")
@@ -623,7 +627,7 @@ func (app *rootHashApplication) updateTimer(
 func (app *rootHashApplication) tryFinalizeCompute(
 	ctx *abci.Context,
 	runtime *registry.Runtime,
-	rtState *runtimeState,
+	rtState *roothashState.RuntimeState,
 	pool *commitment.Pool,
 	forced bool,
 ) {
@@ -700,7 +704,7 @@ func (app *rootHashApplication) tryFinalizeCompute(
 func (app *rootHashApplication) tryFinalizeMerge(
 	ctx *abci.Context,
 	runtime *registry.Runtime,
-	rtState *runtimeState,
+	rtState *roothashState.RuntimeState,
 	forced bool,
 ) *block.Block {
 	latestBlock := rtState.CurrentBlock
@@ -768,13 +772,13 @@ func (app *rootHashApplication) tryFinalizeMerge(
 	return nil
 }
 
-func (app *rootHashApplication) postProcessFinalizedBlock(ctx *abci.Context, rtState *runtimeState, blk *block.Block) error {
+func (app *rootHashApplication) postProcessFinalizedBlock(ctx *abci.Context, rtState *roothashState.RuntimeState, blk *block.Block) error {
 	checkpoint := ctx.NewStateCheckpoint()
 	defer checkpoint.Close()
 
 	for _, message := range blk.Header.RoothashMessages {
 		// Check with staking.
-		stakingState := stakingapp.NewMutableState(ctx.State())
+		stakingState := stakingState.NewMutableState(ctx.State())
 		unsat, err := stakingState.HandleRoothashMessage(rtState.Runtime.ID, message)
 		if err != nil {
 			return err
@@ -812,7 +816,7 @@ func (app *rootHashApplication) postProcessFinalizedBlock(ctx *abci.Context, rtS
 func (app *rootHashApplication) tryFinalizeBlock(
 	ctx *abci.Context,
 	runtime *registry.Runtime,
-	rtState *runtimeState,
+	rtState *roothashState.RuntimeState,
 	mergeForced bool,
 ) error {
 	finalizedBlock := app.tryFinalizeMerge(ctx, runtime, rtState, mergeForced)

--- a/go/tendermint/apps/roothash/roothash.go
+++ b/go/tendermint/apps/roothash/roothash.go
@@ -91,10 +91,6 @@ func (app *rootHashApplication) SetOption(request types.RequestSetOption) types.
 	return types.ResponseSetOption{}
 }
 
-func (app *rootHashApplication) GetState(height int64) (interface{}, error) {
-	return newImmutableState(app.state, height)
-}
-
 func (app *rootHashApplication) InitChain(ctx *abci.Context, request types.RequestInitChain, doc *genesis.Document) error {
 	st := doc.RootHash
 

--- a/go/tendermint/apps/roothash/state/round.go
+++ b/go/tendermint/apps/roothash/state/round.go
@@ -1,4 +1,4 @@
-package roothash
+package state
 
 import (
 	"errors"
@@ -10,11 +10,12 @@ import (
 )
 
 var (
-	_ cbor.Marshaler   = (*round)(nil)
-	_ cbor.Unmarshaler = (*round)(nil)
+	_ cbor.Marshaler   = (*Round)(nil)
+	_ cbor.Unmarshaler = (*Round)(nil)
 )
 
-type round struct {
+// Round is a roothash round.
+type Round struct {
 	ComputePool *commitment.MultiPool `json:"compute_pool"`
 	MergePool   *commitment.Pool      `json:"merge_pool"`
 
@@ -22,13 +23,13 @@ type round struct {
 	Finalized    bool         `json:"finalized"`
 }
 
-func (r *round) reset() {
+func (r *Round) Reset() {
 	r.ComputePool.ResetCommitments()
 	r.MergePool.ResetCommitments()
 	r.Finalized = false
 }
 
-func (r *round) getNextTimeout() (timeout time.Time) {
+func (r *Round) GetNextTimeout() (timeout time.Time) {
 	timeout = r.ComputePool.GetNextTimeout()
 	if timeout.IsZero() || (!r.MergePool.NextTimeout.IsZero() && r.MergePool.NextTimeout.Before(timeout)) {
 		timeout = r.MergePool.NextTimeout
@@ -36,46 +37,46 @@ func (r *round) getNextTimeout() (timeout time.Time) {
 	return
 }
 
-func (r *round) addComputeCommitment(commitment *commitment.ComputeCommitment, sv commitment.SignatureVerifier) (*commitment.Pool, error) {
+func (r *Round) AddComputeCommitment(commitment *commitment.ComputeCommitment, sv commitment.SignatureVerifier) (*commitment.Pool, error) {
 	if r.Finalized {
 		return nil, errors.New("tendermint/roothash: round is already finalized, can't commit")
 	}
 	return r.ComputePool.AddComputeCommitment(r.CurrentBlock, sv, commitment)
 }
 
-func (r *round) addMergeCommitment(commitment *commitment.MergeCommitment, sv commitment.SignatureVerifier) error {
+func (r *Round) AddMergeCommitment(commitment *commitment.MergeCommitment, sv commitment.SignatureVerifier) error {
 	if r.Finalized {
 		return errors.New("tendermint/roothash: round is already finalized, can't commit")
 	}
 	return r.MergePool.AddMergeCommitment(r.CurrentBlock, sv, commitment, r.ComputePool)
 }
 
-func (r *round) transition(blk *block.Block) {
+func (r *Round) Transition(blk *block.Block) {
 	r.CurrentBlock = blk
-	r.reset()
+	r.Reset()
 }
 
 // MarshalCBOR serializes the type into a CBOR byte vector.
-func (r *round) MarshalCBOR() []byte {
+func (r *Round) MarshalCBOR() []byte {
 	return cbor.Marshal(r)
 }
 
 // UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (r *round) UnmarshalCBOR(data []byte) error {
+func (r *Round) UnmarshalCBOR(data []byte) error {
 	return cbor.Unmarshal(data, r)
 }
 
-func newRound(
+func NewRound(
 	computePool *commitment.MultiPool,
 	mergePool *commitment.Pool,
 	blk *block.Block,
-) *round {
-	r := &round{
+) *Round {
+	r := &Round{
 		CurrentBlock: blk,
 		ComputePool:  computePool,
 		MergePool:    mergePool,
 	}
-	r.reset()
+	r.Reset()
 
 	return r
 }

--- a/go/tendermint/apps/scheduler/query.go
+++ b/go/tendermint/apps/scheduler/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	scheduler "github.com/oasislabs/oasis-core/go/scheduler/api"
+	schedulerState "github.com/oasislabs/oasis-core/go/tendermint/apps/scheduler/state"
 )
 
 // Query is the scheduler query interface.
@@ -19,7 +20,7 @@ type QueryFactory struct {
 
 // QueryAt returns the scheduler query interface for a specific height.
 func (sf *QueryFactory) QueryAt(height int64) (Query, error) {
-	state, err := newImmutableState(sf.app.state, height)
+	state, err := schedulerState.NewImmutableState(sf.app.state, height)
 	if err != nil {
 		return nil, err
 	}
@@ -27,15 +28,15 @@ func (sf *QueryFactory) QueryAt(height int64) (Query, error) {
 }
 
 type schedulerQuerier struct {
-	state *immutableState
+	state *schedulerState.ImmutableState
 }
 
 func (sq *schedulerQuerier) AllCommittees(ctx context.Context) ([]*scheduler.Committee, error) {
-	return sq.state.getAllCommittees()
+	return sq.state.AllCommittees()
 }
 
 func (sq *schedulerQuerier) KindsCommittees(ctx context.Context, kinds []scheduler.CommitteeKind) ([]*scheduler.Committee, error) {
-	return sq.state.getKindsCommittees(kinds)
+	return sq.state.KindsCommittees(kinds)
 }
 
 func (app *schedulerApplication) QueryFactory() interface{} {

--- a/go/tendermint/apps/scheduler/scheduler.go
+++ b/go/tendermint/apps/scheduler/scheduler.go
@@ -118,10 +118,6 @@ func (app *schedulerApplication) Dependencies() []string {
 	return []string{beaconapp.AppName, registryapp.AppName, stakingapp.AppName}
 }
 
-func (app *schedulerApplication) GetState(height int64) (interface{}, error) {
-	return newImmutableState(app.state, height)
-}
-
 func (app *schedulerApplication) OnRegister(state *abci.ApplicationState) {
 	app.state = state
 }

--- a/go/tendermint/apps/scheduler/scheduler.go
+++ b/go/tendermint/apps/scheduler/scheduler.go
@@ -25,8 +25,12 @@ import (
 	"github.com/oasislabs/oasis-core/go/tendermint/abci"
 	"github.com/oasislabs/oasis-core/go/tendermint/api"
 	beaconapp "github.com/oasislabs/oasis-core/go/tendermint/apps/beacon"
+	beaconState "github.com/oasislabs/oasis-core/go/tendermint/apps/beacon/state"
 	registryapp "github.com/oasislabs/oasis-core/go/tendermint/apps/registry"
+	registryState "github.com/oasislabs/oasis-core/go/tendermint/apps/registry/state"
+	schedulerState "github.com/oasislabs/oasis-core/go/tendermint/apps/scheduler/state"
 	stakingapp "github.com/oasislabs/oasis-core/go/tendermint/apps/staking"
+	stakingState "github.com/oasislabs/oasis-core/go/tendermint/apps/staking/state"
 )
 
 var (
@@ -42,7 +46,7 @@ var (
 )
 
 type stakeAccumulator struct {
-	stakeCache     *stakingapp.StakeCache
+	stakeCache     *stakingState.StakeCache
 	perEntityStake map[signature.MapKey][]staking.ThresholdKind
 
 	unsafeBypass bool
@@ -79,7 +83,7 @@ func (acc *stakeAccumulator) checkThreshold(id signature.PublicKey, kind staking
 }
 
 func newStakeAccumulator(ctx *abci.Context, unsafeBypass bool) (*stakeAccumulator, error) {
-	stakeCache, err := stakingapp.NewStakeCache(ctx)
+	stakeCache, err := stakingState.NewStakeCache(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -134,8 +138,8 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 		return nil
 	}
 
-	regState := registryapp.NewMutableState(app.state.DeliverTxTree())
-	nodes, err := regState.GetNodes()
+	regState := registryState.NewMutableState(ctx.State())
+	nodes, err := regState.Nodes()
 	if err != nil {
 		return errors.Wrap(err, "tendermint/scheduler: couldn't get nodes")
 	}
@@ -198,8 +202,8 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 	// Sort of stupid it needs to be done this way, but tendermint doesn't
 	// appear to pass ABCI the validator set anywhere other than InitChain.
 
-	state := NewMutableState(app.state.DeliverTxTree())
-	state.putCurrentValidators(currentValidators)
+	state := schedulerState.NewMutableState(ctx.State())
+	state.PutCurrentValidators(currentValidators)
 
 	return nil
 }
@@ -216,18 +220,18 @@ func (app *schedulerApplication) BeginBlock(ctx *abci.Context, request types.Req
 			return nil
 		}
 
-		beaconState := beaconapp.NewMutableState(app.state.DeliverTxTree())
-		beacon, err := beaconState.GetBeacon()
+		beacState := beaconState.NewMutableState(ctx.State())
+		beacon, err := beacState.Beacon()
 		if err != nil {
 			return errors.Wrap(err, "tendermint/scheduler: couldn't get beacon")
 		}
 
-		regState := registryapp.NewMutableState(app.state.DeliverTxTree())
-		runtimes, err := regState.GetRuntimes()
+		regState := registryState.NewMutableState(ctx.State())
+		runtimes, err := regState.Runtimes()
 		if err != nil {
 			return errors.Wrap(err, "tendermint/scheduler: couldn't get runtimes")
 		}
-		nodes, err := regState.GetNodes()
+		nodes, err := regState.Nodes()
 		if err != nil {
 			return errors.Wrap(err, "tendermint/scheduler: couldn't get nodes")
 		}
@@ -284,8 +288,8 @@ func (app *schedulerApplication) ForeignExecuteTx(ctx *abci.Context, other abci.
 func (app *schedulerApplication) EndBlock(ctx *abci.Context, req types.RequestEndBlock) (types.ResponseEndBlock, error) {
 	var resp types.ResponseEndBlock
 
-	state := NewMutableState(app.state.DeliverTxTree())
-	pendingValidators, err := state.getPendingValidators()
+	state := schedulerState.NewMutableState(ctx.State())
+	pendingValidators, err := state.PendingValidators()
 	if err != nil {
 		return resp, errors.Wrap(err, "scheduler/tendermint: failed to query pending validators")
 	}
@@ -294,13 +298,13 @@ func (app *schedulerApplication) EndBlock(ctx *abci.Context, req types.RequestEn
 		return resp, nil
 	}
 
-	currentValidators, err := state.getCurrentValidators()
+	currentValidators, err := state.CurrentValidators()
 	if err != nil {
 		return resp, errors.Wrap(err, "scheduler/tendermint: failed to query current validators")
 	}
 
 	// Clear out the pending validator update.
-	state.putPendingValidators(nil)
+	state.PutPendingValidators(nil)
 
 	// Tendermint expects a vector of ValidatorUpdate that expresses
 	// the difference between the current validator set (tracked manually
@@ -355,7 +359,7 @@ func (app *schedulerApplication) EndBlock(ctx *abci.Context, req types.RequestEn
 	resp.ValidatorUpdates = updates
 
 	// Stash the updated validator set.
-	state.putCurrentValidators(pendingValidators)
+	state.PutCurrentValidators(pendingValidators)
 
 	return resp, nil
 }
@@ -495,7 +499,7 @@ func (app *schedulerApplication) electCommittee(ctx *abci.Context, request types
 			"kind", kind,
 			"runtime_id", rt.ID,
 		)
-		NewMutableState(app.state.DeliverTxTree()).dropCommittee(kind, rt.ID)
+		schedulerState.NewMutableState(ctx.State()).DropCommittee(kind, rt.ID)
 		return nil
 	}
 
@@ -508,7 +512,7 @@ func (app *schedulerApplication) electCommittee(ctx *abci.Context, request types
 			"backup_size", backupSize,
 			"nr_nodes", nrNodes,
 		)
-		NewMutableState(app.state.DeliverTxTree()).dropCommittee(kind, rt.ID)
+		schedulerState.NewMutableState(ctx.State()).DropCommittee(kind, rt.ID)
 		return nil
 	}
 
@@ -552,11 +556,11 @@ func (app *schedulerApplication) electCommittee(ctx *abci.Context, request types
 			"backup_size", backupSize,
 			"available", len(members),
 		)
-		NewMutableState(app.state.DeliverTxTree()).dropCommittee(kind, rt.ID)
+		schedulerState.NewMutableState(ctx.State()).DropCommittee(kind, rt.ID)
 		return nil
 	}
 
-	NewMutableState(app.state.DeliverTxTree()).putCommittee(&scheduler.Committee{
+	schedulerState.NewMutableState(ctx.State()).PutCommittee(&scheduler.Committee{
 		Kind:      kind,
 		RuntimeID: rt.ID,
 		Members:   members,
@@ -623,8 +627,8 @@ func (app *schedulerApplication) electValidators(ctx *abci.Context, beacon []byt
 
 	// Set the new pending validator set in the ABCI state.  It needs to be
 	// applied in EndBlock.
-	state := NewMutableState(app.state.DeliverTxTree())
-	state.putPendingValidators(newValidators)
+	state := schedulerState.NewMutableState(ctx.State())
+	state.PutPendingValidators(newValidators)
 
 	return nil
 }

--- a/go/tendermint/apps/staking/api.go
+++ b/go/tendermint/apps/staking/api.go
@@ -3,18 +3,19 @@ package staking
 import (
 	staking "github.com/oasislabs/oasis-core/go/staking/api"
 	"github.com/oasislabs/oasis-core/go/tendermint/api"
+	stakingState "github.com/oasislabs/oasis-core/go/tendermint/apps/staking/state"
 )
 
 const (
 	// TransactionTag is a unique byte used to identify transactions
 	// for the staking application.
 	TransactionTag byte = 0x05
-
-	// AppName is the ABCI application name.
-	AppName string = "100_staking"
 )
 
 var (
+	// AppName is the ABCI application name.
+	AppName = stakingState.AppName
+
 	//EventType is the ABCI event type for staking events.
 	EventType = api.EventTypeForApp(AppName)
 
@@ -24,7 +25,7 @@ var (
 
 	// KeyTakeEscrow is an ABCI event attribute key for TakeEscrow calls
 	// (value is an app.TakeEscrowEvent).
-	KeyTakeEscrow = []byte("take_escrow")
+	KeyTakeEscrow = stakingState.KeyTakeEscrow
 
 	// KeyReclaimEscrow is an ABCI event attribute key for ReclaimEscrow
 	// calls (value is an app.ReclaimEscrowEvent).
@@ -32,7 +33,7 @@ var (
 
 	// KeyTransfer is an ABCI event attribute key for Transfers (value is
 	// an app.TransferEvent).
-	KeyTransfer = []byte("transfer")
+	KeyTransfer = stakingState.KeyTransfer
 
 	// KeyBurn is an ABCI event attribute key for Burn calls (value is
 	// an app.BurnEvent).

--- a/go/tendermint/apps/staking/query.go
+++ b/go/tendermint/apps/staking/query.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	staking "github.com/oasislabs/oasis-core/go/staking/api"
+	stakingState "github.com/oasislabs/oasis-core/go/tendermint/apps/staking/state"
 )
 
 // ErrInvalidThreshold is the error returned when an invalid threshold kind
@@ -31,7 +32,7 @@ type QueryFactory struct {
 
 // QueryAt returns the staking query interface for a specific height.
 func (sf *QueryFactory) QueryAt(height int64) (Query, error) {
-	state, err := newImmutableState(sf.app.state, height)
+	state, err := stakingState.NewImmutableState(sf.app.state, height)
 	if err != nil {
 		return nil, err
 	}
@@ -39,11 +40,11 @@ func (sf *QueryFactory) QueryAt(height int64) (Query, error) {
 }
 
 type stakingQuerier struct {
-	state *immutableState
+	state *stakingState.ImmutableState
 }
 
 func (sq *stakingQuerier) TotalSupply(ctx context.Context) (*staking.Quantity, error) {
-	return sq.state.totalSupply()
+	return sq.state.TotalSupply()
 }
 
 func (sq *stakingQuerier) CommonPool(ctx context.Context) (*staking.Quantity, error) {
@@ -64,19 +65,19 @@ func (sq *stakingQuerier) Threshold(ctx context.Context, kind staking.ThresholdK
 }
 
 func (sq *stakingQuerier) DebondingInterval(ctx context.Context) (uint64, error) {
-	return sq.state.debondingInterval()
+	return sq.state.DebondingInterval()
 }
 
 func (sq *stakingQuerier) Accounts(ctx context.Context) ([]signature.PublicKey, error) {
-	return sq.state.accounts()
+	return sq.state.Accounts()
 }
 
 func (sq *stakingQuerier) AccountInfo(ctx context.Context, id signature.PublicKey) (*staking.Account, error) {
-	return sq.state.account(id), nil
+	return sq.state.Account(id), nil
 }
 
 func (sq *stakingQuerier) DebondingDelegations(ctx context.Context, id signature.PublicKey) (map[signature.MapKey][]*staking.DebondingDelegation, error) {
-	return sq.state.debondingDelegationsFor(id)
+	return sq.state.DebondingDelegationsFor(id)
 }
 
 func (app *stakingApplication) QueryFactory() interface{} {

--- a/go/tendermint/apps/staking/staking.go
+++ b/go/tendermint/apps/staking/staking.go
@@ -46,10 +46,6 @@ func (app *stakingApplication) Dependencies() []string {
 	return nil
 }
 
-func (app *stakingApplication) GetState(height int64) (interface{}, error) {
-	return newImmutableState(app.state, height)
-}
-
 func (app *stakingApplication) OnRegister(state *abci.ApplicationState) {
 	app.state = state
 }

--- a/go/tendermint/apps/staking/state/cache.go
+++ b/go/tendermint/apps/staking/state/cache.go
@@ -1,0 +1,75 @@
+package state
+
+import (
+	"fmt"
+
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	staking "github.com/oasislabs/oasis-core/go/staking/api"
+	"github.com/oasislabs/oasis-core/go/tendermint/abci"
+)
+
+// EnsureSufficientStake ensures that the account owned by id has sufficient
+// stake to meet the sum of the thresholds specified.  The thresholds vector
+// can have multiple instances of the same threshold kind specified, in which
+// case it will be factored in repeatedly.
+func EnsureSufficientStake(ctx *abci.Context, id signature.PublicKey, thresholds []staking.ThresholdKind) error {
+	sc, err := NewStakeCache(ctx)
+	if err != nil {
+		return err
+	}
+	return sc.EnsureSufficientStake(id, thresholds)
+}
+
+// StakeCache is a lookup cache for escrow balances and thresholds that
+// can be used in lieu of repeated queries to `EnsureSufficientStake` at a
+// given height.  This should be favored when repeated queries are going to
+// be made.
+type StakeCache struct {
+	ctx *abci.Context
+
+	thresholds map[staking.ThresholdKind]staking.Quantity
+	balances   map[signature.MapKey]*staking.Quantity
+}
+
+// EnsureSufficientStake ensures that the account owned by id has sufficient
+// stake to meet the sum of the thresholds specified.  The thresholds vector
+// can have multiple instances of the same threshold kind specified, in which
+// case it will be factored in repeatedly.
+func (sc *StakeCache) EnsureSufficientStake(id signature.PublicKey, thresholds []staking.ThresholdKind) error {
+	escrowBalance := sc.balances[id.ToMapKey()]
+	if escrowBalance == nil {
+		state := NewMutableState(sc.ctx.State())
+		escrowBalance = state.EscrowBalance(id)
+		sc.balances[id.ToMapKey()] = escrowBalance
+	}
+
+	var targetThreshold staking.Quantity
+	for _, v := range thresholds {
+		qty := sc.thresholds[v]
+		if err := targetThreshold.Add(&qty); err != nil {
+			return fmt.Errorf("staking/tendermint: failed to accumulate threshold: %w", err)
+		}
+	}
+
+	if escrowBalance.Cmp(&targetThreshold) < 0 {
+		return staking.ErrInsufficientStake
+	}
+
+	return nil
+}
+
+// NewStakeCache creates a new staking lookup cache.
+func NewStakeCache(ctx *abci.Context) (*StakeCache, error) {
+	state := NewMutableState(ctx.State())
+
+	thresholds, err := state.Thresholds()
+	if err != nil {
+		return nil, fmt.Errorf("staking/tendermint: failed to query thresholds: %w", err)
+	}
+
+	return &StakeCache{
+		ctx:        ctx,
+		thresholds: thresholds,
+		balances:   make(map[signature.MapKey]*staking.Quantity),
+	}, nil
+}


### PR DESCRIPTION
This makes it easier to use application state without import cycles.