### PR TITLE
go: Bump the ed25519 and tendermint dependencies

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -2,9 +2,9 @@ module github.com/oasislabs/oasis-core/go
 
 replace (
 	github.com/tendermint/iavl => github.com/oasislabs/iavl v0.12.0-ekiden3
-	github.com/tendermint/tendermint => github.com/oasislabs/tendermint v0.32.7-oasis1
+	github.com/tendermint/tendermint => github.com/oasislabs/tendermint v0.32.7-oasis2
 	golang.org/x/crypto/curve25519 => github.com/oasislabs/ed25519/extra/x25519 v0.0.0-20191022155220-a426dcc8ad5f
-	golang.org/x/crypto/ed25519 => github.com/oasislabs/ed25519 v0.0.0-20191022155220-a426dcc8ad5f
+	golang.org/x/crypto/ed25519 => github.com/oasislabs/ed25519 v0.0.0-20191109133925-b197a691e30d
 )
 
 require (
@@ -44,7 +44,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.0.1
 	github.com/multiformats/go-multihash v0.0.6 // indirect
 	github.com/oasislabs/deoxysii v0.0.0-20190807103041-6159f99c2236
-	github.com/oasislabs/ed25519 v0.0.0-20191022155220-a426dcc8ad5f
+	github.com/oasislabs/ed25519 v0.0.0-20191109133925-b197a691e30d
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -345,12 +345,16 @@ github.com/oasislabs/deoxysii v0.0.0-20190807103041-6159f99c2236 h1:eTbRemVO4uAX
 github.com/oasislabs/deoxysii v0.0.0-20190807103041-6159f99c2236/go.mod h1:gFIu170Sklo1wPRTYMTDxA664TYdgrl9NENFXfC+u3g=
 github.com/oasislabs/ed25519 v0.0.0-20191022155220-a426dcc8ad5f h1:d7qNaW+eJwgZ/PMMvLo1iGezGH7XwYI6FRcUEjZKDDo=
 github.com/oasislabs/ed25519 v0.0.0-20191022155220-a426dcc8ad5f/go.mod h1:BB2J82Ap0q/mSJZ0ALKKeQ5PTsiEoF/OSNGmwvrHrOI=
+github.com/oasislabs/ed25519 v0.0.0-20191109133925-b197a691e30d h1:JG2ENgp/kOmF+ApF9HtdqsDeK1kXGUQBAUUqvXDcbTg=
+github.com/oasislabs/ed25519 v0.0.0-20191109133925-b197a691e30d/go.mod h1:BB2J82Ap0q/mSJZ0ALKKeQ5PTsiEoF/OSNGmwvrHrOI=
 github.com/oasislabs/iavl v0.12.0-ekiden2 h1:kzdp6OTHYrn8TXlAo+2NsL84Qi2gqydFvjhWQZ/H9GM=
 github.com/oasislabs/iavl v0.12.0-ekiden2/go.mod h1:B/tMpl5cg7n42n3xYQTCckJzQezoI75jedkc8FOiOF0=
 github.com/oasislabs/iavl v0.12.0-ekiden3 h1:8544fXJb57urhAEpTlIwDBdTJukgpPS/FCS/yj14I8E=
 github.com/oasislabs/iavl v0.12.0-ekiden3/go.mod h1:B/tMpl5cg7n42n3xYQTCckJzQezoI75jedkc8FOiOF0=
 github.com/oasislabs/tendermint v0.32.7-oasis1 h1:m1WPCTXn0PgLHAX5YsFx52vx+bQwZP9iSM2kgtMaGVM=
 github.com/oasislabs/tendermint v0.32.7-oasis1/go.mod h1:Ex0OYkB2o7j3qghM7rEePw/drFL5M2WNRs95uiFJOxQ=
+github.com/oasislabs/tendermint v0.32.7-oasis2 h1:5D8Tea1GAJq0kYxJT9KbS0XwhbEqadn/6J70jE1g5ao=
+github.com/oasislabs/tendermint v0.32.7-oasis2/go.mod h1:ijIvBSMsnQc+IffD7mGLYhqMDrgXR/NBhiyS7tzdxLE=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
I made a really stupid mistake in the ed25519 code that required a minor
fix.  This pulls in the new ed25519 and tendermint versions.