### PR TITLE
go/tendermint/apps/registry: Limit node registrations by stake

### DIFF
--- a/go/tendermint/apps/registry/state/state.go
+++ b/go/tendermint/apps/registry/state/state.go
@@ -359,6 +359,26 @@ func (s *ImmutableState) HasEntityNodes(id signature.PublicKey) (bool, error) {
 	return result, nil
 }
 
+func (s *ImmutableState) NumEntityNodes(id signature.PublicKey) (int, error) {
+	var n int
+	s.Snapshot.IterateRange(
+		signedNodeByEntityKeyFmt.Encode(&id),
+		nil,
+		true,
+		func(key, value []byte) bool {
+			var entityID signature.PublicKey
+			if !signedNodeByEntityKeyFmt.Decode(key, &entityID) || !entityID.Equal(id) {
+				return true
+			}
+
+			n++
+
+			return false
+		},
+	)
+	return n, nil
+}
+
 func (s *ImmutableState) ConsensusParameters() (*registry.ConsensusParameters, error) {
 	_, raw := s.Snapshot.Get(parametersKeyFmt.Encode())
 	if raw == nil {

--- a/go/tendermint/apps/staking/state/cache.go
+++ b/go/tendermint/apps/staking/state/cache.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	staking "github.com/oasislabs/oasis-core/go/staking/api"
@@ -29,6 +30,32 @@ type StakeCache struct {
 
 	thresholds map[staking.ThresholdKind]staking.Quantity
 	balances   map[signature.MapKey]*staking.Quantity
+
+	lowestNonZeroThreshold staking.Quantity
+}
+
+// EnsureNodeRegistrationStake ensures the account owned by id has sufficient
+// stake to support the number of nodes, under the assumption that all
+// nodes will be elected with the lowest non-zero threshold.  This routine
+// ignores what roles the nodes actually are registering for as it is
+// intended to be a cheap check to prevent node registration Tx spam.
+func (sc *StakeCache) EnsureNodeRegistrationStake(id signature.PublicKey, n int) error {
+	var newNumNodes staking.Quantity
+	if err := newNumNodes.FromBigInt(big.NewInt(int64(n))); err != nil {
+		return fmt.Errorf("staking/tendermint: failed to create node multiplier: %w", err)
+	}
+
+	targetThreshold := sc.lowestNonZeroThreshold.Clone()
+	if err := targetThreshold.Mul(&newNumNodes); err != nil {
+		return fmt.Errorf("staking/tendermint: failed to derive node target threshold: %w", err)
+	}
+
+	escrowBalance := sc.getEscrowBalance(id)
+	if escrowBalance.Cmp(targetThreshold) < 0 {
+		return staking.ErrInsufficientStake
+	}
+
+	return nil
 }
 
 // EnsureSufficientStake ensures that the account owned by id has sufficient
@@ -36,13 +63,6 @@ type StakeCache struct {
 // can have multiple instances of the same threshold kind specified, in which
 // case it will be factored in repeatedly.
 func (sc *StakeCache) EnsureSufficientStake(id signature.PublicKey, thresholds []staking.ThresholdKind) error {
-	escrowBalance := sc.balances[id.ToMapKey()]
-	if escrowBalance == nil {
-		state := NewMutableState(sc.ctx.State())
-		escrowBalance = state.EscrowBalance(id)
-		sc.balances[id.ToMapKey()] = escrowBalance
-	}
-
 	var targetThreshold staking.Quantity
 	for _, v := range thresholds {
 		qty := sc.thresholds[v]
@@ -51,11 +71,24 @@ func (sc *StakeCache) EnsureSufficientStake(id signature.PublicKey, thresholds [
 		}
 	}
 
+	escrowBalance := sc.getEscrowBalance(id)
 	if escrowBalance.Cmp(&targetThreshold) < 0 {
 		return staking.ErrInsufficientStake
 	}
 
 	return nil
+}
+
+func (sc *StakeCache) getEscrowBalance(id signature.PublicKey) staking.Quantity {
+	escrowBalance := sc.balances[id.ToMapKey()]
+	if escrowBalance == nil {
+		state := NewMutableState(sc.ctx.State())
+		escrowBalance = state.EscrowBalance(id)
+		sc.balances[id.ToMapKey()] = escrowBalance
+	}
+
+	ret := escrowBalance.Clone()
+	return *ret
 }
 
 // NewStakeCache creates a new staking lookup cache.
@@ -67,9 +100,19 @@ func NewStakeCache(ctx *abci.Context) (*StakeCache, error) {
 		return nil, fmt.Errorf("staking/tendermint: failed to query thresholds: %w", err)
 	}
 
+	lowestNonZeroThreshold := staking.NewQuantity()
+	for _, v := range thresholds {
+		if lowestNonZeroThreshold.IsZero() {
+			lowestNonZeroThreshold = v.Clone()
+		} else if !v.IsZero() && lowestNonZeroThreshold.Cmp(&v) == 1 {
+			lowestNonZeroThreshold = v.Clone()
+		}
+	}
+
 	return &StakeCache{
-		ctx:        ctx,
-		thresholds: thresholds,
-		balances:   make(map[signature.MapKey]*staking.Quantity),
+		ctx:                    ctx,
+		thresholds:             thresholds,
+		balances:               make(map[signature.MapKey]*staking.Quantity),
+		lowestNonZeroThreshold: *lowestNonZeroThreshold,
 	}, nil
 }


### PR DESCRIPTION
To prevent entities from spamming the registry with node registrations,
limit node registrations by a check against the entity's staking
balance.

`numNodes * lowestNonZeroThreshold < balance` should be sufficiently
forgiving, and will prevent the worst of the abuse.  The lowest
threshold is used because entities registering more nodes isn't a
problem, until it gets excessive.

Fixes #2338