### PR TITLE
go/tendermint/apps/scheduler: Change the election behavior

### DIFF
--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -61,6 +61,7 @@ const (
 	cfgSchedulerMaxBatchSizeBytes = "worker.txnscheduler.batching.max_batch_size_bytes"
 
 	// Scheduler config flags.
+	cfgSchedulerMinValidators         = "scheduler.min_validators"
 	cfgSchedulerDebugBypassStake      = "scheduler.debug.bypass_stake" // nolint: gosec
 	cfgSchedulerDebugStaticValidators = "scheduler.debug.static_validators"
 
@@ -175,6 +176,7 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 
 	doc.Scheduler = scheduler.Genesis{
 		Parameters: scheduler.ConsensusParameters{
+			MinValidators:         viper.GetInt(cfgSchedulerMinValidators),
 			DebugBypassStake:      viper.GetBool(cfgSchedulerDebugBypassStake),
 			DebugStaticValidators: viper.GetBool(cfgSchedulerDebugStaticValidators),
 		},
@@ -619,6 +621,7 @@ func init() {
 	initGenesisFlags.String(cfgSchedulerMaxBatchSizeBytes, "16mb", "Maximum size (in bytes) of a batch of runtime requests")
 
 	// Scheduler config flags.
+	initGenesisFlags.Int(cfgSchedulerMinValidators, 1, "minumum number of validators")
 	initGenesisFlags.Bool(cfgSchedulerDebugBypassStake, false, "bypass all stake checks and operations (UNSAFE)")
 	initGenesisFlags.Bool(cfgSchedulerDebugStaticValidators, false, "bypass all validator elections (UNSAFE)")
 

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -62,6 +62,7 @@ const (
 
 	// Scheduler config flags.
 	cfgSchedulerMinValidators         = "scheduler.min_validators"
+	cfgSchedulerMaxValidators         = "scheduler.max_validators"
 	cfgSchedulerDebugBypassStake      = "scheduler.debug.bypass_stake" // nolint: gosec
 	cfgSchedulerDebugStaticValidators = "scheduler.debug.static_validators"
 
@@ -177,6 +178,7 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 	doc.Scheduler = scheduler.Genesis{
 		Parameters: scheduler.ConsensusParameters{
 			MinValidators:         viper.GetInt(cfgSchedulerMinValidators),
+			MaxValidators:         viper.GetInt(cfgSchedulerMaxValidators),
 			DebugBypassStake:      viper.GetBool(cfgSchedulerDebugBypassStake),
 			DebugStaticValidators: viper.GetBool(cfgSchedulerDebugStaticValidators),
 		},
@@ -622,6 +624,7 @@ func init() {
 
 	// Scheduler config flags.
 	initGenesisFlags.Int(cfgSchedulerMinValidators, 1, "minumum number of validators")
+	initGenesisFlags.Int(cfgSchedulerMaxValidators, 100, "maximum number of validators")
 	initGenesisFlags.Bool(cfgSchedulerDebugBypassStake, false, "bypass all stake checks and operations (UNSAFE)")
 	initGenesisFlags.Bool(cfgSchedulerDebugStaticValidators, false, "bypass all validator elections (UNSAFE)")
 

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -61,10 +61,11 @@ const (
 	cfgSchedulerMaxBatchSizeBytes = "worker.txnscheduler.batching.max_batch_size_bytes"
 
 	// Scheduler config flags.
-	cfgSchedulerMinValidators         = "scheduler.min_validators"
-	cfgSchedulerMaxValidators         = "scheduler.max_validators"
-	cfgSchedulerDebugBypassStake      = "scheduler.debug.bypass_stake" // nolint: gosec
-	cfgSchedulerDebugStaticValidators = "scheduler.debug.static_validators"
+	cfgSchedulerMinValidators            = "scheduler.min_validators"
+	cfgSchedulerMaxValidators            = "scheduler.max_validators"
+	cfgSchedulerValidatorEntityThreshold = "scheduler.validator_entity_threshold"
+	cfgSchedulerDebugBypassStake         = "scheduler.debug.bypass_stake" // nolint: gosec
+	cfgSchedulerDebugStaticValidators    = "scheduler.debug.static_validators"
 
 	// Beacon config flags.
 	cfgBeaconDebugDeterministic = "beacon.debug.deterministic"
@@ -177,10 +178,11 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 
 	doc.Scheduler = scheduler.Genesis{
 		Parameters: scheduler.ConsensusParameters{
-			MinValidators:         viper.GetInt(cfgSchedulerMinValidators),
-			MaxValidators:         viper.GetInt(cfgSchedulerMaxValidators),
-			DebugBypassStake:      viper.GetBool(cfgSchedulerDebugBypassStake),
-			DebugStaticValidators: viper.GetBool(cfgSchedulerDebugStaticValidators),
+			MinValidators:            viper.GetInt(cfgSchedulerMinValidators),
+			MaxValidators:            viper.GetInt(cfgSchedulerMaxValidators),
+			ValidatorEntityThreshold: viper.GetInt(cfgSchedulerValidatorEntityThreshold),
+			DebugBypassStake:         viper.GetBool(cfgSchedulerDebugBypassStake),
+			DebugStaticValidators:    viper.GetBool(cfgSchedulerDebugStaticValidators),
 		},
 	}
 
@@ -625,6 +627,7 @@ func init() {
 	// Scheduler config flags.
 	initGenesisFlags.Int(cfgSchedulerMinValidators, 1, "minumum number of validators")
 	initGenesisFlags.Int(cfgSchedulerMaxValidators, 100, "maximum number of validators")
+	initGenesisFlags.Int(cfgSchedulerValidatorEntityThreshold, 100, "validator entity threshold")
 	initGenesisFlags.Bool(cfgSchedulerDebugBypassStake, false, "bypass all stake checks and operations (UNSAFE)")
 	initGenesisFlags.Bool(cfgSchedulerDebugStaticValidators, false, "bypass all validator elections (UNSAFE)")
 

--- a/go/scheduler/api/api.go
+++ b/go/scheduler/api/api.go
@@ -189,6 +189,10 @@ type ConsensusParameters struct {
 	// present in elected validator sets.
 	MinValidators int `json:"min_validators"`
 
+	// MaxValidators is the maximum number of validators that MAY be
+	// present in elected validator sets.
+	MaxValidators int `json:"max_validators"`
+
 	// DebugBypassStake is true iff the scheduler should bypass all of
 	// the staking related checks and operations.
 	DebugBypassStake bool `json:"debug_bypass_stake"`

--- a/go/scheduler/api/api.go
+++ b/go/scheduler/api/api.go
@@ -185,6 +185,10 @@ type Genesis struct {
 
 // ConsensusParameters are the scheduler consensus parameters.
 type ConsensusParameters struct {
+	// MinValidators is the minimum number of validators that MUST be
+	// present in elected validator sets.
+	MinValidators int `json:"min_validators"`
+
 	// DebugBypassStake is true iff the scheduler should bypass all of
 	// the staking related checks and operations.
 	DebugBypassStake bool `json:"debug_bypass_stake"`

--- a/go/scheduler/api/api.go
+++ b/go/scheduler/api/api.go
@@ -193,6 +193,11 @@ type ConsensusParameters struct {
 	// present in elected validator sets.
 	MaxValidators int `json:"max_validators"`
 
+	// ValidatorEntityThreshold is the cutoff point (by escrow balance)
+	// of the top-N entities running validator nodes, to be eligible
+	// for the entity's nodes to be elected as a validator.
+	ValidatorEntityThreshold int `json:"validator_entity_threshold"`
+
 	// DebugBypassStake is true iff the scheduler should bypass all of
 	// the staking related checks and operations.
 	DebugBypassStake bool `json:"debug_bypass_stake"`

--- a/go/tendermint/apps/scheduler/genesis.go
+++ b/go/tendermint/apps/scheduler/genesis.go
@@ -38,6 +38,9 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 	if doc.Scheduler.Parameters.MaxValidators <= 0 {
 		return fmt.Errorf("tendermint/scheduler: maximum number of validators not configured")
 	}
+	if doc.Scheduler.Parameters.ValidatorEntityThreshold <= 0 {
+		return fmt.Errorf("tendermint/scheduler: validator entity threshold not configured")
+	}
 
 	regState := registryState.NewMutableState(ctx.State())
 	nodes, err := regState.Nodes()

--- a/go/tendermint/apps/scheduler/genesis.go
+++ b/go/tendermint/apps/scheduler/genesis.go
@@ -35,6 +35,9 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 	if doc.Scheduler.Parameters.MinValidators <= 0 {
 		return fmt.Errorf("tendermint/scheduler: minimum number of validators not configured")
 	}
+	if doc.Scheduler.Parameters.MaxValidators <= 0 {
+		return fmt.Errorf("tendermint/scheduler: maximum number of validators not configured")
+	}
 
 	regState := registryState.NewMutableState(ctx.State())
 	nodes, err := regState.Nodes()

--- a/go/tendermint/apps/scheduler/genesis.go
+++ b/go/tendermint/apps/scheduler/genesis.go
@@ -32,6 +32,10 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 		return nil
 	}
 
+	if doc.Scheduler.Parameters.MinValidators <= 0 {
+		return fmt.Errorf("tendermint/scheduler: minimum number of validators not configured")
+	}
+
 	regState := registryState.NewMutableState(ctx.State())
 	nodes, err := regState.Nodes()
 	if err != nil {

--- a/go/tendermint/apps/scheduler/scheduler.go
+++ b/go/tendermint/apps/scheduler/scheduler.go
@@ -206,7 +206,7 @@ func (app *schedulerApplication) BeginBlock(ctx *abci.Context, request types.Req
 		// Handle the validator election first, because no consensus is
 		// catastrophic, while no validators is not.
 		if !params.DebugStaticValidators {
-			if err = app.electValidators(ctx, beacon, entityStake, entitiesEligibleForReward, nodes, params.MinValidators); err != nil {
+			if err = app.electValidators(ctx, beacon, entityStake, entitiesEligibleForReward, nodes, params); err != nil {
 				// It is unclear what the behavior should be if the validator
 				// election fails.  The system can not ensure integrity, so
 				// presumably manual intervention is required...
@@ -557,12 +557,8 @@ func (app *schedulerApplication) electAllCommittees(ctx *abci.Context, request t
 	return nil
 }
 
-func (app *schedulerApplication) electValidators(ctx *abci.Context, beacon []byte, entityStake *stakeAccumulator, entitiesEligibleForReward map[signature.MapKey]bool, nodes []*node.Node, minValidators int) error {
-	// XXX: How many validators do we want, anyway?
-	const (
-		maxValidators = 100
-		topN          = 100
-	)
+func (app *schedulerApplication) electValidators(ctx *abci.Context, beacon []byte, entityStake *stakeAccumulator, entitiesEligibleForReward map[signature.MapKey]bool, nodes []*node.Node, params *scheduler.ConsensusParameters) error {
+	const topN = 100
 
 	// Filter the node list based on eligibility and minimum required
 	// entity stake.
@@ -625,7 +621,7 @@ func (app *schedulerApplication) electValidators(ctx *abci.Context, beacon []byt
 		}
 
 		newValidators = append(newValidators, n.Consensus.ID)
-		if len(newValidators) >= maxValidators {
+		if len(newValidators) >= params.MaxValidators {
 			break
 		}
 	}
@@ -633,7 +629,7 @@ func (app *schedulerApplication) electValidators(ctx *abci.Context, beacon []byt
 	if len(newValidators) == 0 {
 		return fmt.Errorf("tendermint/scheduler: failed to elect any validators")
 	}
-	if len(newValidators) < minValidators {
+	if len(newValidators) < params.MinValidators {
 		return fmt.Errorf("tendermint/scheduler: insufficient validators")
 	}
 

--- a/go/tendermint/apps/scheduler/scheduler.go
+++ b/go/tendermint/apps/scheduler/scheduler.go
@@ -558,8 +558,6 @@ func (app *schedulerApplication) electAllCommittees(ctx *abci.Context, request t
 }
 
 func (app *schedulerApplication) electValidators(ctx *abci.Context, beacon []byte, entityStake *stakeAccumulator, entitiesEligibleForReward map[signature.MapKey]bool, nodes []*node.Node, params *scheduler.ConsensusParameters) error {
-	const topN = 100
-
 	// Filter the node list based on eligibility and minimum required
 	// entity stake.
 	var preFilteredNodeList []*node.Node
@@ -581,8 +579,8 @@ func (app *schedulerApplication) electValidators(ctx *abci.Context, beacon []byt
 	if err != nil {
 		return err
 	}
-	if len(sortedEntities) > topN {
-		sortedEntities = sortedEntities[:topN]
+	if len(sortedEntities) > params.ValidatorEntityThreshold {
+		sortedEntities = sortedEntities[:params.ValidatorEntityThreshold]
 	}
 	entMap = make(map[signature.MapKey]bool)
 	for _, v := range sortedEntities {

--- a/go/tendermint/apps/scheduler/scheduler.go
+++ b/go/tendermint/apps/scheduler/scheduler.go
@@ -40,6 +40,7 @@ var (
 	rngContextTransactionScheduler = []byte("EkS-ABCI-TransactionScheduler")
 	rngContextMerge                = []byte("EkS-ABCI-Merge")
 	rngContextValidators           = []byte("EkS-ABCI-Validators")
+	rngContextEntities             = []byte("EkS-ABCI-Entities")
 
 	errUnexpectedTransaction = errors.New("tendermint/scheduler: unexpected transaction")
 )
@@ -241,15 +242,7 @@ func (app *schedulerApplication) BeginBlock(ctx *abci.Context, request types.Req
 		)
 
 		if entitiesEligibleForReward != nil {
-			accounts := make([]signature.PublicKey, len(entitiesEligibleForReward))
-			for mk := range entitiesEligibleForReward {
-				var account signature.PublicKey
-				account.FromMapKey(mk)
-				accounts = append(accounts, account)
-			}
-			sort.Slice(accounts, func(i, j int) bool {
-				return bytes.Compare(accounts[i], accounts[j]) < 0
-			})
+			accounts := publicKeyMapToSortedSlice(entitiesEligibleForReward)
 			stakingSt := stakingState.NewMutableState(ctx.State())
 			if err = stakingSt.AddRewards(epoch, scheduler.RewardFactorEpochElectionAny, accounts); err != nil {
 				return errors.Wrap(err, "adding rewards")
@@ -566,15 +559,43 @@ func (app *schedulerApplication) electAllCommittees(ctx *abci.Context, request t
 
 func (app *schedulerApplication) electValidators(ctx *abci.Context, beacon []byte, entityStake *stakeAccumulator, entitiesEligibleForReward map[signature.MapKey]bool, nodes []*node.Node) error {
 	// XXX: How many validators do we want, anyway?
-	const maxValidators = 100
+	const (
+		maxValidators = 100
+		topN          = 100
+	)
 
-	// Filter the node list based on eligibility and entity stake.
-	var nodeList []*node.Node
+	// Filter the node list based on eligibility and minimum required
+	// entity stake.
+	var preFilteredNodeList []*node.Node
+	entMap := make(map[signature.MapKey]bool)
 	for _, n := range nodes {
 		if !n.HasRoles(node.RoleValidator) {
 			continue
 		}
 		if err := entityStake.checkThreshold(n.EntityID, staking.KindValidator, false); err != nil {
+			continue
+		}
+		preFilteredNodeList = append(preFilteredNodeList, n)
+		entMap[n.EntityID.ToMapKey()] = true
+	}
+
+	// Figure out the top-N staked entities, out of the set of entities that
+	// are actually running eligible validator nodes.
+	sortedEntities, err := publicKeyMapToSliceByStake(entMap, entityStake, beacon)
+	if err != nil {
+		return err
+	}
+	if len(sortedEntities) > topN {
+		sortedEntities = sortedEntities[:topN]
+	}
+	entMap = make(map[signature.MapKey]bool)
+	for _, v := range sortedEntities {
+		entMap[v.ToMapKey()] = true
+	}
+
+	var nodeList []*node.Node
+	for _, n := range preFilteredNodeList {
+		if !entMap[n.EntityID.ToMapKey()] {
 			continue
 		}
 		nodeList = append(nodeList, n)
@@ -583,6 +604,8 @@ func (app *schedulerApplication) electValidators(ctx *abci.Context, beacon []byt
 		}
 	}
 
+	// Generate the permutation assuming the entire eligible node list may
+	// need to be traversed, due to some nodes having insufficient stake.
 	drbg, err := drbg.New(crypto.SHA512, beacon, nil, rngContextValidators)
 	if err != nil {
 		return errors.Wrap(err, "tendermint/scheduler: couldn't instantiate DRBG")
@@ -590,8 +613,6 @@ func (app *schedulerApplication) electValidators(ctx *abci.Context, beacon []byt
 	rngSrc := mathrand.New(drbg)
 	rng := rand.New(rngSrc)
 
-	// Generate the permutation assuming the entire eligible node list may
-	// need to be traversed, due to some nodes having insufficient stake.
 	idxs := rng.Perm(len(nodeList))
 
 	var newValidators []signature.PublicKey
@@ -619,6 +640,46 @@ func (app *schedulerApplication) electValidators(ctx *abci.Context, beacon []byt
 	state.PutPendingValidators(newValidators)
 
 	return nil
+}
+
+func publicKeyMapToSliceByStake(entMap map[signature.MapKey]bool, entityStake *stakeAccumulator, beacon []byte) ([]signature.PublicKey, error) {
+	// Convert the map of entity public keys to a lexographically
+	// sorted slice (ie: make it deterministic).
+	entities := publicKeyMapToSortedSlice(entMap)
+
+	// Shuffle the sorted slice to make tie-breaks "random".
+	drbg, err := drbg.New(crypto.SHA512, beacon, nil, rngContextEntities)
+	if err != nil {
+		return nil, errors.Wrap(err, "tendermint/scheduler: couldn't instantiate DRBG")
+	}
+	rngSrc := mathrand.New(drbg)
+	rng := rand.New(rngSrc)
+
+	rng.Shuffle(len(entities), func(i, j int) {
+		entities[i], entities[j] = entities[j], entities[i]
+	})
+
+	// Stable-sort the shuffled slice by decending escrow balance.
+	sort.SliceStable(entities, func(i, j int) bool {
+		iBal := entityStake.stakeCache.GetEscrowBalance(entities[i])
+		jBal := entityStake.stakeCache.GetEscrowBalance(entities[j])
+		return iBal.Cmp(&jBal) == 1 // Note: Not -1 to get a reversed sort.
+	})
+
+	return entities, nil
+}
+
+func publicKeyMapToSortedSlice(m map[signature.MapKey]bool) []signature.PublicKey {
+	v := make([]signature.PublicKey, 0, len(m))
+	for mk := range m {
+		var id signature.PublicKey
+		id.FromMapKey(mk)
+		v = append(v, id)
+	}
+	sort.Slice(v, func(i, j int) bool {
+		return bytes.Compare(v[i], v[j]) < 0
+	})
+	return v
 }
 
 // New constructs a new scheduler application instance.

--- a/go/tendermint/apps/staking/state/cache.go
+++ b/go/tendermint/apps/staking/state/cache.go
@@ -50,7 +50,7 @@ func (sc *StakeCache) EnsureNodeRegistrationStake(id signature.PublicKey, n int)
 		return fmt.Errorf("staking/tendermint: failed to derive node target threshold: %w", err)
 	}
 
-	escrowBalance := sc.getEscrowBalance(id)
+	escrowBalance := sc.GetEscrowBalance(id)
 	if escrowBalance.Cmp(targetThreshold) < 0 {
 		return staking.ErrInsufficientStake
 	}
@@ -71,7 +71,7 @@ func (sc *StakeCache) EnsureSufficientStake(id signature.PublicKey, thresholds [
 		}
 	}
 
-	escrowBalance := sc.getEscrowBalance(id)
+	escrowBalance := sc.GetEscrowBalance(id)
 	if escrowBalance.Cmp(&targetThreshold) < 0 {
 		return staking.ErrInsufficientStake
 	}
@@ -79,7 +79,8 @@ func (sc *StakeCache) EnsureSufficientStake(id signature.PublicKey, thresholds [
 	return nil
 }
 
-func (sc *StakeCache) getEscrowBalance(id signature.PublicKey) staking.Quantity {
+// GetEscrowBalance returns the escrow balance of the account owned by id.
+func (sc *StakeCache) GetEscrowBalance(id signature.PublicKey) staking.Quantity {
 	escrowBalance := sc.balances[id.ToMapKey()]
 	if escrowBalance == nil {
 		state := NewMutableState(sc.ctx.State())

--- a/go/tendermint/tests/genesis_testnode.go
+++ b/go/tendermint/tests/genesis_testnode.go
@@ -68,10 +68,11 @@ func NewTestNodeGenesisProvider(identity *identity.Identity) (genesis.Provider, 
 		},
 		Scheduler: scheduler.Genesis{
 			Parameters: scheduler.ConsensusParameters{
-				MinValidators:         1,
-				MaxValidators:         100,
-				DebugBypassStake:      true,
-				DebugStaticValidators: true,
+				MinValidators:            1,
+				MaxValidators:            100,
+				ValidatorEntityThreshold: 100,
+				DebugBypassStake:         true,
+				DebugStaticValidators:    true,
 			},
 		},
 		Consensus: consensus.Genesis{

--- a/go/tendermint/tests/genesis_testnode.go
+++ b/go/tendermint/tests/genesis_testnode.go
@@ -69,6 +69,7 @@ func NewTestNodeGenesisProvider(identity *identity.Identity) (genesis.Provider, 
 		Scheduler: scheduler.Genesis{
 			Parameters: scheduler.ConsensusParameters{
 				MinValidators:         1,
+				MaxValidators:         100,
 				DebugBypassStake:      true,
 				DebugStaticValidators: true,
 			},

--- a/go/tendermint/tests/genesis_testnode.go
+++ b/go/tendermint/tests/genesis_testnode.go
@@ -68,6 +68,7 @@ func NewTestNodeGenesisProvider(identity *identity.Identity) (genesis.Provider, 
 		},
 		Scheduler: scheduler.Genesis{
 			Parameters: scheduler.ConsensusParameters{
+				MinValidators:         1,
 				DebugBypassStake:      true,
 				DebugStaticValidators: true,
 			},


### PR DESCRIPTION
Change the placeholder election algorithms to something more in-line with what is actually designed.

 * [x] go/tendermint/apps/scheduler: Elect validators based on top-N staked
 * [x] go/tendermint/apps/scheduler: Add `ConsensusParams.MinValidators` (#2314)