### PR TITLE
Use the optimized ed25519 batch verify where applicable

### DIFF
--- a/go/common/crypto/signature/signature.go
+++ b/go/common/crypto/signature/signature.go
@@ -570,7 +570,7 @@ func VerifyBatch(context []byte, messages [][]byte, sigs []Signature) bool {
 		rawSigs = append(rawSigs, v.Signature[:])
 
 		// Sigh. :(
-		msg, err := PrepareSignerMessage(context, msgs[i])
+		msg, err := PrepareSignerMessage(context, messages[i])
 		if err != nil {
 			return false
 		}

--- a/go/tendermint/abci/mux.go
+++ b/go/tendermint/abci/mux.go
@@ -331,8 +331,12 @@ func (mux *abciMux) InitChain(req types.RequestInitChain) types.ResponseInitChai
 
 	// HACK: Can't emit tags from InitChain, stash the genesis state
 	// so that processing can happen in BeginBlock.
+	//
+	// This is also stashed in the CheckTx tree (even though it will get
+	// rolled back), so that it is usable from the genesisHooks.
 	b, _ = req.Marshal()
 	mux.state.deliverTxTree.Set([]byte(stateKeyGenesisRequest), b)
+	mux.state.checkTxTree.Set([]byte(stateKeyGenesisRequest), b)
 
 	resp := mux.BaseApplication.InitChain(req)
 


### PR DESCRIPTION
Not to be content with the ~2x perf increase we already have over using the runtime library's verify, we can do better since our ed25519 implementation has a Bos-Coster based batch verify.

 * [x] Add the required API(s).
 * [x] Use the new API(s) for better performance.
   * [x] Storage receipts.
   * [x] Merge commitments.

Fixes #1351.