### PR TITLE
Use a distinct Ed25519 key for all tendermint operations

### DIFF
--- a/go/common/consensus/consensus.go
+++ b/go/common/consensus/consensus.go
@@ -2,13 +2,19 @@
 // backend.
 package consensus
 
-import "github.com/oasislabs/oasis-core/go/common/node"
+import (
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common/node"
+)
 
 // Backend is an interface that a consensus backend must provide.
 type Backend interface {
 	// Synced returns a channel that is closed once synchronization is
 	// complete.
 	Synced() <-chan struct{}
+
+	// ConsensusKey returns the consensus signing key.
+	ConsensusKey() signature.PublicKey
 
 	// GetAddresses returns the consensus backend addresses.
 	GetAddresses() ([]node.Address, error)

--- a/go/common/crypto/signature/signer.go
+++ b/go/common/crypto/signature/signer.go
@@ -22,6 +22,10 @@ var (
 	// is misconfigured.
 	ErrRoleMismatch = errors.New("signature: signer factory role mismatch")
 
+	// ErrRoleAction is the error returned when the signer role mismatches
+	// the signing operations allowed by the role.
+	ErrRoleAction = errors.New("signature: signer role action mismatch")
+
 	errMalformedContext = errors.New("signature: malformed context")
 )
 
@@ -33,7 +37,17 @@ const (
 	SignerEntity
 	SignerNode
 	SignerP2P
+	SignerConsensus
 )
+
+// MustContextSign returns true iff the SignerRole must only accept ContextSign
+// operations.
+func (r SignerRole) MustContextSign() bool {
+	// Since we're stuck with PrepareSignerMessage instead of a sensible
+	// construct, ensure that only signers (aka keys) that are dedicated
+	// to consensus signing get to use vanilla Ed25519pure.
+	return r != SignerConsensus
+}
 
 // SignerFactoryCtor is an SignerFactory constructor.
 type SignerFactoryCtor func(string, ...SignerRole) SignerFactory

--- a/go/common/identity/identity.go
+++ b/go/common/identity/identity.go
@@ -18,6 +18,10 @@ const (
 	// P2PKeyPubFilename is the filename of the PEM encoded p2p public key.
 	P2PKeyPubFilename = "p2p_pub.pem"
 
+	// ConsensusKeyPubFilename is the filename of the PEM encoded consensus
+	// public key.
+	ConsensusKeyPubFilename = "consensus_pub.pem"
+
 	// CommonName is the CommonName to use when generating TLS certificates.
 	CommonName = "oasis-node"
 
@@ -31,6 +35,8 @@ type Identity struct {
 	NodeSigner signature.Signer
 	// P2PSigner is a node P2P link key signer.
 	P2PSigner signature.Signer
+	// ConsensusSigner is a node consensus key signer.
+	ConsensusSigner signature.Signer
 	// TLSKey is a private key used for TLS connections.
 	TLSKey *ecdsa.PrivateKey
 	// TLSCertificate is a certificate that can be used for TLS.
@@ -55,6 +61,7 @@ func doLoadOrGenerate(dataDir string, signerFactory signature.SignerFactory, sho
 	}{
 		{signature.SignerNode, NodeKeyPubFilename},
 		{signature.SignerP2P, P2PKeyPubFilename},
+		{signature.SignerConsensus, ConsensusKeyPubFilename},
 	} {
 		signer, err := signerFactory.Load(v.role)
 		switch err {
@@ -97,10 +104,11 @@ func doLoadOrGenerate(dataDir string, signerFactory signature.SignerFactory, sho
 	}
 
 	return &Identity{
-		NodeSigner:     signers[0],
-		P2PSigner:      signers[1],
-		TLSKey:         cert.PrivateKey.(*ecdsa.PrivateKey),
-		TLSCertificate: cert,
+		NodeSigner:      signers[0],
+		P2PSigner:       signers[1],
+		ConsensusSigner: signers[2],
+		TLSKey:          cert.PrivateKey.(*ecdsa.PrivateKey),
+		TLSCertificate:  cert,
 	}, nil
 }
 

--- a/go/common/identity/identity_test.go
+++ b/go/common/identity/identity_test.go
@@ -16,7 +16,7 @@ func TestLoadOrGenerate(t *testing.T) {
 	require.NoError(t, err, "create data dir")
 	defer os.RemoveAll(dataDir)
 
-	factory := fileSigner.NewFactory(dataDir, signature.SignerNode, signature.SignerP2P)
+	factory := fileSigner.NewFactory(dataDir, signature.SignerNode, signature.SignerP2P, signature.SignerConsensus)
 
 	// Generate a new identity.
 	identity, err := LoadOrGenerate(dataDir, factory)
@@ -27,6 +27,7 @@ func TestLoadOrGenerate(t *testing.T) {
 	require.NoError(t, err, "LoadOrGenerate (2)")
 	require.EqualValues(t, identity.NodeSigner, identity2.NodeSigner)
 	require.EqualValues(t, identity.P2PSigner, identity2.P2PSigner)
+	require.EqualValues(t, identity.ConsensusSigner, identity2.ConsensusSigner)
 	require.EqualValues(t, identity.TLSKey, identity2.TLSKey)
 	// TODO: Check that it always generates a fresh certificate once oasis-core#1541 is done.
 	require.EqualValues(t, identity.TLSCertificate, identity2.TLSCertificate)

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -266,17 +266,25 @@ func (info *P2PInfo) fromProto(pb *pbCommon.P2PInfo) error {
 // ConsensusInfo contains information for connectiong to this node as a
 // consensus member.
 type ConsensusInfo struct {
+	// ID is the unique identifier of the node as a consensus member.
+	ID signature.PublicKey `json:"id"`
+
 	// Addresses is the list of addresses at which the node can be reached.
 	Addresses []Address `json:"addresses"`
 }
 
 func (info *ConsensusInfo) toProto() *pbCommon.ConsensusInfo {
 	pb := new(pbCommon.ConsensusInfo)
+	pb.Id, _ = info.ID.MarshalBinary()
 	pb.Addresses = ToProtoAddresses(info.Addresses)
 	return pb
 }
 
 func (info *ConsensusInfo) fromProto(pb *pbCommon.ConsensusInfo) error {
+	if err := info.ID.UnmarshalBinary(pb.GetId()); err != nil {
+		return err
+	}
+
 	if pbAddresses := pb.GetAddresses(); pbAddresses != nil {
 		info.Addresses = make([]Address, 0, len(pbAddresses))
 		for _, v := range pbAddresses {

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -65,7 +65,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	BackendProtocol = Version{Major: 0, Minor: 10, Patch: 0}
+	BackendProtocol = Version{Major: 0, Minor: 11, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)

--- a/go/grpc/common/common.proto
+++ b/go/grpc/common/common.proto
@@ -45,7 +45,8 @@ message P2PInfo {
 }
 
 message ConsensusInfo {
-    repeated Address addresses = 1;
+    bytes id = 1;
+    repeated Address addresses = 2;
 }
 
 message NodeRuntime {

--- a/go/oasis-node/cmd/debug/byzantine/registry.go
+++ b/go/oasis-node/cmd/debug/byzantine/registry.go
@@ -33,7 +33,10 @@ func registryRegisterNode(svc service.TendermintService, id *identity.Identity, 
 			Certificate: id.TLSCertificate.Certificate[0],
 			Addresses:   committeeAddresses,
 		},
-		P2P:              p2pInfo,
+		P2P: p2pInfo,
+		Consensus: node.ConsensusInfo{
+			ID: id.ConsensusSigner.Public(),
+		},
 		RegistrationTime: uint64(time.Now().Unix()),
 		Runtimes: []*node.Runtime{
 			&node.Runtime{

--- a/go/oasis-node/cmd/debug/byzantine/steps.go
+++ b/go/oasis-node/cmd/debug/byzantine/steps.go
@@ -37,7 +37,7 @@ var (
 )
 
 func initDefaultIdentity(dataDir string) (*identity.Identity, error) {
-	signerFactory := fileSigner.NewFactory(dataDir, signature.SignerNode, signature.SignerP2P, signature.SignerEntity)
+	signerFactory := fileSigner.NewFactory(dataDir, signature.SignerNode, signature.SignerP2P, signature.SignerEntity, signature.SignerConsensus)
 	id, err := identity.LoadOrGenerate(dataDir, signerFactory)
 	if err != nil {
 		return nil, errors.Wrap(err, "identity LoadOrGenerate")

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -387,7 +387,7 @@ func NewNode() (*Node, error) {
 
 	// Generate/Load the node identity.
 	// TODO/hsm: Configure factory dynamically.
-	signerFactory := fileSigner.NewFactory(dataDir, signature.SignerNode, signature.SignerP2P, signature.SignerEntity)
+	signerFactory := fileSigner.NewFactory(dataDir, signature.SignerNode, signature.SignerP2P, signature.SignerConsensus)
 	node.Identity, err = identity.LoadOrGenerate(dataDir, signerFactory)
 	if err != nil {
 		logger.Error("failed to load/generate identity",

--- a/go/oasis-node/cmd/registry/node/node.go
+++ b/go/oasis-node/cmd/registry/node/node.go
@@ -139,7 +139,7 @@ func doInit(cmd *cobra.Command, args []string) {
 	}
 
 	// Provision the node identity.
-	nodeSignerFactory := fileSigner.NewFactory(dataDir, signature.SignerNode, signature.SignerP2P)
+	nodeSignerFactory := fileSigner.NewFactory(dataDir, signature.SignerNode, signature.SignerP2P, signature.SignerConsensus)
 	nodeIdentity, err := identity.LoadOrGenerate(dataDir, nodeSignerFactory)
 	if err != nil {
 		logger.Error("failed to load or generate node identity",
@@ -168,6 +168,9 @@ func doInit(cmd *cobra.Command, args []string) {
 		},
 		P2P: node.P2PInfo{
 			ID: nodeIdentity.P2PSigner.Public(),
+		},
+		Consensus: node.ConsensusInfo{
+			ID: nodeIdentity.ConsensusSigner.Public(),
 		},
 		RegistrationTime: uint64(time.Now().Unix()),
 	}

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -49,6 +49,11 @@ func (worker *Compute) P2PKeyPath() string {
 	return nodeP2PKeyPath(worker.dir)
 }
 
+// ConsensusKeyPath returns the path to the node's consensus key.
+func (worker *Compute) ConsensusKeyPath() string {
+	return nodeConsensusKeyPath(worker.dir)
+}
+
 // TLSKeyPath returns the path to the node's TLS key.
 func (worker *Compute) TLSKeyPath() string {
 	return nodeTLSKeyPath(worker.dir)

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -60,6 +60,11 @@ func (km *Keymanager) P2PKeyPath() string {
 	return nodeP2PKeyPath(km.dir)
 }
 
+// ConsensusKeyPath returns the path to the node's consensus key.
+func (km *Keymanager) ConsensusKeyPath() string {
+	return nodeConsensusKeyPath(km.dir)
+}
+
 // TLSKeyPath returns the path to the node's TLS key.
 func (km *Keymanager) TLSKeyPath() string {
 	return nodeTLSKeyPath(km.dir)

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -538,6 +538,10 @@ func nodeP2PKeyPath(dir *env.Dir) string {
 	return filepath.Join(dir.String(), fileSigner.FileP2PKey)
 }
 
+func nodeConsensusKeyPath(dir *env.Dir) string {
+	return filepath.Join(dir.String(), fileSigner.FileConsensusKey)
+}
+
 func nodeTLSKeyPath(dir *env.Dir) string {
 	path, _ := identity.TLSCertPaths(dir.String())
 	return path

--- a/go/oasis-test-runner/oasis/seed.go
+++ b/go/oasis-test-runner/oasis/seed.go
@@ -50,7 +50,7 @@ func (net *Network) newSeedNode() (*seedNode, error) {
 	// Pre-provision the node identity, so that we can figure out what
 	// to pass all the actual nodes in advance, instead of having to
 	// start the node and fork out to `oasis-node debug tendermint show-node-id`.
-	signerFactory := fileSigner.NewFactory(seedDir.String(), signature.SignerNode, signature.SignerP2P, signature.SignerEntity)
+	signerFactory := fileSigner.NewFactory(seedDir.String(), signature.SignerNode, signature.SignerP2P, signature.SignerConsensus)
 	seedIdentity, err := identity.LoadOrGenerate(seedDir.String(), signerFactory)
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/seed: failed to provision seed identity")

--- a/go/oasis-test-runner/oasis/storage.go
+++ b/go/oasis-test-runner/oasis/storage.go
@@ -52,6 +52,11 @@ func (worker *Storage) P2PKeyPath() string {
 	return nodeP2PKeyPath(worker.dir)
 }
 
+// ConsensusKeyPath returns the path to the node's consensus key.
+func (worker *Storage) ConsensusKeyPath() string {
+	return nodeConsensusKeyPath(worker.dir)
+}
+
 // TLSKeyPath returns the path to the node's TLS key.
 func (worker *Storage) TLSKeyPath() string {
 	return nodeTLSKeyPath(worker.dir)

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -45,14 +45,19 @@ func (val *Validator) LogPath() string {
 	return nodeLogPath(val.dir)
 }
 
-// IdentityKeyPath returns the paths to the node's identity key.
+// IdentityKeyPath returns the path to the node's identity key.
 func (val *Validator) IdentityKeyPath() string {
 	return nodeIdentityKeyPath(val.dir)
 }
 
-// P2PKeyPath returns the paths to the node's P2P key.
+// P2PKeyPath returns the path to the node's P2P key.
 func (val *Validator) P2PKeyPath() string {
 	return nodeP2PKeyPath(val.dir)
+}
+
+// ConsensusKeyPath returns the path to the node's consensus key.
+func (val *Validator) ConsensusKeyPath() string {
+	return nodeConsensusKeyPath(val.dir)
 }
 
 func (val *Validator) startNode() error {

--- a/go/oasis-test-runner/scenario/e2e/dump_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/dump_restore.go
@@ -92,22 +92,26 @@ func (sc *dumpRestoreImpl) Run(childEnv *env.Env) error {
 	for _, val := range sc.basicImpl.net.Validators() {
 		preservePath(val.IdentityKeyPath())
 		preservePath(val.P2PKeyPath())
+		preservePath(val.ConsensusKeyPath())
 	}
 	for _, sw := range sc.basicImpl.net.StorageWorkers() {
 		preservePath(sw.IdentityKeyPath())
 		preservePath(sw.P2PKeyPath())
+		preservePath(sw.ConsensusKeyPath())
 		preservePath(sw.TLSKeyPath())
 		preservePath(sw.TLSCertPath())
 	}
 	for _, cw := range sc.basicImpl.net.ComputeWorkers() {
 		preservePath(cw.IdentityKeyPath())
 		preservePath(cw.P2PKeyPath())
+		preservePath(cw.ConsensusKeyPath())
 		preservePath(cw.TLSKeyPath())
 		preservePath(cw.TLSCertPath())
 	}
 	km := sc.basicImpl.net.Keymanager()
 	preservePath(km.IdentityKeyPath())
 	preservePath(km.P2PKeyPath())
+	preservePath(km.ConsensusKeyPath())
 	preservePath(km.TLSKeyPath())
 	preservePath(km.TLSCertPath())
 	// Preserve key manager state.

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -639,7 +639,7 @@ func verifyRuntimeCapabilities(logger *logging.Logger, currentCaps *node.Capabil
 }
 
 // VerifyNodeUpdate verifies changes while updating the node.
-func VerifyNodeUpdate(logger *logging.Logger, currentNode *node.Node, newNode *node.Node) error {
+func VerifyNodeUpdate(logger *logging.Logger, currentNode, newNode *node.Node) error {
 	// XXX: In future we might want to allow updating some of these fields as well. But these updates
 	//      should only happen after the epoch transition.
 	//      For now, node should un-register and re-register to update any of these fields.
@@ -679,6 +679,15 @@ func VerifyNodeUpdate(logger *logging.Logger, currentNode *node.Node, newNode *n
 		logger.Error("RegisterNode: current node registration time greater than new",
 			"current_registration_time", currentNode.RegistrationTime,
 			"new_registration_time", newNode.RegistrationTime,
+		)
+		return ErrNodeUpdateNotAllowed
+	}
+
+	// As of right now, every node has a consensus ID.
+	if !currentNode.Consensus.ID.Equal(newNode.Consensus.ID) {
+		logger.Error("RegisterNode: trying to update consensus ID",
+			"current_id", currentNode.Consensus.ID,
+			"new_id", newNode.Consensus.ID,
 		)
 		return ErrNodeUpdateNotAllowed
 	}

--- a/go/tendermint/api/api.go
+++ b/go/tendermint/api/api.go
@@ -91,7 +91,7 @@ func NodeToP2PAddr(n *node.Node) (*tmp2p.NetAddress, error) {
 		return nil, fmt.Errorf("tendermint/api: node is not a validator")
 	}
 
-	pubKey := crypto.PublicKeyToTendermint(&n.ID)
+	pubKey := crypto.PublicKeyToTendermint(&n.Consensus.ID)
 	pubKeyAddrHex := strings.ToLower(pubKey.Address().String())
 
 	if len(n.Consensus.Addresses) == 0 {

--- a/go/tendermint/apps/scheduler/scheduler.go
+++ b/go/tendermint/apps/scheduler/scheduler.go
@@ -147,7 +147,7 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 	registeredValidators := make(map[signature.MapKey]*node.Node)
 	for _, v := range nodes {
 		if v.HasRoles(node.RoleValidator) {
-			registeredValidators[v.ID.ToMapKey()] = v
+			registeredValidators[v.Consensus.ID.ToMapKey()] = v
 		}
 	}
 
@@ -192,7 +192,7 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 		app.logger.Debug("adding validator to current validator set",
 			"id", id,
 		)
-		currentValidators = append(currentValidators, n.ID)
+		currentValidators = append(currentValidators, n.Consensus.ID)
 	}
 
 	// TODO/security: Enforce genesis validator staking.
@@ -615,7 +615,7 @@ func (app *schedulerApplication) electValidators(ctx *abci.Context, beacon []byt
 			continue
 		}
 
-		newValidators = append(newValidators, n.ID)
+		newValidators = append(newValidators, n.Consensus.ID)
 		if len(newValidators) >= maxValidators {
 			break
 		}

--- a/go/tendermint/genesis_single.go
+++ b/go/tendermint/genesis_single.go
@@ -44,7 +44,7 @@ func NewSingleNodeGenesisProvider(identity *identity.Identity) (genesis.Provider
 		AppState:        b,
 	}
 
-	nodeID := identity.NodeSigner.Public()
+	nodeID := identity.ConsensusSigner.Public()
 	pk := crypto.PublicKeyToTendermint(&nodeID)
 	validator := tmtypes.GenesisValidator{
 		Address: pk.Address(),

--- a/go/tendermint/service/service.go
+++ b/go/tendermint/service/service.go
@@ -9,7 +9,6 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/oasislabs/oasis-core/go/common/consensus"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
 	"github.com/oasislabs/oasis-core/go/common/service"
 	genesis "github.com/oasislabs/oasis-core/go/genesis/api"
@@ -51,9 +50,6 @@ type TendermintService interface {
 	// WatchBlocks returns a stream of Tendermint blocks as they are
 	// returned via the `EventDataNewBlock` query.
 	WatchBlocks() (<-chan *tmtypes.Block, *pubsub.Subscription)
-
-	// NodeKey returns the node's P2P (link) authentication public key.
-	NodeKey() *signature.PublicKey
 
 	// MarshalTx returns the Tendermint transaction from the inputs
 	// that you would pass to BroadcastTx.

--- a/go/worker/registration/registration.go
+++ b/go/worker/registration/registration.go
@@ -180,7 +180,10 @@ func (r *Registration) registerNode(epoch epochtime.EpochTime) error {
 			Certificate: r.identity.TLSCertificate.Certificate[0],
 			Addresses:   addresses,
 		},
-		P2P:              r.p2p.Info(),
+		P2P: r.p2p.Info(),
+		Consensus: node.ConsensusInfo{
+			ID: r.consensus.ConsensusKey(),
+		},
 		RegistrationTime: uint64(time.Now().Unix()),
 	}
 	for _, runtime := range r.workerCommonCfg.Runtimes {
@@ -240,6 +243,7 @@ func (r *Registration) consensusValidatorHook(n *node.Node) error {
 	// inclination is to do it in the registry, but this would be the other
 	// location for such a thing.
 
+	// n.Consensus.ID is set for all nodes, no need to set it here.
 	n.Consensus.Addresses = addrs
 	n.AddRoles(node.RoleValidator)
 


### PR DESCRIPTION
This makes tendermint use it's own Ed25519 key that will never use `ContextSign`, and forces every other key to only use `ContextSign`.

Yes, Ed25519ph/ctx is better.  Yes, I'm still mad about it.  Yes, this breaks everything.  If node operators complain, then they get what they deserve since they're the ones that complained about the plans to use Ed25519ph.

As a unfortunate side-effect, the validator election logs will refer to nodes by their consensus key and not their ID key, because this saves ABCI queries.

In this context, "breaking" also means, "every single node descriptor needs to be regenerated with the new code".

Fixes #2307