### PR TITLE
go/common/crypto/signature: Increase domain separation context length

### DIFF
--- a/go/common/crypto/signature/signature.go
+++ b/go/common/crypto/signature/signature.go
@@ -114,7 +114,7 @@ type PublicKey ed25519.PublicKey
 
 // Verify returns true iff the signature is valid for the public key
 // over the context and message.
-func (k PublicKey) Verify(context, message, sig []byte) bool {
+func (k PublicKey) Verify(context Context, message, sig []byte) bool {
 	if len(k) != PublicKeySize {
 		return false
 	}
@@ -339,7 +339,7 @@ type Signature struct {
 
 // Sign generates a signature with the private key over the context and
 // message.
-func Sign(signer Signer, context, message []byte) (*Signature, error) {
+func Sign(signer Signer, context Context, message []byte) (*Signature, error) {
 	signature, err := signer.ContextSign(context, message)
 	if err != nil {
 		return nil, err
@@ -355,7 +355,7 @@ func Sign(signer Signer, context, message []byte) (*Signature, error) {
 
 // Verify returns true iff the signature is valid over the given
 // context and message.
-func (s *Signature) Verify(context, message []byte) bool {
+func (s *Signature) Verify(context Context, message []byte) bool {
 	return s.PublicKey.Verify(context, message, s.Signature[:])
 }
 
@@ -456,7 +456,7 @@ type Signed struct {
 
 // SignSigned generates a Signed with the Signer over the context and
 // CBOR-serialized message.
-func SignSigned(signer Signer, context []byte, src cbor.Marshaler) (*Signed, error) {
+func SignSigned(signer Signer, context Context, src cbor.Marshaler) (*Signed, error) {
 	data := src.MarshalCBOR()
 	signature, err := Sign(signer, context, data)
 	if err != nil {
@@ -467,7 +467,7 @@ func SignSigned(signer Signer, context []byte, src cbor.Marshaler) (*Signed, err
 }
 
 // Open first verifies the blob signature and then unmarshals the blob.
-func (s *Signed) Open(context []byte, dst cbor.Unmarshaler) error {
+func (s *Signed) Open(context Context, dst cbor.Unmarshaler) error {
 	// Verify signature first.
 	if !s.Signature.Verify(context, s.Blob) {
 		return ErrVerifyFailed
@@ -510,13 +510,13 @@ type SignedPublicKey struct {
 }
 
 // Open first verifies the blob signature and then unmarshals the blob.
-func (s *SignedPublicKey) Open(context []byte, pub *PublicKey) error { // nolint: interfacer
+func (s *SignedPublicKey) Open(context Context, pub *PublicKey) error { // nolint: interfacer
 	return s.Signed.Open(context, pub)
 }
 
 // VerifyManyToOne verifies multiple signatures against a single context and
 // message, returning true iff every signature is valid.
-func VerifyManyToOne(context []byte, message []byte, sigs []Signature) bool {
+func VerifyManyToOne(context Context, message []byte, sigs []Signature) bool {
 	// Our batch verify supports doing Ed25519ph/Ed25519ctx in bulk,
 	// but we're stuck with this stupidity.
 	msg, err := PrepareSignerMessage(context, message)
@@ -551,7 +551,7 @@ func VerifyManyToOne(context []byte, message []byte, sigs []Signature) bool {
 // VerifyBatch verifies multiple signatures, made by multiple public keys,
 // against a single context and multiple messages, returning true iff every
 // signature is valid.
-func VerifyBatch(context []byte, messages [][]byte, sigs []Signature) bool {
+func VerifyBatch(context Context, messages [][]byte, sigs []Signature) bool {
 	if len(messages) != len(sigs) {
 		panic("signature: VerifyBatch messages/signature count mismatch")
 	}

--- a/go/common/crypto/signature/signers/file/file_signer.go
+++ b/go/common/crypto/signature/signers/file/file_signer.go
@@ -178,7 +178,7 @@ func (s *Signer) Sign(message []byte) ([]byte, error) {
 
 // ContextSign generates a signature with the private key over the context and
 // message.
-func (s *Signer) ContextSign(context, message []byte) ([]byte, error) {
+func (s *Signer) ContextSign(context signature.Context, message []byte) ([]byte, error) {
 	if !s.role.MustContextSign() {
 		return nil, signature.ErrRoleAction
 	}

--- a/go/common/crypto/signature/signers/memory/memory_signer.go
+++ b/go/common/crypto/signature/signers/memory/memory_signer.go
@@ -68,7 +68,7 @@ func (s *Signer) Sign(message []byte) ([]byte, error) {
 
 // ContextSign generates a signature with the private key over the context and
 // message.
-func (s *Signer) ContextSign(context, message []byte) ([]byte, error) {
+func (s *Signer) ContextSign(context signature.Context, message []byte) ([]byte, error) {
 	if !s.role.MustContextSign() {
 		return nil, signature.ErrRoleAction
 	}

--- a/go/common/entity/entity.go
+++ b/go/common/entity/entity.go
@@ -195,12 +195,12 @@ type SignedEntity struct {
 }
 
 // Open first verifies the blob signature and then unmarshals the blob.
-func (s *SignedEntity) Open(context []byte, entity *Entity) error { // nolint: interfacer
+func (s *SignedEntity) Open(context signature.Context, entity *Entity) error { // nolint: interfacer
 	return s.Signed.Open(context, entity)
 }
 
 // SignEntity serializes the Entity and signs the result.
-func SignEntity(signer signature.Signer, context []byte, entity *Entity) (*SignedEntity, error) {
+func SignEntity(signer signature.Signer, context signature.Context, entity *Entity) (*SignedEntity, error) {
 	signed, err := signature.SignSigned(signer, context, entity)
 	if err != nil {
 		return nil, err

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -586,12 +586,12 @@ type SignedNode struct {
 }
 
 // Open first verifies the blob signature and then unmarshals the blob.
-func (s *SignedNode) Open(context []byte, node *Node) error { // nolint: interfacer
+func (s *SignedNode) Open(context signature.Context, node *Node) error { // nolint: interfacer
 	return s.Signed.Open(context, node)
 }
 
 // SignNode serializes the Node and signs the result.
-func SignNode(signer signature.Signer, context []byte, node *Node) (*SignedNode, error) {
+func SignNode(signer signature.Signer, context signature.Context, node *Node) (*SignedNode, error) {
 	signed, err := signature.SignSigned(signer, context, node)
 	if err != nil {
 		return nil, err

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -29,7 +29,7 @@ var (
 	// ErrNilProtobuf is the error returned when a protobuf is nil.
 	ErrNilProtobuf = errors.New("node: Protobuf is nil")
 
-	teeHashContext = []byte("EkNodReg")
+	teeHashContext = []byte("oasis-core/node: TEE RAK binding")
 
 	_ cbor.Marshaler   = (*Node)(nil)
 	_ cbor.Unmarshaler = (*Node)(nil)

--- a/go/common/sgx/ias/grpc.go
+++ b/go/common/sgx/ias/grpc.go
@@ -20,7 +20,7 @@ var (
 	_ cbor.Unmarshaler = (*SignedEvidence)(nil)
 
 	// EvidenceSignatureContext is the signature context used for verifying evidence.
-	EvidenceSignatureContext = signature.NewContext("EkIASEvi")
+	EvidenceSignatureContext = signature.NewContext("oasis-core/sgx: ias evidence")
 
 	// CommonName is the CommonName for the IAS proxy TLS certificate.
 	CommonName = "ias-proxy"

--- a/go/common/sgx/ias/grpc.go
+++ b/go/common/sgx/ias/grpc.go
@@ -20,7 +20,7 @@ var (
 	_ cbor.Unmarshaler = (*SignedEvidence)(nil)
 
 	// EvidenceSignatureContext is the signature context used for verifying evidence.
-	EvidenceSignatureContext = []byte("EkIASEvi")
+	EvidenceSignatureContext = signature.NewContext("EkIASEvi")
 
 	// CommonName is the CommonName for the IAS proxy TLS certificate.
 	CommonName = "ias-proxy"
@@ -45,7 +45,7 @@ type SignedEvidence struct {
 }
 
 // Open first verifies the blob signature and then unmarshals the blob.
-func (s *SignedEvidence) Open(context []byte, evidence *Evidence) error { // nolint: interfacer
+func (s *SignedEvidence) Open(context signature.Context, evidence *Evidence) error { // nolint: interfacer
 	return s.Signed.Open(context, evidence)
 }
 

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -54,7 +54,7 @@ var (
 	// the runtime.
 	//
 	// NOTE: This version must be synced with runtime/src/common/version.rs.
-	RuntimeProtocol = Version{Major: 0, Minor: 7, Patch: 0}
+	RuntimeProtocol = Version{Major: 0, Minor: 8, Patch: 0}
 
 	// CommitteeProtocol versions the P2P protocol used by the
 	// committee members.
@@ -65,7 +65,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	BackendProtocol = Version{Major: 0, Minor: 12, Patch: 0}
+	BackendProtocol = Version{Major: 0, Minor: 13, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)

--- a/go/keymanager/api/api.go
+++ b/go/keymanager/api/api.go
@@ -30,7 +30,7 @@ var (
 	// in insecure builds when a RAK is unavailable.
 	TestSigners []signature.Signer
 
-	initResponseContext = signature.NewContext("EkKmIniR")
+	initResponseContext = signature.NewContext("oasis-core/keymanager: init response")
 )
 
 // Status is the current key manager status.

--- a/go/keymanager/api/api.go
+++ b/go/keymanager/api/api.go
@@ -30,7 +30,7 @@ var (
 	// in insecure builds when a RAK is unavailable.
 	TestSigners []signature.Signer
 
-	initResponseContext = []byte("EkKmIniR")
+	initResponseContext = signature.NewContext("EkKmIniR")
 )
 
 // Status is the current key manager status.

--- a/go/keymanager/api/policy_sgx.go
+++ b/go/keymanager/api/policy_sgx.go
@@ -6,7 +6,7 @@ import (
 )
 
 // PolicySGXSignatureContext is the context used to sign PolicySGX documents.
-var PolicySGXSignatureContext = signature.NewContext("EkKmPolS")
+var PolicySGXSignatureContext = signature.NewContext("oasis-core/keymanager: policy")
 
 // PolicySGX is a key manager access control policy for the replicated
 // SGX key manager.

--- a/go/keymanager/api/policy_sgx.go
+++ b/go/keymanager/api/policy_sgx.go
@@ -6,7 +6,7 @@ import (
 )
 
 // PolicySGXSignatureContext is the context used to sign PolicySGX documents.
-var PolicySGXSignatureContext = []byte("EkKmPolS")
+var PolicySGXSignatureContext = signature.NewContext("EkKmPolS")
 
 // PolicySGX is a key manager access control policy for the replicated
 // SGX key manager.

--- a/go/oasis-node/cmd/keymanager/keymanager.go
+++ b/go/oasis-node/cmd/keymanager/keymanager.go
@@ -26,8 +26,6 @@ import (
 )
 
 const (
-	policySignContext = "EkKmPolS"
-
 	cfgPolicySerial       = "keymanager.policy.serial"
 	cfgPolicyID           = "keymanager.policy.id"
 	cfgPolicyFile         = "keymanager.policy.file"
@@ -261,7 +259,7 @@ func signPolicyFromFlags() (*signature.Signature, error) {
 		return nil, err
 	}
 
-	rawSigBytes, err := signer.ContextSign([]byte(policySignContext), policyBytes)
+	rawSigBytes, err := signer.ContextSign(kmApi.PolicySGXSignatureContext, policyBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +318,7 @@ func verifyPolicyFromFlags() error {
 				return err
 			}
 
-			if !s.Verify([]byte(policySignContext), policyBytes) {
+			if !s.Verify(kmApi.PolicySGXSignatureContext, policyBytes) {
 				return errors.New("signature is not valid for given policy")
 			}
 		}

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -361,7 +361,7 @@ func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) {
 }
 
 func signForRegistration(rt *registry.Runtime, signer signature.Signer, isGenesis bool) (*registry.SignedRuntime, error) {
-	var ctx []byte
+	var ctx signature.Context
 	switch isGenesis {
 	case false:
 		ctx = registry.RegisterRuntimeSignatureContext

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -28,19 +28,22 @@ const (
 var (
 	// RegisterEntitySignatureContext is the context used for entity
 	// registration.
-	RegisterEntitySignatureContext = signature.NewContext("EkEntReg")
+	RegisterEntitySignatureContext = signature.NewContext("oasis-core/registry: register entity")
 
 	// RegisterGenesisEntitySignatureContext is the context used for
 	// entity registration in the genesis document.
-	RegisterGenesisEntitySignatureContext = signature.NewContext("EkEntGen")
+	//
+	// Note: This is identical to non-gensis registrations to support
+	// migrating existing registrations into a new genesis document.
+	RegisterGenesisEntitySignatureContext = RegisterEntitySignatureContext
 
 	// DeregisterEntitySignatureContext is the context used for entity
 	// deregistration.
-	DeregisterEntitySignatureContext = signature.NewContext("EkEDeReg")
+	DeregisterEntitySignatureContext = signature.NewContext("oasis-core/registry: deregister entity")
 
 	// RegisterNodeSignatureContext is the context used for node
 	// registration.
-	RegisterNodeSignatureContext = signature.NewContext("EkNodReg")
+	RegisterNodeSignatureContext = signature.NewContext("oasis-core/registry: register node")
 
 	// RegisterGenesisNodeSignatureContext is the context used for
 	// node registration in the genesis document.
@@ -51,15 +54,18 @@ var (
 
 	// RegisterRuntimeSignatureContext is the context used for runtime
 	// registration.
-	RegisterRuntimeSignatureContext = signature.NewContext("EkRunReg")
+	RegisterRuntimeSignatureContext = signature.NewContext("oasis-core/registry: register runtime")
 
 	// RegisterGenesisRuntimeSignatureContext is the context used for
 	// runtime registation in the genesis document.
-	RegisterGenesisRuntimeSignatureContext = signature.NewContext("EkRunGen")
+	//
+	// Note: This is identical to non-gensis registrations to support
+	// migrating existing registrations into a new genesis document.
+	RegisterGenesisRuntimeSignatureContext = RegisterRuntimeSignatureContext
 
 	// RegisterUnfreezeNodeSignatureContext is the context used for
 	// unfreezing nodes.
-	RegisterUnfreezeNodeSignatureContext = signature.NewContext("EkUzNReg")
+	RegisterUnfreezeNodeSignatureContext = signature.NewContext("oasis-core/registry: unfreeze node")
 
 	// ErrInvalidArgument is the error returned on malformed argument(s).
 	ErrInvalidArgument = errors.New("registry: invalid argument")

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -28,35 +28,38 @@ const (
 var (
 	// RegisterEntitySignatureContext is the context used for entity
 	// registration.
-	RegisterEntitySignatureContext = []byte("EkEntReg")
+	RegisterEntitySignatureContext = signature.NewContext("EkEntReg")
 
 	// RegisterGenesisEntitySignatureContext is the context used for
 	// entity registration in the genesis document.
-	RegisterGenesisEntitySignatureContext = []byte("EkEntGen")
+	RegisterGenesisEntitySignatureContext = signature.NewContext("EkEntGen")
 
 	// DeregisterEntitySignatureContext is the context used for entity
 	// deregistration.
-	DeregisterEntitySignatureContext = []byte("EkEDeReg")
+	DeregisterEntitySignatureContext = signature.NewContext("EkEDeReg")
 
 	// RegisterNodeSignatureContext is the context used for node
 	// registration.
-	RegisterNodeSignatureContext = []byte("EkNodReg")
+	RegisterNodeSignatureContext = signature.NewContext("EkNodReg")
 
 	// RegisterGenesisNodeSignatureContext is the context used for
-	/// node registration in the genesis document.
-	RegisterGenesisNodeSignatureContext = []byte("EkNodReg")
+	// node registration in the genesis document.
+	//
+	// Note: This is identical to non-gensis registrations to support
+	// migrating existing registrations into a new genesis document.
+	RegisterGenesisNodeSignatureContext = RegisterNodeSignatureContext
 
 	// RegisterRuntimeSignatureContext is the context used for runtime
 	// registration.
-	RegisterRuntimeSignatureContext = []byte("EkRunReg")
+	RegisterRuntimeSignatureContext = signature.NewContext("EkRunReg")
 
 	// RegisterGenesisRuntimeSignatureContext is the context used for
 	// runtime registation in the genesis document.
-	RegisterGenesisRuntimeSignatureContext = []byte("EkRunGen")
+	RegisterGenesisRuntimeSignatureContext = signature.NewContext("EkRunGen")
 
 	// RegisterUnfreezeNodeSignatureContext is the context used for
 	// unfreezing nodes.
-	RegisterUnfreezeNodeSignatureContext = []byte("EkUzNReg")
+	RegisterUnfreezeNodeSignatureContext = signature.NewContext("EkUzNReg")
 
 	// ErrInvalidArgument is the error returned on malformed argument(s).
 	ErrInvalidArgument = errors.New("registry: invalid argument")
@@ -237,7 +240,7 @@ func VerifyRegisterEntityArgs(logger *logging.Logger, sigEnt *entity.SignedEntit
 		return nil, ErrInvalidArgument
 	}
 
-	var ctx []byte
+	var ctx signature.Context
 	switch isGenesis {
 	case true:
 		ctx = RegisterGenesisEntitySignatureContext
@@ -300,7 +303,7 @@ func VerifyRegisterNodeArgs(cfg *Config, logger *logging.Logger, sigNode *node.S
 		return nil, ErrInvalidArgument
 	}
 
-	var ctx []byte
+	var ctx signature.Context
 	switch isGenesis {
 	case true:
 		ctx = RegisterGenesisNodeSignatureContext
@@ -717,7 +720,7 @@ func VerifyRegisterRuntimeArgs(logger *logging.Logger, sigRt *SignedRuntime, isG
 		return nil, ErrInvalidArgument
 	}
 
-	var ctx []byte
+	var ctx signature.Context
 	switch isGenesis {
 	case true:
 		ctx = RegisterGenesisRuntimeSignatureContext

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -201,12 +201,12 @@ type SignedRuntime struct {
 }
 
 // Open first verifies the blob signature and then unmarshals the blob.
-func (s *SignedRuntime) Open(context []byte, runtime *Runtime) error { // nolint: interfacer
+func (s *SignedRuntime) Open(context signature.Context, runtime *Runtime) error { // nolint: interfacer
 	return s.Signed.Open(context, runtime)
 }
 
 // SignRuntime serializes the Runtime and signs the result.
-func SignRuntime(signer signature.Signer, context []byte, runtime *Runtime) (*SignedRuntime, error) {
+func SignRuntime(signer signature.Signer, context signature.Context, runtime *Runtime) (*SignedRuntime, error) {
 	signed, err := signature.SignSigned(signer, context, runtime)
 	if err != nil {
 		return nil, err

--- a/go/registry/api/status.go
+++ b/go/registry/api/status.go
@@ -58,12 +58,12 @@ type SignedUnfreezeNode struct {
 }
 
 // Open first verifies the blob signature and then unmarshals the blob.
-func (s *SignedUnfreezeNode) Open(context []byte, unfreeze *UnfreezeNode) error { // nolint: interfacer
+func (s *SignedUnfreezeNode) Open(context signature.Context, unfreeze *UnfreezeNode) error { // nolint: interfacer
 	return s.Signed.Open(context, unfreeze)
 }
 
 // SignUnfreezeNode serializes the UnfreezeNode and signs the result.
-func SignUnfreezeNode(signer signature.Signer, context []byte, unfreeze *UnfreezeNode) (*SignedUnfreezeNode, error) {
+func SignUnfreezeNode(signer signature.Signer, context signature.Context, unfreeze *UnfreezeNode) (*SignedUnfreezeNode, error) {
 	signed, err := signature.SignSigned(signer, context, unfreeze)
 	if err != nil {
 		return nil, err

--- a/go/roothash/api/commitment/compute.go
+++ b/go/roothash/api/commitment/compute.go
@@ -16,11 +16,11 @@ import (
 var (
 	// ComputeSignatureContext is the signature context used to sign compute
 	// worker commitments.
-	ComputeSignatureContext = signature.NewContext("EkCommCC")
+	ComputeSignatureContext = signature.NewContext("oasis-core/roothash: compute commitment")
 
 	// ComputeResultsHeaderSignatureContext is the signature context used to
 	// sign compute results headers with RAK.
-	ComputeResultsHeaderSignatureContext = signature.NewContext("EkComRHd")
+	ComputeResultsHeaderSignatureContext = signature.NewContext("oasis-core/roothash: compute results header")
 )
 
 // ComputeResultsHeader is the header of a computed batch output by a runtime. This

--- a/go/roothash/api/commitment/compute.go
+++ b/go/roothash/api/commitment/compute.go
@@ -16,11 +16,11 @@ import (
 var (
 	// ComputeSignatureContext is the signature context used to sign compute
 	// worker commitments.
-	ComputeSignatureContext = []byte("EkCommCC")
+	ComputeSignatureContext = signature.NewContext("EkCommCC")
 
 	// ComputeResultsHeaderSignatureContext is the signature context used to
 	// sign compute results headers with RAK.
-	ComputeResultsHeaderSignatureContext = []byte("EkComRHd")
+	ComputeResultsHeaderSignatureContext = signature.NewContext("EkComRHd")
 )
 
 // ComputeResultsHeader is the header of a computed batch output by a runtime. This

--- a/go/roothash/api/commitment/merge.go
+++ b/go/roothash/api/commitment/merge.go
@@ -12,7 +12,7 @@ import (
 
 // MergeSignatureContext is the signature context used to sign merge
 // worker commitments.
-var MergeSignatureContext = signature.NewContext("EkCommMC")
+var MergeSignatureContext = signature.NewContext("oasis-core/roothash: merge commitment")
 
 type MergeBody struct {
 	ComputeCommits []ComputeCommitment `json:"commits"`

--- a/go/roothash/api/commitment/merge.go
+++ b/go/roothash/api/commitment/merge.go
@@ -12,7 +12,7 @@ import (
 
 // MergeSignatureContext is the signature context used to sign merge
 // worker commitments.
-var MergeSignatureContext = []byte("EkCommMC")
+var MergeSignatureContext = signature.NewContext("EkCommMC")
 
 type MergeBody struct {
 	ComputeCommits []ComputeCommitment `json:"commits"`

--- a/go/roothash/api/commitment/txnscheduler.go
+++ b/go/roothash/api/commitment/txnscheduler.go
@@ -9,7 +9,7 @@ import (
 
 // TxnSchedulerBatchDispatchSigCtx is the context used for signing
 // transaction scheduler batch dispatch messages.
-var TxnSchedulerBatchDispatchSigCtx = signature.NewContext("EkTscBat")
+var TxnSchedulerBatchDispatchSigCtx = signature.NewContext("oasis-core/roothash: tx batch dispatch")
 
 // TxnSchedulerBatchDispatch is the message sent from the transaction
 // scheduler to compute workers after a batch is ready to be computed.

--- a/go/roothash/api/commitment/txnscheduler.go
+++ b/go/roothash/api/commitment/txnscheduler.go
@@ -9,7 +9,7 @@ import (
 
 // TxnSchedulerBatchDispatchSigCtx is the context used for signing
 // transaction scheduler batch dispatch messages.
-var TxnSchedulerBatchDispatchSigCtx = []byte("EkTscBat")
+var TxnSchedulerBatchDispatchSigCtx = signature.NewContext("EkTscBat")
 
 // TxnSchedulerBatchDispatch is the message sent from the transaction
 // scheduler to compute workers after a batch is ready to be computed.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -25,16 +25,16 @@ const (
 
 var (
 	// TransferSignatureContext is the context used for transfers.
-	TransferSignatureContext = signature.NewContext("EkStaXfr")
+	TransferSignatureContext = signature.NewContext("oasis-core/staking: transfer")
 
 	// BurnSignatureContext is the context used for burns.
-	BurnSignatureContext = signature.NewContext("EkStaBur")
+	BurnSignatureContext = signature.NewContext("oasis-core/staking: burn")
 
 	// EscrowSignatureContext is the context used for escrows.
-	EscrowSignatureContext = signature.NewContext("EkStaEsc")
+	EscrowSignatureContext = signature.NewContext("oasis-core/staking: escrow")
 
 	// ReclaimEscrowSignatureContext is the context used for escrow reclimation.
-	ReclaimEscrowSignatureContext = signature.NewContext("EkStaRec")
+	ReclaimEscrowSignatureContext = signature.NewContext("oasis-core/staking: reclaim escrow")
 
 	// ErrInvalidArgument is the error returned on malformed arguments.
 	ErrInvalidArgument = errors.New("staking: invalid argument")

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -25,16 +25,16 @@ const (
 
 var (
 	// TransferSignatureContext is the context used for transfers.
-	TransferSignatureContext = []byte("EkStaXfr")
+	TransferSignatureContext = signature.NewContext("EkStaXfr")
 
 	// BurnSignatureContext is the context used for burns.
-	BurnSignatureContext = []byte("EkStaBur")
+	BurnSignatureContext = signature.NewContext("EkStaBur")
 
 	// EscrowSignatureContext is the context used for escrows.
-	EscrowSignatureContext = []byte("EkStaEsc")
+	EscrowSignatureContext = signature.NewContext("EkStaEsc")
 
 	// ReclaimEscrowSignatureContext is the context used for escrow reclimation.
-	ReclaimEscrowSignatureContext = []byte("EkStaRec")
+	ReclaimEscrowSignatureContext = signature.NewContext("EkStaRec")
 
 	// ErrInvalidArgument is the error returned on malformed arguments.
 	ErrInvalidArgument = errors.New("staking: invalid argument")

--- a/go/storage/api/api.go
+++ b/go/storage/api/api.go
@@ -60,7 +60,7 @@ var (
 	ErrRootMustFollowOld = nodedb.ErrRootMustFollowOld
 
 	// ReceiptSignatureContext is the signature context used for verifying MKVS receipts.
-	ReceiptSignatureContext = signature.NewContext("EkStrRct")
+	ReceiptSignatureContext = signature.NewContext("oasis-core/storage: receipt")
 
 	_ cbor.Marshaler   = (*ReceiptBody)(nil)
 	_ cbor.Unmarshaler = (*ReceiptBody)(nil)

--- a/go/storage/api/api.go
+++ b/go/storage/api/api.go
@@ -60,7 +60,7 @@ var (
 	ErrRootMustFollowOld = nodedb.ErrRootMustFollowOld
 
 	// ReceiptSignatureContext is the signature context used for verifying MKVS receipts.
-	ReceiptSignatureContext = []byte("EkStrRct")
+	ReceiptSignatureContext = signature.NewContext("EkStrRct")
 
 	_ cbor.Marshaler   = (*ReceiptBody)(nil)
 	_ cbor.Unmarshaler = (*ReceiptBody)(nil)

--- a/go/worker/common/p2p/crypto.go
+++ b/go/worker/common/p2p/crypto.go
@@ -12,7 +12,7 @@ import (
 var (
 	errCryptoNotSupported = errors.New("worker/common/p2p: crypto op not supported")
 
-	libp2pContext = []byte("EkLibP2P")
+	libp2pContext = signature.NewContext("EkLibP2P")
 )
 
 type p2pSigner struct {

--- a/go/worker/common/p2p/crypto.go
+++ b/go/worker/common/p2p/crypto.go
@@ -12,7 +12,7 @@ import (
 var (
 	errCryptoNotSupported = errors.New("worker/common/p2p: crypto op not supported")
 
-	libp2pContext = signature.NewContext("EkLibP2P")
+	libp2pContext = signature.NewContext("oasis-core/worker: libp2p")
 )
 
 type p2pSigner struct {

--- a/keymanager-runtime/api/src/api.rs
+++ b/keymanager-runtime/api/src/api.rs
@@ -46,8 +46,8 @@ pub struct InitResponse {
     pub policy_checksum: Vec<u8>,
 }
 
-/// Context used for th einit response signature.
-pub const INIT_RESPONSE_CONTEXT: [u8; 8] = *b"EkKmIniR";
+/// Context used for the init response signature.
+pub const INIT_RESPONSE_CONTEXT: &'static [u8] = b"oasis-core/keymanager: init response";
 
 /// Signed InitResponse.
 #[derive(Clone, Serialize, Deserialize)]

--- a/keymanager-runtime/api/src/lib.rs
+++ b/keymanager-runtime/api/src/lib.rs
@@ -46,7 +46,7 @@ lazy_static! {
 }
 const MULTISIG_THRESHOLD: usize = 9001; // TODO: Set this to a real value.
 
-const POLICY_SIGN_CONTEXT: [u8; 8] = *b"EkKmPolS";
+const POLICY_SIGN_CONTEXT: &'static [u8] = b"oasis-core/keymanager: policy";
 
 impl SignedPolicySGX {
     /// Verify the signatures and return the PolicySGX, if the signatures are correct.

--- a/runtime/src/common/roothash.rs
+++ b/runtime/src/common/roothash.rs
@@ -77,7 +77,8 @@ impl Header {
 
 /// Compute results header signature context.
 #[cfg_attr(not(target_env = "sgx"), allow(unused))]
-pub const COMPUTE_RESULTS_HEADER_CONTEXT: [u8; 8] = *b"EkComRHd";
+pub const COMPUTE_RESULTS_HEADER_CONTEXT: &'static [u8] =
+    b"oasis-core/roothash: compute results header";
 
 /// The header of a computed batch output by a runtime. This header is a
 /// compressed representation (e.g., hashes instead of full content) of

--- a/runtime/src/common/version.rs
+++ b/runtime/src/common/version.rs
@@ -66,6 +66,6 @@ impl From<u64> for Version {
 // the worker host.
 pub const PROTOCOL_VERSION: Version = Version {
     major: 0,
-    minor: 7,
+    minor: 8,
     patch: 0,
 };

--- a/runtime/src/rak.rs
+++ b/runtime/src/rak.rs
@@ -21,7 +21,7 @@ use sgx_isa::Report;
 
 /// Context used for computing the RAK digest.
 #[cfg_attr(not(target_env = "sgx"), allow(unused))]
-const RAK_HASH_CONTEXT: [u8; 8] = *b"EkNodReg";
+const RAK_HASH_CONTEXT: &'static [u8] = b"oasis-core/node: TEE RAK binding";
 
 /// RAK-related error.
 #[derive(Debug, Fail)]
@@ -88,9 +88,9 @@ impl RAK {
 
     /// Generate report body = H(RAK_HASH_CONTEXT || RAK_pub).
     fn report_body_for_rak(rak: &PublicKey) -> Hash {
-        let mut message = [0; 40];
-        message[0..8].copy_from_slice(&RAK_HASH_CONTEXT);
-        message[8..40].copy_from_slice(rak.as_ref());
+        let mut message = [0; 64];
+        message[0..32].copy_from_slice(&RAK_HASH_CONTEXT);
+        message[32..64].copy_from_slice(rak.as_ref());
         Hash::digest_bytes(&message)
     }
 


### PR DESCRIPTION
 * [x] Add duplicate context sanity checks.
 * [x] Relax the length restrictions on contexts to 1 <= l <= 255 octets.
 * [x] Use more descriptive contexts.
 * [x] Fix the dump/restore bug(s).

Breaking because every single signature ever made is now invalid.

Fixes #2311
Fixes #2318