### PR TITLE
go/tendermint/apps/scheduler: Change validator elections again

### DIFF
--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -62,11 +62,11 @@ const (
 	cfgSchedulerMaxBatchSizeBytes = "worker.txnscheduler.batching.max_batch_size_bytes"
 
 	// Scheduler config flags.
-	cfgSchedulerMinValidators            = "scheduler.min_validators"
-	cfgSchedulerMaxValidators            = "scheduler.max_validators"
-	cfgSchedulerValidatorEntityThreshold = "scheduler.validator_entity_threshold"
-	cfgSchedulerDebugBypassStake         = "scheduler.debug.bypass_stake" // nolint: gosec
-	cfgSchedulerDebugStaticValidators    = "scheduler.debug.static_validators"
+	cfgSchedulerMinValidators          = "scheduler.min_validators"
+	cfgSchedulerMaxValidators          = "scheduler.max_validators"
+	cfgSchedulerMaxValidatorsPerEntity = "scheduler.max_validators_per_entity"
+	cfgSchedulerDebugBypassStake       = "scheduler.debug.bypass_stake" // nolint: gosec
+	cfgSchedulerDebugStaticValidators  = "scheduler.debug.static_validators"
 
 	// Beacon config flags.
 	cfgBeaconDebugDeterministic = "beacon.debug.deterministic"
@@ -179,11 +179,11 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 
 	doc.Scheduler = scheduler.Genesis{
 		Parameters: scheduler.ConsensusParameters{
-			MinValidators:            viper.GetInt(cfgSchedulerMinValidators),
-			MaxValidators:            viper.GetInt(cfgSchedulerMaxValidators),
-			ValidatorEntityThreshold: viper.GetInt(cfgSchedulerValidatorEntityThreshold),
-			DebugBypassStake:         viper.GetBool(cfgSchedulerDebugBypassStake),
-			DebugStaticValidators:    viper.GetBool(cfgSchedulerDebugStaticValidators),
+			MinValidators:          viper.GetInt(cfgSchedulerMinValidators),
+			MaxValidators:          viper.GetInt(cfgSchedulerMaxValidators),
+			MaxValidatorsPerEntity: viper.GetInt(cfgSchedulerMaxValidatorsPerEntity),
+			DebugBypassStake:       viper.GetBool(cfgSchedulerDebugBypassStake),
+			DebugStaticValidators:  viper.GetBool(cfgSchedulerDebugStaticValidators),
 		},
 	}
 
@@ -628,7 +628,7 @@ func init() {
 	// Scheduler config flags.
 	initGenesisFlags.Int(cfgSchedulerMinValidators, 1, "minumum number of validators")
 	initGenesisFlags.Int(cfgSchedulerMaxValidators, 100, "maximum number of validators")
-	initGenesisFlags.Int(cfgSchedulerValidatorEntityThreshold, 100, "validator entity threshold")
+	initGenesisFlags.Int(cfgSchedulerMaxValidatorsPerEntity, 1, "maximum number of validators per entity")
 	initGenesisFlags.Bool(cfgSchedulerDebugBypassStake, false, "bypass all stake checks and operations (UNSAFE)")
 	initGenesisFlags.Bool(cfgSchedulerDebugStaticValidators, false, "bypass all validator elections (UNSAFE)")
 

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -512,6 +512,7 @@ func (net *Network) makeGenesis() error {
 		"--consensus.tendermint.timeout_commit", net.cfg.ConsensusTimeoutCommit.String(),
 		"--worker.txnscheduler.batching.max_batch_size", "1",
 		"--registry.debug.allow_unroutable_addresses", "true",
+		"--scheduler.max_validators_per_entity", strconv.Itoa(len(net.Validators())),
 	}
 	if net.cfg.EpochtimeMock {
 		args = append(args, "--epochtime.debug.mock_backend")

--- a/go/scheduler/api/api.go
+++ b/go/scheduler/api/api.go
@@ -193,10 +193,9 @@ type ConsensusParameters struct {
 	// present in elected validator sets.
 	MaxValidators int `json:"max_validators"`
 
-	// ValidatorEntityThreshold is the cutoff point (by escrow balance)
-	// of the top-N entities running validator nodes, to be eligible
-	// for the entity's nodes to be elected as a validator.
-	ValidatorEntityThreshold int `json:"validator_entity_threshold"`
+	// MaxValidatorsPerEntity is the maximum number of validators that
+	// may be elected per entity in a single validator set.
+	MaxValidatorsPerEntity int `json:"max_validators_per_entity"`
 
 	// DebugBypassStake is true iff the scheduler should bypass all of
 	// the staking related checks and operations.

--- a/go/tendermint/apps/scheduler/genesis.go
+++ b/go/tendermint/apps/scheduler/genesis.go
@@ -38,8 +38,14 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 	if doc.Scheduler.Parameters.MaxValidators <= 0 {
 		return fmt.Errorf("tendermint/scheduler: maximum number of validators not configured")
 	}
-	if doc.Scheduler.Parameters.ValidatorEntityThreshold <= 0 {
-		return fmt.Errorf("tendermint/scheduler: validator entity threshold not configured")
+	if doc.Scheduler.Parameters.MaxValidatorsPerEntity <= 0 {
+		return fmt.Errorf("tendermint/scheduler: maximum number of validators per entity not configured")
+	}
+	if doc.Scheduler.Parameters.MaxValidatorsPerEntity > 1 {
+		// This should only ever be true for test deployments.
+		app.logger.Warn("maximum number of validators is non-standard, fairness not guaranteed",
+			"max_valiators_per_entity", doc.Scheduler.Parameters.MaxValidatorsPerEntity,
+		)
 	}
 
 	regState := registryState.NewMutableState(ctx.State())

--- a/go/tendermint/tests/genesis_testnode.go
+++ b/go/tendermint/tests/genesis_testnode.go
@@ -68,11 +68,11 @@ func NewTestNodeGenesisProvider(identity *identity.Identity) (genesis.Provider, 
 		},
 		Scheduler: scheduler.Genesis{
 			Parameters: scheduler.ConsensusParameters{
-				MinValidators:            1,
-				MaxValidators:            100,
-				ValidatorEntityThreshold: 100,
-				DebugBypassStake:         true,
-				DebugStaticValidators:    true,
+				MinValidators:          1,
+				MaxValidators:          100,
+				MaxValidatorsPerEntity: 100,
+				DebugBypassStake:       true,
+				DebugStaticValidators:  true,
 			},
 		},
 		Consensus: consensus.Genesis{


### PR DESCRIPTION
Meetings happened when I was asleep, so change the algorithm to a
sensible version of what was decided on.

Validators are now picked, 1 per entity (at random if multiple candiates
ran by a single entity are available), in order of decending stake, up
to the maximum number of validators.

Unlike the previous version of this where eligibility was also
restricted to the top-N entities by stake, this election algorithm will
continue to go down the entity list if required in an attempt to fill
out the validator set.

Incentives are now "any entity that is running a validator at the time
of the election, that meets the minimum stake threshold", rather than
being restricted to "top-N" as well.

Note: The "1 per entity" limit is configurable.  If more are allowed,
then each entity (in descending order) will have the maximum number of
nodes that they have the stake to support be elected.  This isn't great
but the limit being higher should only ever happen in test environments
anyway.