### PR TITLE
split escrow between normal tokens and tokens undergoing debonding

### DIFF
--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -379,7 +379,7 @@ func AppendKeyManagerState(doc *genesis.Document, statuses []string, l *logging.
 	return nil
 }
 
-// AppendStakingState appens the staking gensis state given a state file name.
+// AppendStakingState appends the staking genesis state given a state file name.
 func AppendStakingState(doc *genesis.Document, state string, l *logging.Logger) error {
 	stakingSt := staking.Genesis{
 		Ledger: make(map[signature.MapKey]*staking.Account),
@@ -408,7 +408,7 @@ func AppendStakingState(doc *genesis.Document, state string, l *logging.Logger) 
 
 		ent, _, err := entity.TestEntity()
 		if err != nil {
-			l.Error("failed to retrive test entity",
+			l.Error("failed to retrieve test entity",
 				"err", err,
 			)
 			return err
@@ -429,7 +429,9 @@ func AppendStakingState(doc *genesis.Document, state string, l *logging.Logger) 
 				Nonce:   0,
 			},
 			Escrow: staking.EscrowAccount{
-				Balance: q,
+				Active: staking.SharePool{
+					Balance: q,
+				},
 			},
 		}
 

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -371,6 +371,8 @@ func (p *SharePool) sharesForTokens(amount *Quantity) (*Quantity, error) {
 	return q, nil
 }
 
+// Deposit moves tokens into the combined balance, raising the shares.
+// If an error occurs, the pool and affected accounts are left in an invalid state.
 func (p *SharePool) Deposit(shareDst, tokenSrc, tokenAmount *Quantity) error {
 	shares, err := p.sharesForTokens(tokenAmount)
 	if err != nil {
@@ -418,6 +420,8 @@ func (p *SharePool) tokensForShares(amount *Quantity) (*Quantity, error) {
 	return q, nil
 }
 
+// Withdraw moves tokens out of the combined balance, reducing the shares.
+// If an error occurs, the pool and affected accounts are left in an invalid state.
 func (p *SharePool) Withdraw(tokenDst, shareSrc, shareAmount *Quantity) error {
 	tokens, err := p.tokensForShares(shareAmount)
 	if err != nil {

--- a/go/staking/grpc.go
+++ b/go/staking/grpc.go
@@ -106,9 +106,17 @@ func (s *grpcServer) GetAccountInfo(ctx context.Context, req *pb.GetAccountInfoR
 		return nil, err
 	}
 
+	var escrowBalance api.Quantity
+	if err = escrowBalance.Add(&account.Escrow.Active.Balance); err != nil {
+		return nil, err
+	}
+	if err = escrowBalance.Add(&account.Escrow.Debonding.Balance); err != nil {
+		return nil, err
+	}
+
 	var resp pb.GetAccountInfoResponse
 	resp.GeneralBalance, _ = account.General.Balance.MarshalBinary()
-	resp.EscrowBalance, _ = account.Escrow.Balance.MarshalBinary()
+	resp.EscrowBalance, _ = escrowBalance.MarshalBinary()
 	resp.Nonce = account.General.Nonce
 
 	return &resp, nil

--- a/go/tendermint/apps/staking/staking.go
+++ b/go/tendermint/apps/staking/staking.go
@@ -112,48 +112,26 @@ func (app *stakingApplication) onEpochChange(ctx *abci.Context, epoch epochtime.
 			escrow = state.Account(e.EscrowID)
 		}
 
-		// Compute amount of debonded tokens.
-		tokens, err := staking.TokensForShares(&escrow.Escrow, &deb.Shares)
-		if err != nil {
-			app.logger.Error("failed to compute amount of tokens from shares",
+		var tokens staking.Quantity
+		if err := escrow.Escrow.Debonding.Withdraw(&tokens, &deb.Shares, &deb.Shares); err != nil {
+			app.logger.Error("failed to redeem debonding shares",
 				"err", err,
 				"escrow_id", e.EscrowID,
 				"delegator_id", e.DelegatorID,
 				"shares", deb.Shares,
 			)
-			return errors.Wrap(err, "staking/tendermint: failed to compute amount of tokens")
+			return errors.Wrap(err, "staking/tendermint: failed to redeem debonding shares")
 		}
-		// Update number of total shares.
-		if err := escrow.Escrow.TotalShares.Sub(&deb.Shares); err != nil {
-			app.logger.Error("failed to subtract total shares",
+		tokenAmount := tokens.Clone()
+
+		if err := staking.Move(&delegator.General.Balance, &tokens, &tokens); err != nil {
+			app.logger.Error("failed to move debonded tokens",
 				"err", err,
 				"escrow_id", e.EscrowID,
 				"delegator_id", e.DelegatorID,
 				"shares", deb.Shares,
-				"total_shares", escrow.Escrow.TotalShares,
 			)
-			return errors.Wrap(err, "staking/tendermint: failed to subtract total shares")
-		}
-		// Update number of debonding shares.
-		if err := escrow.Escrow.DebondingShares.Sub(&deb.Shares); err != nil {
-			app.logger.Error("failed to subtract debonding shares",
-				"err", err,
-				"escrow_id", e.EscrowID,
-				"delegator_id", e.DelegatorID,
-				"shares", deb.Shares,
-				"debonding_shares", escrow.Escrow.DebondingShares,
-			)
-			return errors.Wrap(err, "staking/tendermint: failed to subtract debonding shares")
-		}
-		// Transfer tokens from escrow account.
-		if err := staking.Move(&delegator.General.Balance, &escrow.Escrow.Balance, tokens); err != nil {
-			app.logger.Error("failed to move balance",
-				"err", err,
-				"escrow_id", e.EscrowID,
-				"delegator_id", e.DelegatorID,
-				"amount", tokens,
-			)
-			return errors.Wrap(err, "staking/tendermint: failed to move balance")
+			return errors.Wrap(err, "staking/tendermint: failed to redeem debonding shares")
 		}
 
 		// Update state.
@@ -167,13 +145,13 @@ func (app *stakingApplication) onEpochChange(ctx *abci.Context, epoch epochtime.
 		app.logger.Debug("released tokens",
 			"escrow_id", e.EscrowID,
 			"delegator_id", e.DelegatorID,
-			"amount", tokens,
+			"amount", tokenAmount,
 		)
 
 		evt := staking.ReclaimEscrowEvent{
 			Owner:  e.DelegatorID,
 			Escrow: e.EscrowID,
-			Tokens: *tokens,
+			Tokens: *tokenAmount,
 		}
 		ctx.EmitEvent(api.NewEventBuilder(app.Name()).Attribute(KeyReclaimEscrow, cbor.Marshal(evt)))
 	}
@@ -341,19 +319,7 @@ func (app *stakingApplication) addEscrow(ctx *abci.Context, state *stakingState.
 	// Fetch delegation.
 	delegation := state.Delegation(id, escrow.Account)
 
-	// Issue shares.
-	if _, err := staking.IssueShares(&to.Escrow, &escrow.Tokens, delegation); err != nil {
-		app.logger.Error("AddEscrow: failed to escrow tokens",
-			"err", err,
-			"from", id,
-			"to", escrow.Account,
-			"amount", escrow.Tokens,
-		)
-		return err
-	}
-
-	// Remove tokens from the delegator account and put them into escrow.
-	if err := staking.Move(&to.Escrow.Balance, &from.General.Balance, &escrow.Tokens); err != nil {
+	if err := to.Escrow.Active.Deposit(&delegation.Shares, &from.General.Balance, &escrow.Tokens); err != nil {
 		app.logger.Error("AddEscrow: failed to escrow tokens",
 			"err", err,
 			"from", id,
@@ -430,24 +396,6 @@ func (app *stakingApplication) reclaimEscrow(ctx *abci.Context, state *stakingSt
 	// Fetch delegation.
 	delegation := state.Delegation(id, reclaim.Account)
 
-	// Update delegated shares.
-	if err := delegation.Shares.Sub(&reclaim.Shares); err != nil {
-		app.logger.Error("ReclaimEscrow: not enough shares",
-			"to", id,
-			"from", reclaim.Account,
-			"shares", reclaim.Shares,
-			"delegation_shares", delegation.Shares,
-		)
-		return staking.ErrInsufficientBalance
-	}
-	// Update the amount of shares undergoing debonding.
-	if err := from.Escrow.DebondingShares.Add(&reclaim.Shares); err != nil {
-		app.logger.Error("ReclaimEscrow: failed to update debonding shares",
-			"err", err,
-		)
-		return err
-	}
-
 	// Fetch debonding interval and current epoch.
 	debondingInterval, err := state.DebondingInterval()
 	if err != nil {
@@ -462,9 +410,38 @@ func (app *stakingApplication) reclaimEscrow(ctx *abci.Context, state *stakingSt
 	}
 
 	deb := staking.DebondingDelegation{
-		Shares:        reclaim.Shares,
 		DebondEndTime: epoch + epochtime.EpochTime(debondingInterval),
 	}
+
+	var tokens staking.Quantity
+
+	if err := from.Escrow.Active.Withdraw(&tokens, &delegation.Shares, &reclaim.Shares); err != nil {
+		app.logger.Error("ReclaimEscrow: failed to redeem escrow shares",
+			"err", err,
+			"to", id,
+			"from", reclaim.Account,
+			"shares", reclaim.Shares,
+		)
+		return err
+	}
+
+	if err := from.Escrow.Debonding.Deposit(&deb.Shares, &tokens, &tokens); err != nil {
+		app.logger.Error("ReclaimEscrow: failed to debond shares",
+			"err", err,
+			"to", id,
+			"from", reclaim.Account,
+			"shares", reclaim.Shares,
+		)
+		return err
+	}
+
+	if !tokens.IsZero() {
+		app.logger.Error("ReclaimEscrow: inconsistency in transferring tokens from active escrow to debonding",
+			"remaining", tokens,
+		)
+		return staking.ErrInvalidArgument
+	}
+
 	// Include the nonce as the final disambiguator to prevent overwriting debonding
 	// delegations.
 	state.SetDebondingDelegation(id, reclaim.Account, to.General.Nonce, &deb)

--- a/go/tendermint/apps/staking/state/state.go
+++ b/go/tendermint/apps/staking/state/state.go
@@ -199,17 +199,7 @@ func (s *ImmutableState) Account(id signature.PublicKey) *staking.Account {
 func (s *ImmutableState) EscrowBalance(id signature.PublicKey) *staking.Quantity {
 	account := s.Account(id)
 
-	balance := account.Escrow.Balance.Clone()
-	// Subtract the amount currently undergoing debonding.
-	debonding, err := staking.TokensForShares(&account.Escrow, &account.Escrow.DebondingShares)
-	if err != nil {
-		panic("staking: failed to compute escrow balance: " + err.Error())
-	}
-	if err = balance.Sub(debonding); err != nil {
-		panic("staking: failed to compute escrow balance: " + err.Error())
-	}
-
-	return balance
+	return account.Escrow.Active.Balance.Clone()
 }
 
 func (s *ImmutableState) Delegations() (map[signature.MapKey]map[signature.MapKey]*staking.Delegation, error) {
@@ -433,39 +423,14 @@ func (s *MutableState) RemoveFromDebondingQueue(epoch epochtime.EpochTime, deleg
 	s.tree.Remove(debondingQueueKeyFmt.Encode(uint64(epoch), &delegatorID, &escrowID, seq))
 }
 
-// SlashEscrow slashes up to the amount from the escrow balance of the account,
+// SlashEscrow slashes the escrow balance and the escrow-but-undergoing-debonding balance of the account,
 // transfering it to the global common pool, returning true iff the amount
 // actually slashed is > 0.
 //
 // WARNING: This is an internal routine to be used to implement staking policy,
 // and MUST NOT be exposed outside of backend implementations.
 func (s *MutableState) SlashEscrow(ctx *abci.Context, fromID signature.PublicKey, amount *staking.Quantity) (bool, error) {
-	commonPool, err := s.CommonPool()
-	if err != nil {
-		return false, errors.Wrap(err, "staking: failed to query common pool for slash ")
-	}
-
-	from := s.Account(fromID)
-	slashed, err := staking.MoveUpTo(commonPool, &from.Escrow.Balance, amount)
-	if err != nil {
-		return false, errors.Wrap(err, "staking: failed to slash")
-	}
-
-	ret := !slashed.IsZero()
-	if ret {
-		s.SetCommonPool(commonPool)
-		s.SetAccount(fromID, from)
-
-		if !ctx.IsCheckOnly() {
-			ev := cbor.Marshal(&staking.TakeEscrowEvent{
-				Owner:  fromID,
-				Tokens: *slashed,
-			})
-			ctx.EmitEvent(api.NewEventBuilder(AppName).Attribute(KeyTakeEscrow, ev))
-		}
-	}
-
-	return ret, nil
+	return false, errors.New("SlashEscrow is not implemented")
 }
 
 // TransferFromCommon transfers up to the amount from the global common pool

--- a/go/tendermint/apps/staking/state/state.go
+++ b/go/tendermint/apps/staking/state/state.go
@@ -423,19 +423,75 @@ func (s *MutableState) RemoveFromDebondingQueue(epoch epochtime.EpochTime, deleg
 	s.tree.Remove(debondingQueueKeyFmt.Encode(uint64(epoch), &delegatorID, &escrowID, seq))
 }
 
+func slashPool(dst *staking.Quantity, p *staking.SharePool, keepNumerator, denominator *staking.Quantity) error {
+	slashAmount := p.Balance.Clone()
+	keepAmount := p.Balance.Clone()
+	if err := keepAmount.Mul(keepNumerator); err != nil {
+		return errors.Wrap(err, "keepAmount.Mul")
+	}
+	if err := keepAmount.Quo(denominator); err != nil {
+		return errors.Wrap(err, "keepAmount.Quo")
+	}
+	if err := slashAmount.Sub(keepAmount); err != nil {
+		return errors.Wrap(err, "slashAmount.Sub")
+	}
+
+	if err := staking.Move(dst, &p.Balance, slashAmount); err != nil {
+		return errors.Wrap(err, "moving tokens")
+	}
+
+	return nil
+}
+
 // SlashEscrow slashes the escrow balance and the escrow-but-undergoing-debonding balance of the account,
-// transfering it to the global common pool, returning true iff the amount
+// transferring it to the global common pool, returning true iff the amount
 // actually slashed is > 0.
 //
 // WARNING: This is an internal routine to be used to implement staking policy,
 // and MUST NOT be exposed outside of backend implementations.
-func (s *MutableState) SlashEscrow(ctx *abci.Context, fromID signature.PublicKey, amount *staking.Quantity) (bool, error) {
-	return false, errors.New("SlashEscrow is not implemented")
+func (s *MutableState) SlashEscrow(ctx *abci.Context, fromID signature.PublicKey, keepNumerator, denominator *staking.Quantity) (bool, error) {
+	commonPool, err := s.CommonPool()
+	if err != nil {
+		return false, errors.Wrap(err, "staking: failed to query common pool for slash ")
+	}
+
+	from := s.Account(fromID)
+
+	var slashed staking.Quantity
+	if err = slashPool(&slashed, &from.Escrow.Active, keepNumerator, denominator); err != nil {
+		return false, errors.Wrap(err, "slashing active escrow")
+	}
+	if err = slashPool(&slashed, &from.Escrow.Debonding, keepNumerator, denominator); err != nil {
+		return false, errors.Wrap(err, "slashing debonding escrow")
+	}
+
+	if slashed.IsZero() {
+		return false, nil
+	}
+
+	totalSlashed := slashed.Clone()
+
+	if err = staking.Move(commonPool, &slashed, totalSlashed); err != nil {
+		return false, errors.Wrap(err, "moving tokens to common pool")
+	}
+
+	s.SetCommonPool(commonPool)
+	s.SetAccount(fromID, from)
+
+	if !ctx.IsCheckOnly() {
+		ev := cbor.Marshal(&staking.TakeEscrowEvent{
+			Owner:  fromID,
+			Tokens: *totalSlashed,
+		})
+		ctx.EmitEvent(api.NewEventBuilder(AppName).Attribute(KeyTakeEscrow, ev))
+	}
+
+	return true, nil
 }
 
 // TransferFromCommon transfers up to the amount from the global common pool
 // to the general balance of the account, returning true iff the
-// amount transfered is > 0.
+// amount transferred is > 0.
 //
 // WARNING: This is an internal routine to be used to implement incentivization
 // policy, and MUST NOT be exposed outside of backend implementations.


### PR DESCRIPTION
We'll need this for rewards, so that we can increase the value of the escrow shares that aren't undergoing debonding.

blocks #2288

cc #2290, which also changes slashing to take a fraction. That PR uses a single shared denominator, which is fine.