### PR TITLE
go/common/crypto/signature: Move `UnsafeBytes`

### DIFF
--- a/go/common/crypto/signature/signer.go
+++ b/go/common/crypto/signature/signer.go
@@ -117,9 +117,13 @@ type Signer interface {
 
 	// Reset tears down the Signer and obliterates any sensitive state if any.
 	Reset()
+}
 
-	// UnsafeBytes returns the byte representation of the private key.  This
-	// MUST be removed for HSM support.
+// UnsafeSigner is a Signer that also supports access to the raw private key.
+type UnsafeSigner interface {
+	Signer
+
+	// UnsafeBytes returns the byte representation of the private key.
 	UnsafeBytes() []byte
 }
 

--- a/go/oasis-test-runner/oasis/seed.go
+++ b/go/oasis-test-runner/oasis/seed.go
@@ -55,7 +55,7 @@ func (net *Network) newSeedNode() (*seedNode, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/seed: failed to provision seed identity")
 	}
-	seedPublicKey := seedIdentity.NodeSigner.Public()
+	seedPublicKey := seedIdentity.ConsensusSigner.Public()
 
 	seedNode := &seedNode{
 		net:           net,

--- a/go/tendermint/crypto/signature.go
+++ b/go/tendermint/crypto/signature.go
@@ -23,12 +23,10 @@ func PublicKeyFromTendermint(tk *tmed.PubKeyEd25519) signature.PublicKey {
 	return k
 }
 
-// UnsafeSignerToTendermint coverts a signature.Signer to the tendermint
-// equivalent.
-//
-// TODO/hsm: Remove this.
-func UnsafeSignerToTendermint(signer signature.Signer) tmed.PrivKeyEd25519 {
+// UnsafeSignerToTendermint coverts a signature.UnsafeSigner to the
+// tendermint equivalent.
+func UnsafeSignerToTendermint(unsafeSigner signature.UnsafeSigner) tmed.PrivKeyEd25519 {
 	var tk tmed.PrivKeyEd25519
-	copy(tk[:], signer.UnsafeBytes())
+	copy(tk[:], unsafeSigner.UnsafeBytes())
 	return tk
 }

--- a/go/tendermint/crypto/signature_test.go
+++ b/go/tendermint/crypto/signature_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	tmed "github.com/tendermint/tendermint/crypto/ed25519"
 
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/memory"
 )
 
@@ -14,8 +15,9 @@ func TestSignatureConversions(t *testing.T) {
 	signer, err := memorySigner.NewSigner(rand.Reader)
 	require.NoError(t, err, "NewSigner()")
 
-	tmSk := UnsafeSignerToTendermint(signer)
-	require.Equal(t, signer.UnsafeBytes(), tmSk[:], "Private key: ToTendermint")
+	unsafeSigner := signer.(signature.UnsafeSigner)
+	tmSk := UnsafeSignerToTendermint(unsafeSigner)
+	require.Equal(t, unsafeSigner.UnsafeBytes(), tmSk[:], "Private key: ToTendermint")
 
 	pk := signer.Public()
 	tmPk := tmSk.PubKey().(tmed.PubKeyEd25519)


### PR DESCRIPTION
Not all Signer implementations should provide `UnsafeBytes`, so remove
it from the base interface.  This also switches the seed node to use the
`Identity.ConsensusSigner` instead of `Identity.NodeSigner` for it's
keys.