### PR TITLE
Add more consensus parameters

### DIFF
--- a/go/consensus/genesis/genesis.go
+++ b/go/consensus/genesis/genesis.go
@@ -5,9 +5,18 @@ import "time"
 
 // Genesis contains various consensus config flags that should be part of the genesis state.
 type Genesis struct {
-	Backend            string        `json:"backend"`
+	Backend    string     `json:"backend"`
+	Parameters Parameters `json:"params"`
+}
+
+// Parameters are the consensus parameters.
+type Parameters struct {
 	TimeoutCommit      time.Duration `json:"timeout_commit"`
 	SkipTimeoutCommit  bool          `json:"skip_timeout_commit"`
 	EmptyBlockInterval time.Duration `json:"empty_block_interval"`
-	MaxTxSize          uint          `json:"max_tx_size"`
+
+	MaxTxSize      uint64 `json:"max_tx_size"`
+	MaxBlockSize   uint64 `json:"max_block_size"`
+	MaxBlockGas    uint64 `json:"max_block_gas"`
+	MaxEvidenceAge uint64 `json:"max_evidence_age"`
 }

--- a/go/consensus/tendermint/abci/context.go
+++ b/go/consensus/tendermint/abci/context.go
@@ -220,6 +220,11 @@ func (bc *BlockContext) Get(key BlockContextKey) interface{} {
 	return v
 }
 
+// Set overwrites the value stored under the given key.
+func (bc *BlockContext) Set(key BlockContextKey, value interface{}) {
+	bc.storage[key] = value
+}
+
 // NewBlockContext creates an empty block context.
 func NewBlockContext() *BlockContext {
 	return &BlockContext{

--- a/go/consensus/tendermint/abci/gas_test.go
+++ b/go/consensus/tendermint/abci/gas_test.go
@@ -1,0 +1,134 @@
+package abci
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasislabs/oasis-core/go/common/consensus/gas"
+)
+
+func TestBasicGasAccountant(t *testing.T) {
+	require := require.New(t)
+
+	cheapOp := gas.Op("cheap op")
+	expensiveOp := gas.Op("expensive op")
+	overflowOp := gas.Op("overflow op")
+	costs := gas.Costs{
+		cheapOp:     10,
+		expensiveOp: 91,
+		overflowOp:  math.MaxUint64,
+	}
+
+	a := NewGasAccountant(100)
+	require.EqualValues(100, a.GasWanted(), "GasWanted")
+
+	// Normal gas consumption.
+	err := a.UseGas(cheapOp, costs)
+	require.NoError(err, "UseGas")
+	require.EqualValues(10, a.GasUsed(), "GasUsed")
+
+	// Overflow.
+	err = a.UseGas(overflowOp, costs)
+	require.Error(err, "UseGas should fail on overflow")
+	require.Equal(ErrGasOverflow, err)
+	require.EqualValues(10, a.GasUsed(), "GasUsed")
+
+	// Out of gas.
+	err = a.UseGas(expensiveOp, costs)
+	require.Error(err, "UseGas should fail when out of gas")
+	require.Equal(ErrOutOfGas, err)
+	require.EqualValues(10, a.GasUsed(), "GasUsed")
+
+	require.EqualValues(100, a.GasWanted(), "GasWanted")
+}
+
+func TestNopGasAccountant(t *testing.T) {
+	require := require.New(t)
+
+	cheapOp := gas.Op("cheap op")
+	expensiveOp := gas.Op("expensive op")
+	overflowOp := gas.Op("overflow op")
+	costs := gas.Costs{
+		cheapOp:     10,
+		expensiveOp: 91,
+		overflowOp:  math.MaxUint64,
+	}
+
+	a := NewNopGasAccountant()
+	require.EqualValues(0, a.GasWanted(), "GasWanted")
+
+	// Normal gas consumption.
+	err := a.UseGas(cheapOp, costs)
+	require.NoError(err, "UseGas")
+	require.EqualValues(0, a.GasUsed(), "GasUsed")
+
+	// Overflow.
+	err = a.UseGas(overflowOp, costs)
+	require.NoError(err, "UseGas")
+	require.EqualValues(0, a.GasUsed(), "GasUsed")
+
+	// Out of gas.
+	err = a.UseGas(expensiveOp, costs)
+	require.NoError(err, "UseGas")
+	require.EqualValues(0, a.GasUsed(), "GasUsed")
+
+	require.EqualValues(0, a.GasWanted(), "GasWanted")
+}
+
+func TestCompositeGasAccountant(t *testing.T) {
+	require := require.New(t)
+
+	cheapOp := gas.Op("cheap op")
+	expensiveOp := gas.Op("expensive op")
+	overflowOp := gas.Op("overflow op")
+	costs := gas.Costs{
+		cheapOp:     10,
+		expensiveOp: 91,
+		overflowOp:  math.MaxUint64,
+	}
+
+	a := NewGasAccountant(10)
+	b := NewGasAccountant(10)
+	c := NewCompositeGasAccountant(a, b)
+	require.EqualValues(10, c.GasWanted(), "GasWanted")
+
+	// Normal gas consumption.
+	err := c.UseGas(cheapOp, costs)
+	require.NoError(err, "UseGas")
+	require.EqualValues(10, c.GasUsed(), "GasUsed")
+	require.EqualValues(10, a.GasUsed(), "GasUsed")
+	require.EqualValues(10, b.GasUsed(), "GasUsed")
+
+	// Overflow.
+	err = c.UseGas(overflowOp, costs)
+	require.Error(err, "UseGas should fail on overflow")
+	require.Equal(ErrGasOverflow, err)
+	require.EqualValues(10, c.GasUsed(), "GasUsed")
+	require.EqualValues(10, a.GasUsed(), "GasUsed")
+	require.EqualValues(10, b.GasUsed(), "GasUsed")
+
+	// Out of gas.
+	err = a.UseGas(expensiveOp, costs)
+	require.Error(err, "UseGas should fail when out of gas")
+	require.Equal(ErrOutOfGas, err)
+	require.EqualValues(10, c.GasUsed(), "GasUsed")
+	require.EqualValues(10, a.GasUsed(), "GasUsed")
+	require.EqualValues(10, b.GasUsed(), "GasUsed")
+
+	require.EqualValues(10, c.GasWanted(), "GasWanted")
+
+	// Reuse one of the accountants, reset the other.
+	a = NewGasAccountant(10)
+	c = NewCompositeGasAccountant(a, b)
+	require.EqualValues(10, c.GasWanted(), "GasWanted")
+	require.EqualValues(10, c.GasUsed(), "GasUsed")
+
+	err = c.UseGas(cheapOp, costs)
+	require.Error(err, "UseGas should fail when out of gas")
+	require.Equal(ErrOutOfGas, err)
+	require.EqualValues(10, c.GasUsed(), "GasUsed")
+	require.EqualValues(10, a.GasUsed(), "GasUsed")
+	require.EqualValues(10, b.GasUsed(), "GasUsed")
+}

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -257,7 +257,7 @@ type abciMux struct {
 
 	lastBeginBlock int64
 	currentTime    time.Time
-	maxTxSize      uint
+	maxTxSize      uint64
 
 	genesisHooks []func()
 	haltHooks    []func(context.Context, int64, epochtime.EpochTime)
@@ -341,7 +341,7 @@ func (mux *abciMux) InitChain(req types.RequestInitChain) types.ResponseInitChai
 		panic("mux: invalid genesis application state")
 	}
 
-	if mux.maxTxSize = st.Consensus.MaxTxSize; mux.maxTxSize == 0 {
+	if mux.maxTxSize = st.Consensus.Parameters.MaxTxSize; mux.maxTxSize == 0 {
 		mux.logger.Warn("maximum transaction size enforcement is disabled")
 	}
 
@@ -547,7 +547,7 @@ func (mux *abciMux) executeTx(ctx *Context, tx []byte) error {
 		return fmt.Errorf("halt mode, rejecting all transactions")
 	}
 
-	if mux.maxTxSize > 0 && uint(len(tx)) > mux.maxTxSize {
+	if mux.maxTxSize > 0 && uint64(len(tx)) > mux.maxTxSize {
 		// This deliberately avoids logging the tx since spamming the
 		// logs is also bad.
 		logger.Error("received oversized transaction",

--- a/go/consensus/tendermint/tests/genesis_testnode.go
+++ b/go/consensus/tendermint/tests/genesis_testnode.go
@@ -76,9 +76,11 @@ func NewTestNodeGenesisProvider(identity *identity.Identity) (genesis.Provider, 
 			},
 		},
 		Consensus: consensus.Genesis{
-			Backend:           tendermint.BackendName,
-			TimeoutCommit:     1 * time.Millisecond,
-			SkipTimeoutCommit: true,
+			Backend: tendermint.BackendName,
+			Parameters: consensus.Parameters{
+				TimeoutCommit:     1 * time.Millisecond,
+				SkipTimeoutCommit: true,
+			},
 		},
 		Staking: stakingTests.DebugGenesisState,
 	}

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -80,6 +80,9 @@ const (
 	cfgConsensusSkipTimeoutCommit  = "consensus.tendermint.skip_timeout_commit"
 	cfgConsensusEmptyBlockInterval = "consensus.tendermint.empty_block_interval"
 	cfgConsensusMaxTxSizeBytes     = "consensus.tendermint.max_tx_size"
+	cfgConsensusMaxBlockSizeBytes  = "consensus.tendermint.max_block_size"
+	cfgConsensusMaxBlockGas        = "consensus.tendermint.max_block_gas"
+	cfgConsensusMaxEvidenceAge     = "consensus.tendermint.max_evidence_age"
 
 	// Consensus backend config flag.
 	cfgConsensusBackend = "consensus.backend"
@@ -201,11 +204,16 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 	}
 
 	doc.Consensus = consensus.Genesis{
-		Backend:            viper.GetString(cfgConsensusBackend),
-		TimeoutCommit:      viper.GetDuration(cfgConsensusTimeoutCommit),
-		SkipTimeoutCommit:  viper.GetBool(cfgConsensusSkipTimeoutCommit),
-		EmptyBlockInterval: viper.GetDuration(cfgConsensusEmptyBlockInterval),
-		MaxTxSize:          viper.GetSizeInBytes(cfgConsensusMaxTxSizeBytes),
+		Backend: viper.GetString(cfgConsensusBackend),
+		Parameters: consensus.Parameters{
+			TimeoutCommit:      viper.GetDuration(cfgConsensusTimeoutCommit),
+			SkipTimeoutCommit:  viper.GetBool(cfgConsensusSkipTimeoutCommit),
+			EmptyBlockInterval: viper.GetDuration(cfgConsensusEmptyBlockInterval),
+			MaxTxSize:          uint64(viper.GetSizeInBytes(cfgConsensusMaxTxSizeBytes)),
+			MaxBlockSize:       uint64(viper.GetSizeInBytes(cfgConsensusMaxBlockSizeBytes)),
+			MaxBlockGas:        viper.GetUint64(cfgConsensusMaxBlockGas),
+			MaxEvidenceAge:     viper.GetUint64(cfgConsensusMaxEvidenceAge),
+		},
 	}
 
 	// TODO: Ensure consistency/sanity.
@@ -644,6 +652,9 @@ func init() {
 	initGenesisFlags.Bool(cfgConsensusSkipTimeoutCommit, false, "skip tendermint commit timeout")
 	initGenesisFlags.Duration(cfgConsensusEmptyBlockInterval, 0*time.Second, "tendermint empty block interval")
 	initGenesisFlags.String(cfgConsensusMaxTxSizeBytes, "32kb", "tendermint maximum transaction size (in bytes)")
+	initGenesisFlags.String(cfgConsensusMaxBlockSizeBytes, "21mb", "tendermint maximum block size (in bytes)")
+	initGenesisFlags.Uint64(cfgConsensusMaxBlockGas, 0, "tendermint max gas used per block")
+	initGenesisFlags.Uint64(cfgConsensusMaxEvidenceAge, 100000, "tendermint max evidence age (in blocks)")
 
 	// Consensus backend flag.
 	initGenesisFlags.String(cfgConsensusBackend, tendermint.BackendName, "consensus backend")


### PR DESCRIPTION
Fixes #2367 

This adds MaxBlockSize, MaxBlockGas and MaxEvidenceAge and makes the
Tendermint consensus backend use these instead of the default config.

The genesis document generation utility is updated to use the same
defaults as previously.
