### PR TITLE
go/tendermint: Use our domain-separation signature scheme

### DIFF
--- a/go/common/crypto/signature/signer.go
+++ b/go/common/crypto/signature/signer.go
@@ -70,15 +70,6 @@ const (
 	SignerConsensus
 )
 
-// MustContextSign returns true iff the SignerRole must only accept ContextSign
-// operations.
-func (r SignerRole) MustContextSign() bool {
-	// Since we're stuck with PrepareSignerMessage instead of a sensible
-	// construct, ensure that only signers (aka keys) that are dedicated
-	// to consensus signing get to use vanilla Ed25519pure.
-	return r != SignerConsensus
-}
-
 // SignerFactoryCtor is an SignerFactory constructor.
 type SignerFactoryCtor func(string, ...SignerRole) SignerFactory
 
@@ -103,9 +94,6 @@ type SignerFactory interface {
 type Signer interface {
 	// Public returns the PublicKey corresponding to the signer.
 	Public() PublicKey
-
-	// Sign generates a signature with the private key over the message.
-	Sign(message []byte) ([]byte, error)
 
 	// ContextSign generates a signature with the private key over the context and
 	// message.

--- a/go/common/crypto/signature/signers/file/file_signer.go
+++ b/go/common/crypto/signature/signers/file/file_signer.go
@@ -168,21 +168,9 @@ func (s *Signer) Public() signature.PublicKey {
 	return signature.PublicKey(s.privateKey.Public().(ed25519.PublicKey))
 }
 
-// Sign generates a signature with the private key over the message.
-func (s *Signer) Sign(message []byte) ([]byte, error) {
-	if s.role.MustContextSign() {
-		return nil, signature.ErrRoleAction
-	}
-	return ed25519.Sign(s.privateKey, message), nil
-}
-
 // ContextSign generates a signature with the private key over the context and
 // message.
 func (s *Signer) ContextSign(context signature.Context, message []byte) ([]byte, error) {
-	if !s.role.MustContextSign() {
-		return nil, signature.ErrRoleAction
-	}
-
 	data, err := signature.PrepareSignerMessage(context, message)
 	if err != nil {
 		return nil, err

--- a/go/common/crypto/signature/signers/memory/memory_signer.go
+++ b/go/common/crypto/signature/signers/memory/memory_signer.go
@@ -58,21 +58,9 @@ func (s *Signer) Public() signature.PublicKey {
 	return signature.PublicKey(s.privateKey.Public().(ed25519.PublicKey))
 }
 
-// Sign generates a signature with the private key over the message.
-func (s *Signer) Sign(message []byte) ([]byte, error) {
-	if s.role.MustContextSign() {
-		return nil, signature.ErrRoleAction
-	}
-	return ed25519.Sign(s.privateKey, message), nil
-}
-
 // ContextSign generates a signature with the private key over the context and
 // message.
 func (s *Signer) ContextSign(context signature.Context, message []byte) ([]byte, error) {
-	if !s.role.MustContextSign() {
-		return nil, signature.ErrRoleAction
-	}
-
 	data, err := signature.PrepareSignerMessage(context, message)
 	if err != nil {
 		return nil, err

--- a/go/go.mod
+++ b/go/go.mod
@@ -2,6 +2,7 @@ module github.com/oasislabs/oasis-core/go
 
 replace (
 	github.com/tendermint/iavl => github.com/oasislabs/iavl v0.12.0-ekiden3
+	github.com/tendermint/tendermint => github.com/oasislabs/tendermint v0.32.7-oasis1
 	golang.org/x/crypto/curve25519 => github.com/oasislabs/ed25519/extra/x25519 v0.0.0-20191022155220-a426dcc8ad5f
 	golang.org/x/crypto/ed25519 => github.com/oasislabs/ed25519 v0.0.0-20191022155220-a426dcc8ad5f
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -349,6 +349,8 @@ github.com/oasislabs/iavl v0.12.0-ekiden2 h1:kzdp6OTHYrn8TXlAo+2NsL84Qi2gqydFvjh
 github.com/oasislabs/iavl v0.12.0-ekiden2/go.mod h1:B/tMpl5cg7n42n3xYQTCckJzQezoI75jedkc8FOiOF0=
 github.com/oasislabs/iavl v0.12.0-ekiden3 h1:8544fXJb57urhAEpTlIwDBdTJukgpPS/FCS/yj14I8E=
 github.com/oasislabs/iavl v0.12.0-ekiden3/go.mod h1:B/tMpl5cg7n42n3xYQTCckJzQezoI75jedkc8FOiOF0=
+github.com/oasislabs/tendermint v0.32.7-oasis1 h1:m1WPCTXn0PgLHAX5YsFx52vx+bQwZP9iSM2kgtMaGVM=
+github.com/oasislabs/tendermint v0.32.7-oasis1/go.mod h1:Ex0OYkB2o7j3qghM7rEePw/drFL5M2WNRs95uiFJOxQ=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/go/oasis-test-runner/oasis/seed.go
+++ b/go/oasis-test-runner/oasis/seed.go
@@ -55,7 +55,7 @@ func (net *Network) newSeedNode() (*seedNode, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/seed: failed to provision seed identity")
 	}
-	seedPublicKey := seedIdentity.ConsensusSigner.Public()
+	seedPublicKey := seedIdentity.NodeSigner.Public()
 
 	seedNode := &seedNode{
 		net:           net,

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -116,7 +116,7 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 	}
 
 	valConsensusAddr := node.ConsensusAddress{
-		ID: valIdentity.ConsensusSigner.Public(),
+		ID: valIdentity.NodeSigner.Public(),
 	}
 	if err = valConsensusAddr.Address.FromIP(netPkg.ParseIP("127.0.0.1"), val.consensusPort); err != nil {
 		return nil, fmt.Errorf("oasis/validator: failed to parse IP: %w", err)

--- a/go/tendermint/crypto/priv_val.go
+++ b/go/tendermint/crypto/priv_val.go
@@ -278,7 +278,7 @@ func (pv *privVal) SignVote(chainID string, vote *tmtypes.Vote) error {
 		return err
 	}
 
-	sig, err := pv.signer.Sign(signBytes)
+	sig, err := pv.signer.ContextSign(tendermintSignatureContext, signBytes)
 	if err != nil {
 		return errors.Wrap(err, "tendermint/crypto: failed to sign vote")
 	}
@@ -311,7 +311,7 @@ func (pv *privVal) SignProposal(chainID string, proposal *tmtypes.Proposal) erro
 		return err
 	}
 
-	sig, err := pv.signer.Sign(signBytes)
+	sig, err := pv.signer.ContextSign(tendermintSignatureContext, signBytes)
 	if err != nil {
 		return errors.Wrap(err, "tendermint/crypto: failed to sign proposal")
 	}

--- a/go/tendermint/crypto/signature.go
+++ b/go/tendermint/crypto/signature.go
@@ -7,6 +7,8 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 )
 
+var tendermintSignatureContext = signature.NewContext("oasis-core/tendermint")
+
 // PublicKeyToTendermint converts a signature.PublicKey to the
 // tendermint equivalent.
 func PublicKeyToTendermint(k *signature.PublicKey) tmed.PubKeyEd25519 {
@@ -29,4 +31,8 @@ func UnsafeSignerToTendermint(unsafeSigner signature.UnsafeSigner) tmed.PrivKeyE
 	var tk tmed.PrivKeyEd25519
 	copy(tk[:], unsafeSigner.UnsafeBytes())
 	return tk
+}
+
+func init() {
+	tmed.EnableOasisDomainSeparation(string(tendermintSignatureContext))
 }

--- a/go/tendermint/seed.go
+++ b/go/tendermint/seed.go
@@ -100,12 +100,11 @@ func NewSeed(dataDir string, identity *identity.Identity, genesisProvider genesi
 	cfg.AddrBookStrict = !viper.GetBool(CfgDebugP2PAddrBookLenient)
 	// MaxNumInboundPeers/MaxNumOutboundPeers
 
-	// TODO/hsm: This really should be Identity.NodeSigner.
-	unsafeConsensusSigner, ok := identity.ConsensusSigner.(signature.UnsafeSigner)
+	unsafeNodeSigner, ok := identity.NodeSigner.(signature.UnsafeSigner)
 	if !ok {
-		return nil, errors.New("tendermint/seed: consensus signer does not allow private key access")
+		return nil, errors.New("tendermint/seed: node signer does not allow private key access")
 	}
-	nodeKey := &p2p.NodeKey{PrivKey: crypto.UnsafeSignerToTendermint(unsafeConsensusSigner)}
+	nodeKey := &p2p.NodeKey{PrivKey: crypto.UnsafeSignerToTendermint(unsafeNodeSigner)}
 
 	doc, err := genesisProvider.GetGenesisDocument()
 	if err != nil {


### PR DESCRIPTION
This deprecates all non-context signatures, and forces tendermint to use
our ad-hoc construct via extensions provided with our fork.

Additionally, the tendermint node identity key is now the oasis node
identity key, and the old ConsensusSigner is only used for validator
signatures (proposals/votes).

Fixes #2332