### PR TITLE
go/tendermint/abci: Enforce a maximum transaction size limit

### DIFF
--- a/go/common/consensus/consensus.go
+++ b/go/common/consensus/consensus.go
@@ -36,4 +36,5 @@ type Genesis struct {
 	TimeoutCommit      time.Duration `json:"timeout_commit"`
 	SkipTimeoutCommit  bool          `json:"skip_timeout_commit"`
 	EmptyBlockInterval time.Duration `json:"empty_block_interval"`
+	MaxTxSize          uint          `json:"max_tx_size"`
 }

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -74,6 +74,7 @@ const (
 	cfgConsensusTimeoutCommit      = "consensus.tendermint.timeout_commit"
 	cfgConsensusSkipTimeoutCommit  = "consensus.tendermint.skip_timeout_commit"
 	cfgConsensusEmptyBlockInterval = "consensus.tendermint.empty_block_interval"
+	cfgConsensusMaxTxSizeBytes     = "consensus.tendermint.max_tx_size"
 
 	// Consensus backend config flag.
 	cfgConsensusBackend = "consensus.backend"
@@ -195,6 +196,7 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 		TimeoutCommit:      viper.GetDuration(cfgConsensusTimeoutCommit),
 		SkipTimeoutCommit:  viper.GetBool(cfgConsensusSkipTimeoutCommit),
 		EmptyBlockInterval: viper.GetDuration(cfgConsensusEmptyBlockInterval),
+		MaxTxSize:          viper.GetSizeInBytes(cfgConsensusMaxTxSizeBytes),
 	}
 
 	// TODO: Ensure consistency/sanity.
@@ -628,6 +630,7 @@ func init() {
 	initGenesisFlags.Duration(cfgConsensusTimeoutCommit, 1*time.Second, "tendermint commit timeout")
 	initGenesisFlags.Bool(cfgConsensusSkipTimeoutCommit, false, "skip tendermint commit timeout")
 	initGenesisFlags.Duration(cfgConsensusEmptyBlockInterval, 0*time.Second, "tendermint empty block interval")
+	initGenesisFlags.String(cfgConsensusMaxTxSizeBytes, "32kb", "tendermint maximum transaction size (in bytes)")
 
 	// Consensus backend flag.
 	initGenesisFlags.String(cfgConsensusBackend, tendermint.BackendName, "consensus backend")


### PR DESCRIPTION
To avoid trivial DoS attacks against the consensus layer, enforce an
upper bound on the maximum transaction size (default: 32 KiB).  At a
future date, this limit can either be made more fine-grained, or the
limit can be adjusted as required.

Inspired by #2022.