### PR TITLE
go oasis-node: close stdout before test framework prints junk

### DIFF
--- a/go/oasis-node/integrationrunner/integration_test.go
+++ b/go/oasis-node/integrationrunner/integration_test.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var run = flag.Bool("integration.run", false, "Run the node")
@@ -19,5 +21,7 @@ func TestIntegration(t *testing.T) {
 	launch()
 
 	// Suppress coverage report on stdout.
-	_ = os.Stdout.Close()
+	f, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	require.NoError(t, err, "opening %s", os.DevNull)
+	os.Stdout = f
 }

--- a/go/oasis-node/integrationrunner/integration_test.go
+++ b/go/oasis-node/integrationrunner/integration_test.go
@@ -2,6 +2,7 @@ package integrationrunner
 
 import (
 	"flag"
+	"os"
 	"testing"
 )
 
@@ -16,4 +17,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	launch()
+
+	// Suppress coverage report on stdout.
+	_ = os.Stdout.Close()
 }


### PR DESCRIPTION
blocks #2344

there's no option to disable messages from the test framework