### PR TITLE
Enable domain separation by ChainID for specific contexts

### DIFF
--- a/go/common/crypto/signature/signer_test.go
+++ b/go/common/crypto/signature/signer_test.go
@@ -1,0 +1,78 @@
+package signature
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContext(t *testing.T) {
+	require := require.New(t)
+
+	// Make sure a context can be registered.
+	var ctx, ctx2 Context
+	require.NotPanics(func() { ctx = NewContext("test: dummy context 1") })
+	require.NotPanics(func() { ctx2 = NewContext("test: dummy context 2") })
+
+	// Make sure we panic if the same context is registered twice.
+	require.Panics(func() { NewContext("test: dummy context 1") })
+	// Even with different options.
+	require.Panics(func() { NewContext("test: dummy context 1", WithChainSeparation()) })
+
+	// Make sure we panic if context is too long.
+	require.Panics(func() { NewContext(strings.Repeat("a", 500)) })
+
+	// Make sure we panic if context includes the chain context separator.
+	require.Panics(func() { NewContext("test: dummy context 1 for chain blah") })
+
+	// Make sure a context with chain separation can be registered.
+	var chainCtx Context
+	require.NotPanics(func() { chainCtx = NewContext("test: dummy context 3", WithChainSeparation()) })
+
+	// Make sure we cannot use an unregistered context.
+	unregCtx := Context("test: unregistered")
+	_, err := PrepareSignerMessage(unregCtx, []byte("message"))
+	require.Error(err, "PrepareSignerMessage should fail with unregistered context")
+
+	// Should work with registered context.
+	msg1, err := PrepareSignerMessage(ctx, []byte("message"))
+	require.NoError(err, "PrepareSignerMessage should work")
+	msg2, err := PrepareSignerMessage(ctx2, []byte("message"))
+	require.NoError(err, "PrepareSignerMessage should work")
+	require.NotEqual(msg1, msg2, "messages for different contexts should be different")
+
+	// Should fail with context that requires chain separation as no
+	// chain context has been set.
+	_, err = PrepareSignerMessage(chainCtx, []byte("message"))
+	require.Error(err, "PrepareSignerMessage should fail without chain context")
+
+	// Make sure we can set a chain context.
+	require.NotPanics(func() { SetChainContext("test: oasis-core tests 1") })
+	// Make sure we can set the same chain context again.
+	require.NotPanics(func() { SetChainContext("test: oasis-core tests 1") })
+	// Make sure we can't modify a set chain context.
+	require.Panics(func() { SetChainContext("test: context change") })
+
+	msg1, err = PrepareSignerMessage(chainCtx, []byte("message"))
+	require.NoError(err, "PrepareSignerMessage should work with chain context")
+
+	// Manually change the chain context to test that this generates different
+	// messages with different contexts (this is otherwise not allowed).
+	chainContextLock.Lock()
+	chainContext = Context("test: oasis-core tests")
+	chainContextLock.Unlock()
+
+	msg2, err = PrepareSignerMessage(chainCtx, []byte("message"))
+	require.NoError(err, "PrepareSignerMessage should work with chain context")
+	require.NotEqual(msg1, msg2, "messages for different chain contexts should be different")
+
+	// Manually delete a registered context so that we can re-register with
+	// different options and check that the messages are different.
+	registeredContexts.Delete(chainCtx)
+
+	chainCtx = NewContext("test: dummy context 3")
+	msg3, err := PrepareSignerMessage(chainCtx, []byte("message"))
+	require.NoError(err, "PrepareSignerMessage should work")
+	require.NotEqual(msg2, msg3, "messages for different contexts should be different")
+}

--- a/go/consensus/tendermint/apps/roothash/genesis.go
+++ b/go/consensus/tendermint/apps/roothash/genesis.go
@@ -46,7 +46,16 @@ func (rq *rootHashQuerier) Genesis(ctx context.Context) (*roothash.Genesis, erro
 	// Get per-runtime blocks.
 	blocks := make(map[signature.MapKey]*block.Block)
 	for _, rt := range runtimes {
-		blocks[rt.Runtime.ID.ToMapKey()] = rt.CurrentBlock
+		blk := *rt.CurrentBlock
+		// Header should be a normal header for genesis.
+		blk.Header.HeaderType = block.Normal
+		// There should be no previous hash.
+		blk.Header.PreviousHash.Empty()
+		// No roothash messages.
+		blk.Header.RoothashMessages = []*block.RoothashMessage{}
+		// No storage signatures.
+		blk.Header.StorageSignatures = []signature.Signature{}
+		blocks[rt.Runtime.ID.ToMapKey()] = &blk
 	}
 
 	params, err := rq.state.ConsensusParameters()

--- a/go/consensus/tendermint/tests/genesis_testnode.go
+++ b/go/consensus/tendermint/tests/genesis_testnode.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/service"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	genesis "github.com/oasislabs/oasis-core/go/genesis/api"
+	genesisTests "github.com/oasislabs/oasis-core/go/genesis/tests"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
 	scheduler "github.com/oasislabs/oasis-core/go/scheduler/api"
@@ -40,7 +41,7 @@ func (p *testNodeGenesisProvider) GetTendermintGenesisDocument() (*tmtypes.Genes
 // running a single node "network", only for testing.
 func NewTestNodeGenesisProvider(identity *identity.Identity) (genesis.Provider, error) {
 	doc := &genesis.Document{
-		ChainID:   "oasis-test-chain",
+		ChainID:   genesisTests.TestChainID,
 		Time:      time.Now(),
 		HaltEpoch: epochtime.EpochTime(math.MaxUint64),
 		EpochTime: epochtime.Genesis{

--- a/go/genesis/file/file.go
+++ b/go/genesis/file/file.go
@@ -3,9 +3,8 @@ package file
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
-
-	"github.com/pkg/errors"
 
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/genesis/api"
@@ -43,7 +42,11 @@ func NewFileProvider(filename string) (api.Provider, error) {
 
 	var doc api.Document
 	if err = json.Unmarshal(raw, &doc); err != nil {
-		return nil, errors.Wrap(err, "genesis: malformed genesis file")
+		return nil, fmt.Errorf("genesis: malformed genesis file: %w", err)
+	}
+
+	if err = doc.SanityCheck(); err != nil {
+		return nil, fmt.Errorf("genesis: bad genesis file: %w", err)
 	}
 
 	return &fileProvider{document: &doc}, nil

--- a/go/genesis/tests/tests.go
+++ b/go/genesis/tests/tests.go
@@ -1,0 +1,12 @@
+package tests
+
+import "github.com/oasislabs/oasis-core/go/common/crypto/signature"
+
+// TestChainID is the chain ID that should be used in tests.
+const TestChainID = "test: oasis-core tests"
+
+// SetTestChainContext configures the TestChainID as the chain domain
+// separation context.
+func SetTestChainContext() {
+	signature.SetChainContext(TestChainID)
+}

--- a/go/oasis-node/cmd/debug/byzantine/tendermint.go
+++ b/go/oasis-node/cmd/debug/byzantine/tendermint.go
@@ -7,6 +7,7 @@ import (
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	tmtypes "github.com/tendermint/tendermint/types"
 
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/service"
@@ -30,6 +31,15 @@ func (ht *honestTendermint) start(id *identity.Identity, dataDir string) error {
 	if err != nil {
 		return errors.Wrap(err, "genesis DefaultFileProvider")
 	}
+
+	// Retrieve the genesis document and use it to configure the ChainID for
+	// signature domain separation. We do this as early as possible.
+	genesisDoc, err := genesis.GetGenesisDocument()
+	if err != nil {
+		return err
+	}
+	signature.SetChainContext(genesisDoc.ChainID)
+
 	ht.service, err = tendermint.New(context.Background(), dataDir, id, genesis)
 	if err != nil {
 		return errors.Wrap(err, "tendermint New")

--- a/go/oasis-test-runner/scenario/e2e/halt_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/halt_restore.go
@@ -22,7 +22,7 @@ var (
 	// HaltRestore is the halt and restore scenario.
 	HaltRestore scenario.Scenario = newHaltRestoreImpl()
 
-	dumpGlob = "genesis-oasis-test-runner-at-*.json"
+	dumpGlob = "genesis-*.json"
 )
 
 const haltEpoch = 3

--- a/go/oasis-test-runner/scenario/e2e/stake_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/stake_cli.go
@@ -381,6 +381,8 @@ func (s *stakeCLIImpl) genTransferTx(childEnv *env.Env, amount int, nonce int, d
 		"--" + stake.CfgTxFeeAmount, strconv.Itoa(feeAmount),
 		"--" + stake.CfgTxFeeGas, strconv.Itoa(feeGas),
 		"--" + flags.CfgDebugTestEntity,
+		"--" + common.CfgDebugAllowTestKeys,
+		"--" + flags.CfgGenesisFile, s.basicImpl.net.GenesisPath(),
 	}
 	if err := runSubCommand(childEnv, "gen_transfer", s.basicImpl.net.Config().NodeBinary, args); err != nil {
 		return fmt.Errorf("genTransferTx: failed to generate transfer tx: %w", err)
@@ -399,6 +401,8 @@ func (s *stakeCLIImpl) genBurnTx(childEnv *env.Env, amount int, nonce int, txPat
 		"--" + stake.CfgTxFeeAmount, strconv.Itoa(feeAmount),
 		"--" + stake.CfgTxFeeGas, strconv.Itoa(feeGas),
 		"--" + flags.CfgDebugTestEntity,
+		"--" + common.CfgDebugAllowTestKeys,
+		"--" + flags.CfgGenesisFile, s.basicImpl.net.GenesisPath(),
 	}
 	if err := runSubCommand(childEnv, "gen_burn", s.basicImpl.net.Config().NodeBinary, args); err != nil {
 		return fmt.Errorf("genBurnTx: failed to generate burn tx: %w", err)
@@ -418,6 +422,8 @@ func (s *stakeCLIImpl) genEscrowTx(childEnv *env.Env, amount int, nonce int, esc
 		"--" + stake.CfgTxFeeAmount, strconv.Itoa(feeAmount),
 		"--" + stake.CfgTxFeeGas, strconv.Itoa(feeGas),
 		"--" + flags.CfgDebugTestEntity,
+		"--" + common.CfgDebugAllowTestKeys,
+		"--" + flags.CfgGenesisFile, s.basicImpl.net.GenesisPath(),
 	}
 	if err := runSubCommand(childEnv, "gen_escrow", s.basicImpl.net.Config().NodeBinary, args); err != nil {
 		return fmt.Errorf("genEscrowTx: failed to generate escrow tx: %w", err)
@@ -437,6 +443,8 @@ func (s *stakeCLIImpl) genReclaimEscrowTx(childEnv *env.Env, amount int, nonce i
 		"--" + stake.CfgTxFeeAmount, strconv.Itoa(feeAmount),
 		"--" + stake.CfgTxFeeGas, strconv.Itoa(feeGas),
 		"--" + flags.CfgDebugTestEntity,
+		"--" + common.CfgDebugAllowTestKeys,
+		"--" + flags.CfgGenesisFile, s.basicImpl.net.GenesisPath(),
 	}
 	if err := runSubCommand(childEnv, "gen_reclaim_escrow", s.basicImpl.net.Config().NodeBinary, args); err != nil {
 		return fmt.Errorf("genReclaimEscrowTx: failed to generate reclaim escrow tx: %w", err)

--- a/go/roothash/api/block/block.go
+++ b/go/roothash/api/block/block.go
@@ -37,6 +37,7 @@ func NewGenesisBlock(id signature.PublicKey, timestamp uint64) *Block {
 	blk.Header.Version = 0
 	blk.Header.Timestamp = timestamp
 	_ = blk.Header.Namespace.UnmarshalBinary(id[:])
+	blk.Header.PreviousHash.Empty()
 	blk.Header.IORoot.Empty()
 	blk.Header.StateRoot.Empty()
 

--- a/go/roothash/api/commitment/compute.go
+++ b/go/roothash/api/commitment/compute.go
@@ -16,7 +16,7 @@ import (
 var (
 	// ComputeSignatureContext is the signature context used to sign compute
 	// worker commitments.
-	ComputeSignatureContext = signature.NewContext("oasis-core/roothash: compute commitment")
+	ComputeSignatureContext = signature.NewContext("oasis-core/roothash: compute commitment", signature.WithChainSeparation())
 
 	// ComputeResultsHeaderSignatureContext is the signature context used to
 	// sign compute results headers with RAK.

--- a/go/roothash/api/commitment/merge.go
+++ b/go/roothash/api/commitment/merge.go
@@ -12,7 +12,7 @@ import (
 
 // MergeSignatureContext is the signature context used to sign merge
 // worker commitments.
-var MergeSignatureContext = signature.NewContext("oasis-core/roothash: merge commitment")
+var MergeSignatureContext = signature.NewContext("oasis-core/roothash: merge commitment", signature.WithChainSeparation())
 
 type MergeBody struct {
 	ComputeCommits []ComputeCommitment `json:"commits"`

--- a/go/roothash/api/commitment/pool_test.go
+++ b/go/roothash/api/commitment/pool_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasislabs/oasis-core/go/common/node"
+	genesisTests "github.com/oasislabs/oasis-core/go/genesis/tests"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
 	scheduler "github.com/oasislabs/oasis-core/go/scheduler/api"
@@ -53,6 +54,8 @@ func (n *staticSignatureVerifier) VerifyCommitteeSignatures(kind scheduler.Commi
 }
 
 func TestPoolDefault(t *testing.T) {
+	genesisTests.SetTestChainContext()
+
 	// Generate a commitment.
 	sk, err := memorySigner.NewSigner(rand.Reader)
 	require.NoError(t, err, "NewSigner")
@@ -86,6 +89,8 @@ func TestPoolDefault(t *testing.T) {
 }
 
 func TestPoolSingleCommitment(t *testing.T) {
+	genesisTests.SetTestChainContext()
+
 	// Generate a non-TEE runtime.
 	var rtID signature.PublicKey
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
@@ -190,6 +195,8 @@ func TestPoolSingleCommitment(t *testing.T) {
 }
 
 func TestPoolSingleCommitmentTEE(t *testing.T) {
+	genesisTests.SetTestChainContext()
+
 	// Generate a TEE runtime.
 	var rtID signature.PublicKey
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
@@ -283,6 +290,8 @@ func TestPoolSingleCommitmentTEE(t *testing.T) {
 }
 
 func TestPoolTwoCommitments(t *testing.T) {
+	genesisTests.SetTestChainContext()
+
 	rt, sks, committee, nodeInfo := generateMockCommittee(t)
 	sk1 := sks[0]
 	sk2 := sks[1]
@@ -422,6 +431,8 @@ func TestPoolTwoCommitments(t *testing.T) {
 }
 
 func TestPoolSerialization(t *testing.T) {
+	genesisTests.SetTestChainContext()
+
 	// Generate a non-TEE runtime.
 	var rtID signature.PublicKey
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
@@ -490,6 +501,8 @@ func TestPoolSerialization(t *testing.T) {
 }
 
 func TestMultiPoolSerialization(t *testing.T) {
+	genesisTests.SetTestChainContext()
+
 	rt, sks1, committee1, nodeInfo1 := generateMockCommittee(t)
 	_, sks2, committee2, nodeInfo2 := generateMockCommittee(t)
 	com1ID := committee1.EncodedMembersHash()
@@ -560,6 +573,8 @@ func TestMultiPoolSerialization(t *testing.T) {
 }
 
 func TestPoolMergeCommitment(t *testing.T) {
+	genesisTests.SetTestChainContext()
+
 	rt, computeSks, computeCommittee, computeNodeInfo := generateMockCommittee(t)
 	_, mergeSks, mergeCommittee, mergeNodeInfo := generateMockCommittee(t)
 	mergeCommittee.Kind = scheduler.KindMerge
@@ -720,6 +735,8 @@ func TestPoolMergeCommitment(t *testing.T) {
 }
 
 func TestMultiPool(t *testing.T) {
+	genesisTests.SetTestChainContext()
+
 	rt, sks1, committee1, nodeInfo1 := generateMockCommittee(t)
 	_, sks2, committee2, nodeInfo2 := generateMockCommittee(t)
 	com1ID := committee1.EncodedMembersHash()
@@ -889,6 +906,8 @@ func TestMultiPool(t *testing.T) {
 }
 
 func TestTryFinalize(t *testing.T) {
+	genesisTests.SetTestChainContext()
+
 	rt, sks, committee, nodeInfo := generateMockCommittee(t)
 	sk1 := sks[0]
 	sk2 := sks[1]

--- a/go/roothash/api/commitment/txnscheduler.go
+++ b/go/roothash/api/commitment/txnscheduler.go
@@ -9,7 +9,7 @@ import (
 
 // TxnSchedulerBatchDispatchSigCtx is the context used for signing
 // transaction scheduler batch dispatch messages.
-var TxnSchedulerBatchDispatchSigCtx = signature.NewContext("oasis-core/roothash: tx batch dispatch")
+var TxnSchedulerBatchDispatchSigCtx = signature.NewContext("oasis-core/roothash: tx batch dispatch", signature.WithChainSeparation())
 
 // TxnSchedulerBatchDispatch is the message sent from the transaction
 // scheduler to compute workers after a batch is ready to be computed.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -28,16 +28,16 @@ const (
 
 var (
 	// TransferSignatureContext is the context used for transfers.
-	TransferSignatureContext = signature.NewContext("oasis-core/staking: transfer")
+	TransferSignatureContext = signature.NewContext("oasis-core/staking: transfer", signature.WithChainSeparation())
 
 	// BurnSignatureContext is the context used for burns.
-	BurnSignatureContext = signature.NewContext("oasis-core/staking: burn")
+	BurnSignatureContext = signature.NewContext("oasis-core/staking: burn", signature.WithChainSeparation())
 
 	// EscrowSignatureContext is the context used for escrows.
-	EscrowSignatureContext = signature.NewContext("oasis-core/staking: escrow")
+	EscrowSignatureContext = signature.NewContext("oasis-core/staking: escrow", signature.WithChainSeparation())
 
 	// ReclaimEscrowSignatureContext is the context used for escrow reclimation.
-	ReclaimEscrowSignatureContext = signature.NewContext("oasis-core/staking: reclaim escrow")
+	ReclaimEscrowSignatureContext = signature.NewContext("oasis-core/staking: reclaim escrow", signature.WithChainSeparation())
 
 	// ErrInvalidArgument is the error returned on malformed arguments.
 	ErrInvalidArgument = errors.New("staking: invalid argument")

--- a/go/staking/tests/tendermint.go
+++ b/go/staking/tests/tendermint.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	tmcrypto "github.com/oasislabs/oasis-core/go/consensus/tendermint/crypto"
+	genesisTests "github.com/oasislabs/oasis-core/go/genesis/tests"
 	"github.com/oasislabs/oasis-core/go/staking/api"
 )
 
@@ -59,8 +60,8 @@ func tendermintMakeDoubleSignEvidence(t *testing.T, ident *identity.Identity) ap
 	ev := &tmtypes.DuplicateVoteEvidence{
 		PubKey: pv1.GetPubKey(),
 		// NOTE: ChainID must match the unit test genesis block.
-		VoteA: makeVote(pv1, "oasis-test-chain", 0, 1, 2, 1, blockID1),
-		VoteB: makeVote(pv2, "oasis-test-chain", 0, 1, 2, 1, blockID2),
+		VoteA: makeVote(pv1, genesisTests.TestChainID, 0, 1, 2, 1, blockID1),
+		VoteB: makeVote(pv2, genesisTests.TestChainID, 0, 1, 2, 1, blockID2),
 	}
 	return api.NewConsensusEvidence(ev)
 }

--- a/go/storage/api/api.go
+++ b/go/storage/api/api.go
@@ -60,7 +60,7 @@ var (
 	ErrRootMustFollowOld = nodedb.ErrRootMustFollowOld
 
 	// ReceiptSignatureContext is the signature context used for verifying MKVS receipts.
-	ReceiptSignatureContext = signature.NewContext("oasis-core/storage: receipt")
+	ReceiptSignatureContext = signature.NewContext("oasis-core/storage: receipt", signature.WithChainSeparation())
 
 	_ cbor.Marshaler   = (*ReceiptBody)(nil)
 	_ cbor.Unmarshaler = (*ReceiptBody)(nil)

--- a/go/storage/mkvs/urkel/interop/cmd/protocol_server.go
+++ b/go/storage/mkvs/urkel/interop/cmd/protocol_server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/grpc"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/logging"
+	genesisTests "github.com/oasislabs/oasis-core/go/genesis/tests"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/background"
 	"github.com/oasislabs/oasis-core/go/storage"
 	storageApi "github.com/oasislabs/oasis-core/go/storage/api"
@@ -41,6 +42,8 @@ func doProtoServer(cmd *cobra.Command, args []string) {
 		logger.Error("no data directory specified")
 		return
 	}
+
+	genesisTests.SetTestChainContext()
 
 	// Generate dummy identity.
 	ident, err := identity.LoadOrGenerate(dataDir, memorySigner.NewFactory())

--- a/go/storage/tests/tester.go
+++ b/go/storage/tests/tester.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
+	genesisTests "github.com/oasislabs/oasis-core/go/genesis/tests"
 	"github.com/oasislabs/oasis-core/go/storage/api"
 	"github.com/oasislabs/oasis-core/go/storage/mkvs/urkel"
 	"github.com/oasislabs/oasis-core/go/storage/mkvs/urkel/writelog"
@@ -82,6 +83,8 @@ func foldWriteLogIterator(t *testing.T, w api.WriteLogIterator) api.WriteLog {
 // StorageImplementationTests exercises the basic functionality of a storage
 // backend.
 func StorageImplementationTests(t *testing.T, backend api.Backend, namespace common.Namespace, round uint64) {
+	genesisTests.SetTestChainContext()
+
 	<-backend.Initialized()
 
 	t.Run("Basic", func(t *testing.T) {


### PR DESCRIPTION
Fixes #2364 

Note: This is a BREAKING change as it changes the signing contexts. It also makes some contexts dependent on the value of ChainID as specified in the genesis file so specific statements can no longer be mixed between different chains.

Note: This changes the invocations for generating staking transactions as the genesis file must now be passed as an argument (see E2E tests) in order to extract the ChainID.