### PR TITLE
Staking commission

### DIFF
--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -65,7 +65,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	BackendProtocol = Version{Major: 0, Minor: 16, Patch: 0}
+	BackendProtocol = Version{Major: 0, Minor: 17, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)

--- a/go/consensus/tendermint/apps/staking/api.go
+++ b/go/consensus/tendermint/apps/staking/api.go
@@ -46,10 +46,11 @@ var (
 
 // Tx is a transaction to be accepted by the staking app.
 type Tx struct {
-	*TxTransfer      `json:"Transfer,omitempty"`
-	*TxBurn          `json:"Burn,omitempty"`
-	*TxAddEscrow     `json:"AddEscrow,omitempty"`
-	*TxReclaimEscrow `json:"ReclaimEscrow,omitempty"`
+	*TxTransfer                `json:"Transfer,omitempty"`
+	*TxBurn                    `json:"Burn,omitempty"`
+	*TxAddEscrow               `json:"AddEscrow,omitempty"`
+	*TxReclaimEscrow           `json:"ReclaimEscrow,omitempty"`
+	*TxAmendCommissionSchedule `json:"AmendCommissionSchedule,omitempty"`
 }
 
 // TxTransfer is a transaction for a transfer.
@@ -70,4 +71,9 @@ type TxAddEscrow struct {
 // TxReclaimEscrow is a transaction for a ReclaimEscrow.
 type TxReclaimEscrow struct {
 	SignedReclaimEscrow staking.SignedReclaimEscrow
+}
+
+// TxAmendCommissionSchedule is a transaction for an AmendCommissionSchedule
+type TxAmendCommissionSchedule struct {
+	SignedAmendCommissionSchedule staking.SignedAmendCommissionSchedule
 }

--- a/go/consensus/tendermint/apps/staking/staking.go
+++ b/go/consensus/tendermint/apps/staking/staking.go
@@ -100,6 +100,8 @@ func (app *stakingApplication) ExecuteTx(ctx *abci.Context, rawTx []byte) error 
 		return app.addEscrow(ctx, state, &tx.TxAddEscrow.SignedEscrow)
 	} else if tx.TxReclaimEscrow != nil {
 		return app.reclaimEscrow(ctx, state, &tx.TxReclaimEscrow.SignedReclaimEscrow)
+	} else if tx.TxAmendCommissionSchedule != nil {
+		return app.amendCommissionSchedule(ctx, state, &tx.TxAmendCommissionSchedule.SignedAmendCommissionSchedule)
 	}
 	return staking.ErrInvalidArgument
 }

--- a/go/consensus/tendermint/apps/staking/state/state.go
+++ b/go/consensus/tendermint/apps/staking/state/state.go
@@ -128,40 +128,13 @@ func (s *ImmutableState) RewardSchedule() ([]staking.RewardStep, error) {
 	return params.RewardSchedule, nil
 }
 
-func (s *ImmutableState) CommissionRateChangeInterval() (epochtime.EpochTime, error) {
+func (s *ImmutableState) CommissionScheduleRules() (*staking.CommissionScheduleRules, error) {
 	params, err := s.ConsensusParameters()
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
-	return params.CommissionRateChangeInterval, nil
-}
-
-func (s *ImmutableState) CommissionRateBoundLead() (epochtime.EpochTime, error) {
-	params, err := s.ConsensusParameters()
-	if err != nil {
-		return 0, err
-	}
-
-	return params.CommissionRateBoundLead, nil
-}
-
-func (s *ImmutableState) CommissionScheduleMaxRateSteps() (int, error) {
-	params, err := s.ConsensusParameters()
-	if err != nil {
-		return 0, err
-	}
-
-	return params.CommissionScheduleMaxRateSteps, nil
-}
-
-func (s *ImmutableState) CommissionScheduleMaxBoundSteps() (int, error) {
-	params, err := s.ConsensusParameters()
-	if err != nil {
-		return 0, err
-	}
-
-	return params.CommissionScheduleMaxBoundSteps, nil
+	return &params.CommissionScheduleRules, nil
 }
 
 func (s *ImmutableState) AcceptableTransferPeers() (map[signature.PublicKey]bool, error) {

--- a/go/consensus/tendermint/apps/staking/state/state.go
+++ b/go/consensus/tendermint/apps/staking/state/state.go
@@ -605,8 +605,37 @@ func (s *MutableState) AddRewards(time epochtime.EpochTime, factor *quantity.Qua
 			continue
 		}
 
-		if err := quantity.Move(&ent.Escrow.Active.Balance, commonPool, q); err != nil {
-			return errors.Wrap(err, "transferring to active escrow balance from common pool")
+		var com *quantity.Quantity
+		rate := ent.Escrow.CommissionSchedule.CurrentRate(time)
+		if rate != nil {
+			com = q.Clone()
+			// Multiply first.
+			if err := com.Mul(rate); err != nil {
+				return errors.Wrap(err, "multiplying by commission rate")
+			}
+			if err := com.Quo(staking.CommissionRateDenominator); err != nil {
+				return errors.Wrap(err, "dividing by commission rate denominator")
+			}
+
+			if err := q.Sub(com); err != nil {
+				return errors.Wrap(err, "subtracting commission")
+			}
+		}
+
+		if !q.IsZero() {
+			if err := quantity.Move(&ent.Escrow.Active.Balance, commonPool, q); err != nil {
+				return errors.Wrap(err, "transferring to active escrow balance from common pool")
+			}
+		}
+
+		if com != nil && !com.IsZero() {
+			delegation := s.Delegation(id, id)
+
+			if err := ent.Escrow.Active.Deposit(&delegation.Shares, commonPool, com); err != nil {
+				return errors.Wrap(err, "depositing commission")
+			}
+
+			s.SetDelegation(id, id, delegation)
 		}
 
 		s.SetAccount(id, ent)

--- a/go/consensus/tendermint/apps/staking/state/state.go
+++ b/go/consensus/tendermint/apps/staking/state/state.go
@@ -146,6 +146,24 @@ func (s *ImmutableState) CommissionRateBoundLead() (epochtime.EpochTime, error) 
 	return params.CommissionRateBoundLead, nil
 }
 
+func (s *ImmutableState) CommissionScheduleMaxRateSteps() (int, error) {
+	params, err := s.ConsensusParameters()
+	if err != nil {
+		return 0, err
+	}
+
+	return params.CommissionScheduleMaxRateSteps, nil
+}
+
+func (s *ImmutableState) CommissionScheduleMaxBoundSteps() (int, error) {
+	params, err := s.ConsensusParameters()
+	if err != nil {
+		return 0, err
+	}
+
+	return params.CommissionScheduleMaxBoundSteps, nil
+}
+
 func (s *ImmutableState) AcceptableTransferPeers() (map[signature.PublicKey]bool, error) {
 	params, err := s.ConsensusParameters()
 	if err != nil {

--- a/go/consensus/tendermint/apps/staking/state/state.go
+++ b/go/consensus/tendermint/apps/staking/state/state.go
@@ -128,6 +128,24 @@ func (s *ImmutableState) RewardSchedule() ([]staking.RewardStep, error) {
 	return params.RewardSchedule, nil
 }
 
+func (s *ImmutableState) CommissionRateChangeInterval() (epochtime.EpochTime, error) {
+	params, err := s.ConsensusParameters()
+	if err != nil {
+		return 0, err
+	}
+
+	return params.CommissionRateChangeInterval, nil
+}
+
+func (s *ImmutableState) CommissionRateBoundLead() (epochtime.EpochTime, error) {
+	params, err := s.ConsensusParameters()
+	if err != nil {
+		return 0, err
+	}
+
+	return params.CommissionRateBoundLead, nil
+}
+
 func (s *ImmutableState) AcceptableTransferPeers() (map[signature.PublicKey]bool, error) {
 	params, err := s.ConsensusParameters()
 	if err != nil {

--- a/go/consensus/tendermint/apps/staking/state/state_test.go
+++ b/go/consensus/tendermint/apps/staking/state/state_test.go
@@ -106,7 +106,7 @@ func TestRewardAndSlash(t *testing.T) {
 	require.NoError(t, err, "slash escrow")
 	require.True(t, slashedNonzero, "slashed nonzero")
 
-	// 10% loss.
+	// 40 token loss.
 	delegatorAccount = s.Account(delegatorID)
 	require.Equal(t, mustInitQuantity(t, 100), delegatorAccount.General.Balance, "slash - delegator general")
 	escrowAccount = s.Account(escrowID)

--- a/go/consensus/tendermint/apps/staking/state/state_test.go
+++ b/go/consensus/tendermint/apps/staking/state/state_test.go
@@ -55,7 +55,7 @@ func TestRewardAndSlash(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, escrowAccount.Escrow.CommissionSchedule.PruneAndValidateForGenesis(0, 10), "commission schedule")
+	require.NoError(t, escrowAccount.Escrow.CommissionSchedule.PruneAndValidateForGenesis(0, 10, 4, 12), "commission schedule")
 
 	del := &staking.Delegation{}
 	require.NoError(t, escrowAccount.Escrow.Active.Deposit(&del.Shares, &delegatorAccount.General.Balance, mustInitQuantityP(t, 100)), "active escrow deposit")
@@ -80,8 +80,10 @@ func TestRewardAndSlash(t *testing.T) {
 				Scale: mustInitQuantity(t, 500),
 			},
 		},
-		CommissionRateChangeInterval: 10,
-		CommissionRateBoundLead:      30,
+		CommissionRateChangeInterval:    10,
+		CommissionRateBoundLead:         30,
+		CommissionScheduleMaxRateSteps:  4,
+		CommissionScheduleMaxBoundSteps: 12,
 	})
 	s.SetCommonPool(mustInitQuantityP(t, 10000))
 

--- a/go/consensus/tendermint/apps/staking/state/state_test.go
+++ b/go/consensus/tendermint/apps/staking/state/state_test.go
@@ -55,7 +55,12 @@ func TestRewardAndSlash(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, escrowAccount.Escrow.CommissionSchedule.PruneAndValidateForGenesis(0, 10, 4, 12), "commission schedule")
+	require.NoError(t, escrowAccount.Escrow.CommissionSchedule.PruneAndValidateForGenesis(&staking.CommissionScheduleRules{
+		RateChangeInterval: 10,
+		RateBoundLead:      30,
+		MaxRateSteps:       4,
+		MaxBoundSteps:      12,
+	}, 0), "commission schedule")
 
 	del := &staking.Delegation{}
 	require.NoError(t, escrowAccount.Escrow.Active.Deposit(&del.Shares, &delegatorAccount.General.Balance, mustInitQuantityP(t, 100)), "active escrow deposit")
@@ -80,10 +85,12 @@ func TestRewardAndSlash(t *testing.T) {
 				Scale: mustInitQuantity(t, 500),
 			},
 		},
-		CommissionRateChangeInterval:    10,
-		CommissionRateBoundLead:         30,
-		CommissionScheduleMaxRateSteps:  4,
-		CommissionScheduleMaxBoundSteps: 12,
+		CommissionScheduleRules: staking.CommissionScheduleRules{
+			RateChangeInterval: 10,
+			RateBoundLead:      30,
+			MaxRateSteps:       4,
+			MaxBoundSteps:      12,
+		},
 	})
 	s.SetCommonPool(mustInitQuantityP(t, 10000))
 

--- a/go/consensus/tendermint/apps/staking/transactions.go
+++ b/go/consensus/tendermint/apps/staking/transactions.go
@@ -362,13 +362,6 @@ func (app *stakingApplication) amendCommissionSchedule(ctx *abci.Context, state 
 		return err
 	}
 
-	commit := true
-	defer func() {
-		if commit {
-			state.SetAccount(id, from)
-		}
-	}()
-
 	epoch, err := app.state.GetEpoch(ctx.Ctx(), ctx.BlockHeight()+1)
 	if err != nil {
 		return err
@@ -379,8 +372,10 @@ func (app *stakingApplication) amendCommissionSchedule(ctx *abci.Context, state 
 			"err", err,
 			"from", id,
 		)
-		commit = false
+		return err
 	}
+
+	state.SetAccount(id, from)
 
 	return nil
 }

--- a/go/consensus/tendermint/apps/staking/transactions.go
+++ b/go/consensus/tendermint/apps/staking/transactions.go
@@ -367,7 +367,7 @@ func (app *stakingApplication) amendCommissionSchedule(ctx *abci.Context, state 
 		return err
 	}
 
-	if err = from.Escrow.CommissionSchedule.AmendAndPruneAndValidate(&amendCommissionSchedule.Amendment, epoch, params.CommissionRateChangeInterval, params.CommissionRateBoundLead, params.CommissionScheduleMaxRateSteps, params.CommissionScheduleMaxBoundSteps); err != nil {
+	if err = from.Escrow.CommissionSchedule.AmendAndPruneAndValidate(&amendCommissionSchedule.Amendment, &params.CommissionScheduleRules, epoch); err != nil {
 		app.logger.Error("AmendCommissionSchedule: amendment not acceptable",
 			"err", err,
 			"from", id,

--- a/go/consensus/tendermint/apps/staking/transactions.go
+++ b/go/consensus/tendermint/apps/staking/transactions.go
@@ -367,7 +367,7 @@ func (app *stakingApplication) amendCommissionSchedule(ctx *abci.Context, state 
 		return err
 	}
 
-	if err = from.Escrow.CommissionSchedule.AmendAndPruneAndValidate(&amendCommissionSchedule.Amendment, epoch, params.CommissionRateChangeInterval, params.CommissionRateBoundLead); err != nil {
+	if err = from.Escrow.CommissionSchedule.AmendAndPruneAndValidate(&amendCommissionSchedule.Amendment, epoch, params.CommissionRateChangeInterval, params.CommissionRateBoundLead, params.CommissionScheduleMaxRateSteps, params.CommissionScheduleMaxBoundSteps); err != nil {
 		app.logger.Error("AmendCommissionSchedule: amendment not acceptable",
 			"err", err,
 			"from", id,

--- a/go/consensus/tendermint/staking/staking.go
+++ b/go/consensus/tendermint/staking/staking.go
@@ -153,6 +153,19 @@ func (tb *tendermintBackend) ReclaimEscrow(ctx context.Context, signedReclaim *a
 	return nil
 }
 
+func (tb *tendermintBackend) AmendCommissionSchedule(ctx context.Context, signedAmendCommissionSchedule *api.SignedAmendCommissionSchedule) error {
+	tx := app.Tx{
+		TxAmendCommissionSchedule: &app.TxAmendCommissionSchedule{
+			SignedAmendCommissionSchedule: *signedAmendCommissionSchedule,
+		},
+	}
+	if err := tb.service.BroadcastTx(ctx, app.TransactionTag, tx, true); err != nil {
+		return errors.Wrap(err, "staking: amend commission schedule transaction failed")
+	}
+
+	return nil
+}
+
 func (tb *tendermintBackend) SubmitEvidence(ctx context.Context, evidence api.Evidence) error {
 	if evidence.Kind() != api.EvidenceKindConsensus {
 		return errors.New("staking: unsupported evidence kind")

--- a/go/genesis/api/api.go
+++ b/go/genesis/api/api.go
@@ -89,7 +89,7 @@ func (d *Document) SanityCheck() error {
 	if err = d.RootHash.SanityCheck(); err != nil {
 		return err
 	}
-	if err = d.Staking.SanityCheck(); err != nil {
+	if err = d.Staking.SanityCheck(d.EpochTime.Base); err != nil {
 		return err
 	}
 	if err = d.KeyManager.SanityCheck(); err != nil {

--- a/go/grpc/staking/staking.proto
+++ b/go/grpc/staking/staking.proto
@@ -19,6 +19,7 @@ service Staking {
 	rpc Burn(BurnRequest) returns (BurnResponse) {}
 	rpc AddEscrow(AddEscrowRequest) returns (AddEscrowResponse) {}
 	rpc ReclaimEscrow(ReclaimEscrowRequest) returns (ReclaimEscrowResponse) {}
+	rpc AmendCommissionSchedule(AmendCommissionScheduleRequest) returns (AmendCommissionScheduleResponse) {}
 
 	// Calls that watch events.
 	rpc WatchTransfers (WatchTransfersRequest) returns (stream WatchTransfersResponse) {}
@@ -118,6 +119,12 @@ message ReclaimEscrowRequest {
 }
 
 message ReclaimEscrowResponse {}
+
+message AmendCommissionScheduleRequest {
+	bytes signed_amend_commission_schedule = 1;
+}
+
+message AmendCommissionScheduleResponse {}
 
 message WatchTransfersRequest {}
 

--- a/go/oasis-test-runner/scenario/e2e/stake_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/stake_cli.go
@@ -374,7 +374,7 @@ func (s *stakeCLIImpl) genTransferTx(childEnv *env.Env, amount int, nonce int, d
 
 	args := []string{
 		"stake", "account", "gen_transfer",
-		"--" + stake.CfgTxAmount, strconv.Itoa(amount),
+		"--" + stake.CfgAmount, strconv.Itoa(amount),
 		"--" + stake.CfgTxNonce, strconv.Itoa(nonce),
 		"--" + stake.CfgTxFile, txPath,
 		"--" + stake.CfgTransferDestination, dst.String(),
@@ -395,7 +395,7 @@ func (s *stakeCLIImpl) genBurnTx(childEnv *env.Env, amount int, nonce int, txPat
 
 	args := []string{
 		"stake", "account", "gen_burn",
-		"--" + stake.CfgTxAmount, strconv.Itoa(amount),
+		"--" + stake.CfgAmount, strconv.Itoa(amount),
 		"--" + stake.CfgTxNonce, strconv.Itoa(nonce),
 		"--" + stake.CfgTxFile, txPath,
 		"--" + stake.CfgTxFeeAmount, strconv.Itoa(feeAmount),
@@ -415,7 +415,7 @@ func (s *stakeCLIImpl) genEscrowTx(childEnv *env.Env, amount int, nonce int, esc
 
 	args := []string{
 		"stake", "account", "gen_escrow",
-		"--" + stake.CfgTxAmount, strconv.Itoa(amount),
+		"--" + stake.CfgAmount, strconv.Itoa(amount),
 		"--" + stake.CfgTxNonce, strconv.Itoa(nonce),
 		"--" + stake.CfgTxFile, txPath,
 		"--" + stake.CfgEscrowAccount, escrow.String(),
@@ -436,7 +436,7 @@ func (s *stakeCLIImpl) genReclaimEscrowTx(childEnv *env.Env, amount int, nonce i
 
 	args := []string{
 		"stake", "account", "gen_reclaim_escrow",
-		"--" + stake.CfgTxAmount, strconv.Itoa(amount),
+		"--" + stake.CfgAmount, strconv.Itoa(amount),
 		"--" + stake.CfgTxNonce, strconv.Itoa(nonce),
 		"--" + stake.CfgTxFile, txPath,
 		"--" + stake.CfgEscrowAccount, escrow.String(),

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -472,15 +472,17 @@ type Genesis struct {
 
 // ConsensusParameters are the staking consensus parameters.
 type ConsensusParameters struct {
-	Thresholds                   map[ThresholdKind]quantity.Quantity `json:"thresholds,omitempty"`
-	DebondingInterval            epochtime.EpochTime                 `json:"debonding_interval,omitempty"`
-	RewardSchedule               []RewardStep                        `json:"reward_schedule,omitempty"`
-	CommissionRateChangeInterval epochtime.EpochTime                 `json:"commission_rate_change_interval,omitempty"`
-	CommissionRateBoundLead      epochtime.EpochTime                 `json:"commission_rate_bound_lead,omitempty"`
-	AcceptableTransferPeers      map[signature.PublicKey]bool        `json:"acceptable_transfer_peers,omitempty"`
-	Slashing                     map[SlashReason]Slash               `json:"slashing,omitempty"`
-	GasCosts                     gas.Costs                           `json:"gas_costs,omitempty"`
-	MinDelegationAmount          quantity.Quantity                   `json:"min_delegation,omitempty"`
+	Thresholds                      map[ThresholdKind]quantity.Quantity `json:"thresholds,omitempty"`
+	DebondingInterval               epochtime.EpochTime                 `json:"debonding_interval,omitempty"`
+	RewardSchedule                  []RewardStep                        `json:"reward_schedule,omitempty"`
+	CommissionRateChangeInterval    epochtime.EpochTime                 `json:"commission_rate_change_interval,omitempty"`
+	CommissionRateBoundLead         epochtime.EpochTime                 `json:"commission_rate_bound_lead,omitempty"`
+	CommissionScheduleMaxRateSteps  int                                 `json:"commission_schedule_max_rate_steps,omitempty"`
+	CommissionScheduleMaxBoundSteps int                                 `json:"commission_schedule_max_bound_steps,omitempty"`
+	AcceptableTransferPeers         map[signature.PublicKey]bool        `json:"acceptable_transfer_peers,omitempty"`
+	Slashing                        map[SlashReason]Slash               `json:"slashing,omitempty"`
+	GasCosts                        gas.Costs                           `json:"gas_costs,omitempty"`
+	MinDelegationAmount             quantity.Quantity                   `json:"min_delegation,omitempty"`
 }
 
 // SanityCheck performs a sanity check on the consensus parameters.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -100,6 +100,9 @@ type Backend interface {
 	// back into the owner's general balance.
 	ReclaimEscrow(ctx context.Context, signedReclaim *SignedReclaimEscrow) error
 
+	// AmendCommissionSchedule amends the signer's commission schedule.
+	AmendCommissionSchedule(ctx context.Context, signedAmendCommissionSchedule *SignedAmendCommissionSchedule) error
+
 	// SubmitEvidence submits evidence of misbehavior.
 	SubmitEvidence(ctx context.Context, evidence Evidence) error
 

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -427,12 +427,6 @@ type DebondingDelegation struct {
 	DebondEndTime epochtime.EpochTime `json:"debond_end"`
 }
 
-// RewardStep is one of the time periods in the reward schedule.
-type RewardStep struct {
-	Until epochtime.EpochTime `json:"until"`
-	Scale quantity.Quantity   `json:"scale"`
-}
-
 // Genesis is the initial ledger balances at genesis for use in the genesis
 // block and test cases.
 type Genesis struct {

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -534,7 +534,7 @@ func (g *Genesis) SanityCheck(now epochtime.EpochTime) error {
 		_ = total.Add(&acct.Escrow.Debonding.Balance)
 
 		commissionStateShallowCopy := acct.Escrow.CommissionSchedule
-		if err := commissionStateShallowCopy.PruneAndValidateForGenesis(now, g.Parameters.CommissionRateChangeInterval); err != nil {
+		if err := commissionStateShallowCopy.PruneAndValidateForGenesis(now, g.Parameters.CommissionRateChangeInterval, g.Parameters.CommissionScheduleMaxRateSteps, g.Parameters.CommissionScheduleMaxBoundSteps); err != nil {
 			return fmt.Errorf("staking: sanity check failed: commission schedule for %s is invalid: %+v", id, err)
 		}
 	}

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -39,7 +39,7 @@ var (
 	ReclaimEscrowSignatureContext = signature.NewContext("oasis-core/staking: reclaim escrow", signature.WithChainSeparation())
 
 	// AmendCommissionScheduleSignatureContext is the context used for escrow reclimation.
-	AmendCommissionScheduleSignatureContext = signature.NewContext("oasis-core/staking: amend commission schedule")
+	AmendCommissionScheduleSignatureContext = signature.NewContext("oasis-core/staking: amend commission schedule", signature.WithChainSeparation())
 
 	// ErrInvalidArgument is the error returned on malformed arguments.
 	ErrInvalidArgument = errors.New("staking: invalid argument")

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -472,17 +472,14 @@ type Genesis struct {
 
 // ConsensusParameters are the staking consensus parameters.
 type ConsensusParameters struct {
-	Thresholds                      map[ThresholdKind]quantity.Quantity `json:"thresholds,omitempty"`
-	DebondingInterval               epochtime.EpochTime                 `json:"debonding_interval,omitempty"`
-	RewardSchedule                  []RewardStep                        `json:"reward_schedule,omitempty"`
-	CommissionRateChangeInterval    epochtime.EpochTime                 `json:"commission_rate_change_interval,omitempty"`
-	CommissionRateBoundLead         epochtime.EpochTime                 `json:"commission_rate_bound_lead,omitempty"`
-	CommissionScheduleMaxRateSteps  int                                 `json:"commission_schedule_max_rate_steps,omitempty"`
-	CommissionScheduleMaxBoundSteps int                                 `json:"commission_schedule_max_bound_steps,omitempty"`
-	AcceptableTransferPeers         map[signature.PublicKey]bool        `json:"acceptable_transfer_peers,omitempty"`
-	Slashing                        map[SlashReason]Slash               `json:"slashing,omitempty"`
-	GasCosts                        gas.Costs                           `json:"gas_costs,omitempty"`
-	MinDelegationAmount             quantity.Quantity                   `json:"min_delegation,omitempty"`
+	Thresholds              map[ThresholdKind]quantity.Quantity `json:"thresholds,omitempty"`
+	DebondingInterval       epochtime.EpochTime                 `json:"debonding_interval,omitempty"`
+	RewardSchedule          []RewardStep                        `json:"reward_schedule,omitempty"`
+	CommissionScheduleRules CommissionScheduleRules             `json:"commission_schedule_rules,omitempty"`
+	AcceptableTransferPeers map[signature.PublicKey]bool        `json:"acceptable_transfer_peers,omitempty"`
+	Slashing                map[SlashReason]Slash               `json:"slashing,omitempty"`
+	GasCosts                gas.Costs                           `json:"gas_costs,omitempty"`
+	MinDelegationAmount     quantity.Quantity                   `json:"min_delegation,omitempty"`
 }
 
 // SanityCheck performs a sanity check on the consensus parameters.
@@ -534,7 +531,7 @@ func (g *Genesis) SanityCheck(now epochtime.EpochTime) error {
 		_ = total.Add(&acct.Escrow.Debonding.Balance)
 
 		commissionStateShallowCopy := acct.Escrow.CommissionSchedule
-		if err := commissionStateShallowCopy.PruneAndValidateForGenesis(now, g.Parameters.CommissionRateChangeInterval, g.Parameters.CommissionScheduleMaxRateSteps, g.Parameters.CommissionScheduleMaxBoundSteps); err != nil {
+		if err := commissionStateShallowCopy.PruneAndValidateForGenesis(&g.Parameters.CommissionScheduleRules, now); err != nil {
 			return fmt.Errorf("staking: sanity check failed: commission schedule for %s is invalid: %+v", id, err)
 		}
 	}

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -38,6 +38,9 @@ var (
 	// ReclaimEscrowSignatureContext is the context used for escrow reclimation.
 	ReclaimEscrowSignatureContext = signature.NewContext("oasis-core/staking: reclaim escrow", signature.WithChainSeparation())
 
+	// AmendCommissionScheduleSignatureContext is the context used for escrow reclimation.
+	AmendCommissionScheduleSignatureContext = signature.NewContext("oasis-core/staking: amend commission schedule")
+
 	// ErrInvalidArgument is the error returned on malformed arguments.
 	ErrInvalidArgument = errors.New("staking: invalid argument")
 
@@ -193,6 +196,14 @@ type ReclaimEscrow struct {
 	Shares  quantity.Quantity   `json:"reclaim_shares"`
 }
 
+// AmendCommissionSchedule is an amendment to a commission schedule.
+type AmendCommissionSchedule struct {
+	Nonce uint64  `json:"nonce"`
+	Fee   gas.Fee `json:"fee"`
+
+	Amendment CommissionSchedule `json:"amendment"`
+}
+
 // SignedTransfer is a Transfer, signed by the owner (source) entity.
 type SignedTransfer struct {
 	signature.Signed
@@ -257,6 +268,23 @@ func SignReclaimEscrow(signer signature.Signer, reclaim *ReclaimEscrow) (*Signed
 	}
 
 	return &SignedReclaimEscrow{
+		Signed: *signed,
+	}, nil
+}
+
+// SignedAmendCommissionSchedule is a ReclaimEscrow, signed by the owner entity.
+type SignedAmendCommissionSchedule struct {
+	signature.Signed
+}
+
+// SignReclaimEscrow serializes the Reclaim and signs the result.
+func SignAmendCommissionSchedule(signer signature.Signer, amendCommissionSchedule *AmendCommissionSchedule) (*SignedAmendCommissionSchedule, error) {
+	signed, err := signature.SignSigned(signer, AmendCommissionScheduleSignatureContext, amendCommissionSchedule)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SignedAmendCommissionSchedule{
 		Signed: *signed,
 	}, nil
 }
@@ -567,4 +595,6 @@ const (
 	GasOpAddEscrow gas.Op = "add_escrow"
 	// GasOpReclaimEscrow is the gas operation identifier for reclaim escrow.
 	GasOpReclaimEscrow gas.Op = "reclaim_escrow"
+	// GasOpAmendCommissionSchedule is the gas operation identifier for amend commission schedule.
+	GasOpAmendCommissionSchedule gas.Op = "amend_commission_schedule"
 )

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -403,8 +403,9 @@ type GeneralAccount struct {
 // EscrowAccount is an escrow account the balance of which is subject to
 // special delegation provisions and a debonding period.
 type EscrowAccount struct {
-	Active    SharePool `json:"active"`
-	Debonding SharePool `json:"debonding"`
+	Active             SharePool          `json:"active"`
+	Debonding          SharePool          `json:"debonding"`
+	CommissionSchedule CommissionSchedule `json:"commission_schedule"`
 }
 
 // Account is an entry in the staking ledger.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -444,13 +444,15 @@ type Genesis struct {
 
 // ConsensusParameters are the staking consensus parameters.
 type ConsensusParameters struct {
-	Thresholds              map[ThresholdKind]quantity.Quantity `json:"thresholds,omitempty"`
-	DebondingInterval       epochtime.EpochTime                 `json:"debonding_interval,omitempty"`
-	RewardSchedule          []RewardStep                        `json:"reward_schedule,omitempty"`
-	AcceptableTransferPeers map[signature.PublicKey]bool        `json:"acceptable_transfer_peers,omitempty"`
-	Slashing                map[SlashReason]Slash               `json:"slashing,omitempty"`
-	GasCosts                gas.Costs                           `json:"gas_costs,omitempty"`
-	MinDelegationAmount     quantity.Quantity                   `json:"min_delegation,omitempty"`
+	Thresholds                   map[ThresholdKind]quantity.Quantity `json:"thresholds,omitempty"`
+	DebondingInterval            epochtime.EpochTime                 `json:"debonding_interval,omitempty"`
+	RewardSchedule               []RewardStep                        `json:"reward_schedule,omitempty"`
+	CommissionRateChangeInterval epochtime.EpochTime                 `json:"commission_rate_change_interval,omitempty"`
+	CommissionRateBoundLead      epochtime.EpochTime                 `json:"commission_rate_bound_lead,omitempty"`
+	AcceptableTransferPeers      map[signature.PublicKey]bool        `json:"acceptable_transfer_peers,omitempty"`
+	Slashing                     map[SlashReason]Slash               `json:"slashing,omitempty"`
+	GasCosts                     gas.Costs                           `json:"gas_costs,omitempty"`
+	MinDelegationAmount          quantity.Quantity                   `json:"min_delegation,omitempty"`
 }
 
 // SanityCheck performs a sanity check on the consensus parameters.

--- a/go/staking/api/commission.go
+++ b/go/staking/api/commission.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"github.com/oasislabs/oasis-core/go/common/quantity"
+	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
+)
+
+// CommissionRateDenominator is the denominator for the commission rate.
+var CommissionRateDenominator *quantity.Quantity
+
+type CommissionRateStep struct {
+	Start epochtime.EpochTime `json:"start"`
+	Rate  quantity.Quantity   `json:"rate"`
+}
+
+type CommissionRateBoundStep struct {
+	Start   epochtime.EpochTime `json:"start"`
+	RateMin quantity.Quantity   `json:"rate_min"`
+	RateMax quantity.Quantity   `json:"rate_max"`
+}
+
+type CommissionSchedule struct {
+	Rates  []CommissionRateStep      `json:"rates"`
+	Bounds []CommissionRateBoundStep `json:"bounds"`
+}
+
+func init() {
+	// Denominated in 1000th of a percent.
+	CommissionRateDenominator = quantity.NewQuantity()
+	err := CommissionRateDenominator.FromInt64(100_000)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/go/staking/api/commission.go
+++ b/go/staking/api/commission.go
@@ -1,6 +1,10 @@
 package api
 
 import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
 	"github.com/oasislabs/oasis-core/go/common/quantity"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 )
@@ -22,6 +26,237 @@ type CommissionRateBoundStep struct {
 type CommissionSchedule struct {
 	Rates  []CommissionRateStep      `json:"rates"`
 	Bounds []CommissionRateBoundStep `json:"bounds"`
+}
+
+// validateNondegenerate detects degenerate steps.
+func (cs *CommissionSchedule) validateNondegenerate(commissionRateChangeInterval epochtime.EpochTime) error {
+	for i, step := range cs.Rates {
+		if step.Start%commissionRateChangeInterval != 0 {
+			return fmt.Errorf("rate step %d start epoch %d not aligned with commission rate change interval %d", i, step.Start, commissionRateChangeInterval)
+		}
+		if i > 0 && step.Start <= cs.Rates[i-1].Start {
+			return fmt.Errorf("rate step %d start epoch %d not after previous step start epoch %d", i, step.Start, cs.Rates[i-1].Start)
+		}
+		if step.Rate.Cmp(CommissionRateDenominator) > 0 {
+			return fmt.Errorf("rate step %d rate %v/%v over unity", i, step.Rate, CommissionRateDenominator)
+		}
+	}
+
+	for i, step := range cs.Bounds {
+		if step.Start%commissionRateChangeInterval != 0 {
+			return fmt.Errorf("bound step %d start epoch %d not aligned with commission rate change interval %d", i, step.Start, commissionRateChangeInterval)
+		}
+		if i > 0 && step.Start <= cs.Rates[i-1].Start {
+			return fmt.Errorf("bound step %d start epoch %d not after previous step start epoch %d", i, step.Start, cs.Rates[i-1].Start)
+		}
+		if step.RateMin.Cmp(CommissionRateDenominator) > 0 {
+			return fmt.Errorf("bound step %d minimum rate %v/%v over unity", i, step.RateMin, CommissionRateDenominator)
+		}
+		if step.RateMax.Cmp(CommissionRateDenominator) > 0 {
+			return fmt.Errorf("bound step %d maximum rate %v/%v over unity", i, step.RateMax, CommissionRateDenominator)
+		}
+		if step.RateMax.Cmp(&step.RateMin) < 0 {
+			return fmt.Errorf("bound step %d maximum rate %v/%v less than minimum rate %v/%v", i, step.RateMax, CommissionRateDenominator, step.RateMin, CommissionRateDenominator)
+		}
+	}
+
+	return nil
+}
+
+// validateAmendmentAcceptable apply policy for "when" changes can be made, for CommissionSchedules that are amendments.
+func (cs *CommissionSchedule) validateAmendmentAcceptable(now epochtime.EpochTime, commissionRateBoundLead epochtime.EpochTime) error {
+	if len(cs.Rates) != 0 {
+		if cs.Rates[0].Start <= now {
+			return fmt.Errorf("rate schedule with start epoch %d must not alter rate on or before %d", cs.Rates[0].Start, now)
+		}
+	}
+
+	if len(cs.Bounds) != 0 {
+		if cs.Bounds[0].Start <= now+commissionRateBoundLead {
+			return fmt.Errorf("bound schedule with start epoch %d must not alter bound on or before %d", cs.Bounds[0].Start, now+commissionRateBoundLead)
+		}
+	}
+
+	return nil
+}
+
+// prune discards past steps that aren't in effect anymore.
+func (cs *CommissionSchedule) prune(now epochtime.EpochTime) {
+	for len(cs.Rates) > 1 {
+		if cs.Rates[1].Start > now {
+			// Remaining steps haven't started yet, so keep them and the current active one.
+			break
+		}
+
+		cs.Rates = cs.Rates[1:]
+	}
+
+	for len(cs.Bounds) > 1 {
+		if cs.Bounds[1].Start > now {
+			// Remaining steps haven't started yet, so keep them and the current active one.
+			break
+		}
+
+		cs.Bounds = cs.Bounds[1:]
+	}
+}
+
+// amend changes the schedule to use new given steps, replacing steps that are fully covered in the amendment.
+func (cs *CommissionSchedule) amend(amendment *CommissionSchedule) {
+	if len(amendment.Rates) != 0 {
+		rateSpliceIndex := 0
+		for ; rateSpliceIndex < len(cs.Rates); rateSpliceIndex++ {
+			if cs.Rates[rateSpliceIndex].Start >= amendment.Rates[0].Start {
+				// This and remaining steps are completely overwritten by the amendment.
+				break
+			}
+		}
+		cs.Rates = append(cs.Rates[:rateSpliceIndex], amendment.Rates...)
+	}
+
+	if len(amendment.Bounds) != 0 {
+		boundSpliceIndex := 0
+		for ; boundSpliceIndex < len(cs.Bounds); boundSpliceIndex++ {
+			if cs.Bounds[boundSpliceIndex].Start >= amendment.Bounds[0].Start {
+				// This and remaining steps are completely overwritten by the amendment.
+				break
+			}
+		}
+		cs.Bounds = append(cs.Bounds[:boundSpliceIndex], amendment.Bounds...)
+	}
+}
+
+// validateWithinBound detects rates out of bound.
+func (cs *CommissionSchedule) validateWithinBound(start epochtime.EpochTime) error {
+	if len(cs.Rates) == 0 && len(cs.Bounds) == 0 {
+		// Nothing to check.
+		return nil
+	}
+
+	if len(cs.Rates) == 0 {
+		return fmt.Errorf("rates missing")
+	}
+	currentRateIndex := 0
+	currentRate := &cs.Rates[currentRateIndex]
+	if currentRate.Start > start {
+		return fmt.Errorf("rate schedule start epoch %d after %d", currentRate.Start, start)
+	}
+
+	if len(cs.Bounds) == 0 {
+		return fmt.Errorf("bounds missing")
+	}
+	currentBoundIndex := 0
+	currentBound := &cs.Bounds[currentBoundIndex]
+	if currentBound.Start > start {
+		return fmt.Errorf("bound schedule start epoch %d after %d", currentBound.Start, start)
+	}
+
+	diagnosticTime := start
+	for {
+		if currentRate.Rate.Cmp(&currentBound.RateMin) < 0 {
+			return fmt.Errorf("rate %v/%v from rate step %d less than minimum rate %v/%v from bound step %d at epoch %d",
+				currentRate.Rate, CommissionRateDenominator, currentRateIndex,
+				currentBound.RateMin, CommissionRateDenominator, currentBoundIndex,
+				diagnosticTime,
+			)
+		}
+		if currentRate.Rate.Cmp(&currentBound.RateMax) > 0 {
+			return fmt.Errorf("rate %v/%v from rate step %d greater than maximum rate %v/%v from bound step %d at epoch %d",
+				currentRate.Rate, CommissionRateDenominator, currentRateIndex,
+				currentBound.RateMax, CommissionRateDenominator, currentBoundIndex,
+				diagnosticTime,
+			)
+		}
+
+		// Determine what changes next.
+		nextRateIndex := currentRateIndex + 1
+		var nextRate *CommissionRateStep
+		if nextRateIndex < len(cs.Rates) {
+			nextRate = &cs.Rates[nextRateIndex]
+		} else {
+			nextRate = nil
+		}
+		nextBoundIndex := currentBoundIndex + 1
+		var nextBound *CommissionRateBoundStep
+		if nextBoundIndex < len(cs.Bounds) {
+			nextBound = &cs.Bounds[nextBoundIndex]
+		} else {
+			nextBound = nil
+		}
+
+		if nextRate == nil && nextBound == nil {
+			// Current rate and bound continue happily ever after.
+			break
+		}
+
+		if nextRate != nil {
+			if nextBound == nil || nextRate.Start <= nextBound.Start {
+				// Rate changes. Check with the new rate on next iteration.
+				currentRateIndex = nextRateIndex
+				currentRate = nextRate
+				diagnosticTime = nextRate.Start
+			}
+		}
+
+		if nextBound != nil {
+			if nextRate == nil || nextBound.Start <= nextRate.Start {
+				// Bound changes. Check with the new bound on the next iteration.
+				currentBoundIndex = nextBoundIndex
+				currentBound = nextBound
+				diagnosticTime = nextBound.Start
+			}
+		}
+	}
+
+	return nil
+}
+
+// PruneAndValidateForGenesis gets a schedule ready for use in the genesis document.
+// Returns an error if there is a validation failure. If it does, the schedule may be pruned already.
+func (cs *CommissionSchedule) PruneAndValidateForGenesis(now epochtime.EpochTime, commissionRateChangeInterval epochtime.EpochTime) error {
+	if err := cs.validateNondegenerate(commissionRateChangeInterval); err != nil {
+		return err
+	}
+	// If we, for example, import a snapshot as a genesis document, the current steps might not be cued up. So run a
+	// prune step too at this time.
+	cs.prune(now)
+	if err := cs.validateWithinBound(now); err != nil {
+		return errors.Wrap(err, "after pruning")
+	}
+	return nil
+}
+
+// AmendAndPruneAndValidate applies a proposed amendment to a valid schedule.
+// Returns an error if there is a validation failure. If it does, the schedule may be amended and pruned already.
+func (cs *CommissionSchedule) AmendAndPruneAndValidate(amendment *CommissionSchedule, now epochtime.EpochTime, commissionRateChangeInterval epochtime.EpochTime, commissionRateBoundLead epochtime.EpochTime) error {
+	if err := amendment.validateNondegenerate(commissionRateChangeInterval); err != nil {
+		return errors.Wrap(err, "amendment")
+	}
+	if err := amendment.validateAmendmentAcceptable(now, commissionRateBoundLead); err != nil {
+		return errors.Wrap(err, "amendment")
+	}
+	cs.prune(now)
+	cs.amend(amendment)
+	if err := cs.validateWithinBound(now); err != nil {
+		return errors.Wrap(err, "after pruning and amending")
+	}
+	return nil
+}
+
+// CurrentRate returns the rate at the latest rate step that has started or nil if no step has started.
+func (cs *CommissionSchedule) CurrentRate(now epochtime.EpochTime) *quantity.Quantity {
+	var latestStartedStep *CommissionRateStep
+	for i := range cs.Rates {
+		step := &cs.Rates[i]
+		if step.Start > now {
+			break
+		}
+		latestStartedStep = step
+	}
+	if latestStartedStep == nil {
+		return nil
+	}
+	return &latestStartedStep.Rate
 }
 
 func init() {

--- a/go/staking/api/commission_test.go
+++ b/go/staking/api/commission_test.go
@@ -1,0 +1,567 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasislabs/oasis-core/go/common/quantity"
+	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
+)
+
+func mustInitQuantity(t *testing.T, i int64) (q quantity.Quantity) {
+	require.NoError(t, q.FromInt64(i), "FromInt64")
+	return
+}
+
+func mustInitQuantityP(t *testing.T, i int64) *quantity.Quantity {
+	q := mustInitQuantity(t, i)
+	return &q
+}
+
+func requireErrorShowDiagnostic(t *testing.T, err error, msg string) {
+	require.Error(t, err, msg)
+	t.Log(msg+":", err)
+}
+
+func TestCommissionSchedule(t *testing.T) {
+	cs := CommissionSchedule{
+		Rates:  nil,
+		Bounds: nil,
+	}
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "empty")
+	require.Nil(t, cs.CurrentRate(0), "empty current rate")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "valid")
+
+	requireErrorShowDiagnostic(t, cs.AmendAndPruneAndValidate(&CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 11,
+				Rate:  mustInitQuantity(t, 60_000),
+			},
+		},
+		Bounds: nil,
+	}, 10, 10, 30), "amend unaligned")
+
+	requireErrorShowDiagnostic(t, cs.AmendAndPruneAndValidate(&CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 10,
+				Rate:  mustInitQuantity(t, 60_000),
+			},
+		},
+		Bounds: nil,
+	}, 10, 10, 30), "amend rate start too early")
+
+	requireErrorShowDiagnostic(t, cs.AmendAndPruneAndValidate(&CommissionSchedule{
+		Rates: nil,
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   40,
+				RateMin: mustInitQuantity(t, 10_000),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}, 10, 10, 30), "amend bound start too early")
+
+	require.NoError(t, cs.AmendAndPruneAndValidate(&CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 20,
+				Rate:  mustInitQuantity(t, 60_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   50,
+				RateMin: mustInitQuantity(t, 10_000),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}, 10, 10, 30), "amend append")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+			{
+				Start: 50,
+				Rate:  mustInitQuantity(t, 60_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+			{
+				Start:   50,
+				RateMin: mustInitQuantity(t, 10_000),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}
+	require.Equal(t, mustInitQuantityP(t, 50_000), cs.CurrentRate(0), "current rate 0")
+	require.Equal(t, mustInitQuantityP(t, 50_000), cs.CurrentRate(1), "current rate 1")
+	require.Equal(t, mustInitQuantityP(t, 60_000), cs.CurrentRate(50), "current rate 1")
+	require.Equal(t, mustInitQuantityP(t, 60_000), cs.CurrentRate(999), "current rate 999")
+	require.NoError(t, cs.AmendAndPruneAndValidate(&CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 20,
+				Rate:  mustInitQuantity(t, 70_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   50,
+				RateMin: mustInitQuantity(t, 20_000),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}, 10, 10, 30), "amend replace")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 50_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.AmendAndPruneAndValidate(&CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 20,
+				Rate:  mustInitQuantity(t, 60_000),
+			},
+		},
+		Bounds: nil,
+	}, 10, 10, 30), "amend out of bound")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 1,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "unaligned rate step")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 10,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 60_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "reversed rate steps")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 60_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "zero-duration rate step")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 100_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "rate unity")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 110_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "rate over unity")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   1,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "unaligned bound step")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   10,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 90_000),
+			},
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "reversed bound steps")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 100_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 110_000),
+				RateMax: mustInitQuantity(t, 120_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "bound min over unity")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 110_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "bound max over unity")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 50_000),
+				RateMax: mustInitQuantity(t, 50_000),
+			},
+		},
+	}
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "bound exact")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 60_000),
+				RateMax: mustInitQuantity(t, 40_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "bound inverted")
+
+	cs = CommissionSchedule{
+		Rates: nil,
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "no rates")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 10,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "rates late start")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+		},
+		Bounds: nil,
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "no bounds")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   10,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "bounds late start")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 30_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 40_000),
+				RateMax: mustInitQuantity(t, 60_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "rate below min")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 70_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 40_000),
+				RateMax: mustInitQuantity(t, 60_000),
+			},
+		},
+	}
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "rate above max")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+			{
+				Start: 20,
+				Rate:  mustInitQuantity(t, 45_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+			{
+				Start:   10,
+				RateMin: mustInitQuantity(t, 40_000),
+				RateMax: mustInitQuantity(t, 60_000),
+			},
+		},
+	}
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "bound change then rate change")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+			{
+				Start: 10,
+				Rate:  mustInitQuantity(t, 45_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+			{
+				Start:   20,
+				RateMin: mustInitQuantity(t, 40_000),
+				RateMax: mustInitQuantity(t, 60_000),
+			},
+		},
+	}
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "rate change then bound change")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 10_000),
+			},
+			{
+				Start: 10,
+				Rate:  mustInitQuantity(t, 40_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 20_000),
+			},
+			{
+				Start:   10,
+				RateMin: mustInitQuantity(t, 30_000),
+				RateMax: mustInitQuantity(t, 50_000),
+			},
+		},
+	}
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "simultaneous rate and bound change")
+
+	cs = CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 0,
+				Rate:  mustInitQuantity(t, 10_000),
+			},
+			{
+				Start: 10,
+				Rate:  mustInitQuantity(t, 20_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   0,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+			{
+				Start:   10,
+				RateMin: mustInitQuantity(t, 10_000),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}
+	require.NoError(t, cs.PruneAndValidateForGenesis(1, 10), "prune no effect")
+	require.Equal(t, epochtime.EpochTime(0), cs.Rates[0].Start, "prune 1 rates start")
+	require.Equal(t, epochtime.EpochTime(0), cs.Bounds[0].Start, "prune 1 bounds start")
+	require.NoError(t, cs.PruneAndValidateForGenesis(10, 10), "prune rate step")
+	require.Equal(t, epochtime.EpochTime(10), cs.Rates[0].Start, "prune 10 rates start")
+	require.Equal(t, epochtime.EpochTime(10), cs.Bounds[0].Start, "prune 10 bounds start")
+}

--- a/go/staking/api/commission_test.go
+++ b/go/staking/api/commission_test.go
@@ -31,6 +31,41 @@ func TestCommissionSchedule(t *testing.T) {
 	}
 	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "empty")
 	require.Nil(t, cs.CurrentRate(0), "empty current rate")
+	require.NoError(t, cs.AmendAndPruneAndValidate(&CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 40,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   40,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}, 0, 10, 30), "amend init")
+
+	cs = CommissionSchedule{
+		Rates:  nil,
+		Bounds: nil,
+	}
+	requireErrorShowDiagnostic(t, cs.AmendAndPruneAndValidate(&CommissionSchedule{
+		Rates: []CommissionRateStep{
+			{
+				Start: 10,
+				Rate:  mustInitQuantity(t, 50_000),
+			},
+		},
+		Bounds: []CommissionRateBoundStep{
+			{
+				Start:   40,
+				RateMin: mustInitQuantity(t, 0),
+				RateMax: mustInitQuantity(t, 100_000),
+			},
+		},
+	}, 0, 10, 30), "amend init unsimultaneous")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{

--- a/go/staking/api/commission_test.go
+++ b/go/staking/api/commission_test.go
@@ -29,7 +29,7 @@ func TestCommissionSchedule(t *testing.T) {
 		Rates:  nil,
 		Bounds: nil,
 	}
-	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "empty")
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "empty")
 	require.Nil(t, cs.CurrentRate(0), "empty current rate")
 	require.NoError(t, cs.AmendAndPruneAndValidate(&CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -45,7 +45,7 @@ func TestCommissionSchedule(t *testing.T) {
 				RateMax: mustInitQuantity(t, 100_000),
 			},
 		},
-	}, 0, 10, 30), "amend init")
+	}, 0, 10, 30, 4, 12), "amend init")
 
 	cs = CommissionSchedule{
 		Rates:  nil,
@@ -65,7 +65,7 @@ func TestCommissionSchedule(t *testing.T) {
 				RateMax: mustInitQuantity(t, 100_000),
 			},
 		},
-	}, 0, 10, 30), "amend init unsimultaneous")
+	}, 0, 10, 30, 4, 12), "amend init unsimultaneous")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -82,7 +82,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "valid")
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "valid")
 
 	requireErrorShowDiagnostic(t, cs.AmendAndPruneAndValidate(&CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -92,7 +92,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 		Bounds: nil,
-	}, 10, 10, 30), "amend unaligned")
+	}, 10, 10, 30, 4, 12), "amend unaligned")
 
 	requireErrorShowDiagnostic(t, cs.AmendAndPruneAndValidate(&CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -102,7 +102,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 		Bounds: nil,
-	}, 10, 10, 30), "amend rate start too early")
+	}, 10, 10, 30, 4, 12), "amend rate start too early")
 
 	requireErrorShowDiagnostic(t, cs.AmendAndPruneAndValidate(&CommissionSchedule{
 		Rates: nil,
@@ -113,7 +113,7 @@ func TestCommissionSchedule(t *testing.T) {
 				RateMax: mustInitQuantity(t, 100_000),
 			},
 		},
-	}, 10, 10, 30), "amend bound start too early")
+	}, 10, 10, 30, 4, 12), "amend bound start too early")
 
 	require.NoError(t, cs.AmendAndPruneAndValidate(&CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -129,7 +129,7 @@ func TestCommissionSchedule(t *testing.T) {
 				RateMax: mustInitQuantity(t, 100_000),
 			},
 		},
-	}, 10, 10, 30), "amend append")
+	}, 10, 10, 30, 4, 12), "amend append")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -173,7 +173,7 @@ func TestCommissionSchedule(t *testing.T) {
 				RateMax: mustInitQuantity(t, 100_000),
 			},
 		},
-	}, 10, 10, 30), "amend replace")
+	}, 10, 10, 30, 4, 12), "amend replace")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -198,7 +198,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 		Bounds: nil,
-	}, 10, 10, 30), "amend out of bound")
+	}, 10, 10, 30, 4, 12), "amend out of bound")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -215,7 +215,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "unaligned rate step")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "unaligned rate step")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -236,7 +236,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "reversed rate steps")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "reversed rate steps")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -257,7 +257,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "zero-duration rate step")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "zero-duration rate step")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -274,7 +274,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "rate unity")
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "rate unity")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -291,7 +291,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "rate over unity")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "rate over unity")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -308,7 +308,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "unaligned bound step")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "unaligned bound step")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -330,7 +330,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "reversed bound steps")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "reversed bound steps")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -347,7 +347,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "bound min over unity")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "bound min over unity")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -364,7 +364,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "bound max over unity")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "bound max over unity")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -381,7 +381,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "bound exact")
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "bound exact")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -398,7 +398,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "bound inverted")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "bound inverted")
 
 	cs = CommissionSchedule{
 		Rates: nil,
@@ -410,7 +410,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "no rates")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "no rates")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -427,7 +427,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "rates late start")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "rates late start")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -438,7 +438,7 @@ func TestCommissionSchedule(t *testing.T) {
 		},
 		Bounds: nil,
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "no bounds")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "no bounds")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -455,7 +455,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "bounds late start")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "bounds late start")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -472,7 +472,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "rate below min")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "rate below min")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -489,7 +489,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10), "rate above max")
+	requireErrorShowDiagnostic(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "rate above max")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -515,7 +515,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "bound change then rate change")
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "bound change then rate change")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -541,7 +541,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "rate change then bound change")
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "rate change then bound change")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -567,7 +567,7 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10), "simultaneous rate and bound change")
+	require.NoError(t, cs.PruneAndValidateForGenesis(0, 10, 4, 12), "simultaneous rate and bound change")
 
 	cs = CommissionSchedule{
 		Rates: []CommissionRateStep{
@@ -593,10 +593,10 @@ func TestCommissionSchedule(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, cs.PruneAndValidateForGenesis(1, 10), "prune no effect")
+	require.NoError(t, cs.PruneAndValidateForGenesis(1, 10, 4, 12), "prune no effect")
 	require.Equal(t, epochtime.EpochTime(0), cs.Rates[0].Start, "prune 1 rates start")
 	require.Equal(t, epochtime.EpochTime(0), cs.Bounds[0].Start, "prune 1 bounds start")
-	require.NoError(t, cs.PruneAndValidateForGenesis(10, 10), "prune rate step")
+	require.NoError(t, cs.PruneAndValidateForGenesis(10, 10, 4, 12), "prune rate step")
 	require.Equal(t, epochtime.EpochTime(10), cs.Rates[0].Start, "prune 10 rates start")
 	require.Equal(t, epochtime.EpochTime(10), cs.Bounds[0].Start, "prune 10 bounds start")
 }

--- a/go/staking/api/rewards.go
+++ b/go/staking/api/rewards.go
@@ -4,10 +4,17 @@ import (
 	"math/big"
 
 	"github.com/oasislabs/oasis-core/go/common/quantity"
+	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 )
 
 // RewardAmountDenominator is the denominator for the reward rate.
 var RewardAmountDenominator *quantity.Quantity
+
+// RewardStep is one of the time periods in the reward schedule.
+type RewardStep struct {
+	Until epochtime.EpochTime `json:"until"`
+	Scale quantity.Quantity   `json:"scale"`
+}
 
 func init() {
 	// Denominated in 1000th of a percent.

--- a/go/staking/client/client.go
+++ b/go/staking/client/client.go
@@ -166,6 +166,15 @@ func (b *clientBackend) ReclaimEscrow(ctx context.Context, signedReclaim *api.Si
 	return nil
 }
 
+// AmendCommissionSchedule amends the signer's commission schedule.
+func (b *clientBackend) AmendCommissionSchedule(ctx context.Context, signedAmendCommissionSchedule *api.SignedAmendCommissionSchedule) error {
+	_, err := b.grpc.AmendCommissionSchedule(ctx, &pb.AmendCommissionScheduleRequest{SignedAmendCommissionSchedule: cbor.Marshal(signedAmendCommissionSchedule)})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // SubmitEvidence submits evidence of misbehavior.
 func (b *clientBackend) SubmitEvidence(ctx context.Context, evidence api.Evidence) error {
 	// TODO: Add gRPC method.

--- a/go/staking/grpc.go
+++ b/go/staking/grpc.go
@@ -179,6 +179,19 @@ func (s *grpcServer) ReclaimEscrow(ctx context.Context, req *pb.ReclaimEscrowReq
 	return &pb.ReclaimEscrowResponse{}, nil
 }
 
+func (s *grpcServer) AmendCommissionSchedule(ctx context.Context, req *pb.AmendCommissionScheduleRequest) (*pb.AmendCommissionScheduleResponse, error) {
+	var signedAmendCommissionSchedule api.SignedAmendCommissionSchedule
+	if err := cbor.Unmarshal(req.GetSignedAmendCommissionSchedule(), &signedAmendCommissionSchedule); err != nil {
+		return nil, err
+	}
+
+	if err := s.backend.AmendCommissionSchedule(ctx, &signedAmendCommissionSchedule); err != nil {
+		return nil, err
+	}
+
+	return &pb.AmendCommissionScheduleResponse{}, nil
+}
+
 func (s *grpcServer) WatchTransfers(req *pb.WatchTransfersRequest, stream pb.Staking_WatchTransfersServer) error {
 	ctx := stream.Context()
 	ch, sub, err := s.backend.WatchTransfers(ctx)

--- a/tests/fixture-data/stake-cli/staking-genesis.json
+++ b/tests/fixture-data/stake-cli/staking-genesis.json
@@ -1,0 +1,10 @@
+{
+  "params": {
+    "commission_schedule_rules": {
+      "rate_change_interval": 10,
+      "rate_bound_lead": 30,
+      "max_rate_steps": 4,
+      "max_bound_steps": 12
+    }
+  }
+}


### PR DESCRIPTION
it was said that rewards should have some portion split off as "commission" and paid to the node operator, i.e., the entity that owns the node. that's the account where we keep the escrow pools.

it was said that one should only be able to change the commission rate once per some interval. that interval is modeled in the consensus parameter CommissionRateChangeInterval.

it was said that one should have to post a future bound on the commission rate. this distance into the future is modeled in the consensus parameter CommissionRateBoundLead.

each entity's schedule of commission rates and bounds are represented in a CommissionSchedule structure in the account's new `.Escrow.CommissionSchedule` field.

there's a new transaction where an entity can amend its own commission rate and bound schedule. in this iteration, we charge a fixed gas fee for it, no matter the complexity of the schedule. when we process the amendment, we also prune old schedule information that is no longer in effect.