### PR TITLE
go/common/crypto/signature: Fail when unmarshaling nil keys

### DIFF
--- a/go/common/node/node_test.go
+++ b/go/common/node/node_test.go
@@ -20,6 +20,9 @@ func TestSerialization(t *testing.T) {
 		P2P: P2PInfo{
 			ID: signature.PublicKey(key),
 		},
+		Consensus: ConsensusInfo{
+			ID: signature.PublicKey(key),
+		},
 		Expiration: 42,
 		Roles:      RoleComputeWorker,
 	}

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -58,14 +58,14 @@ var (
 
 	// CommitteeProtocol versions the P2P protocol used by the
 	// committee members.
-	CommitteeProtocol = Version{Major: 0, Minor: 5, Patch: 0}
+	CommitteeProtocol = Version{Major: 0, Minor: 6, Patch: 0}
 
 	// BackendProtocol versions all data structures and processing used by
 	// the epochtime, beacon, registry, roothash, etc.
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	BackendProtocol = Version{Major: 0, Minor: 14, Patch: 0}
+	BackendProtocol = Version{Major: 0, Minor: 15, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -272,6 +272,13 @@ func VerifyRegisterEntityArgs(logger *logging.Logger, sigEnt *entity.SignedEntit
 	// Ensure the node list has no duplicates.
 	nodesMap := make(map[signature.MapKey]bool)
 	for _, v := range ent.Nodes {
+		if !v.IsValid() {
+			logger.Error("RegisterEntity: malformed node id",
+				"entity", ent,
+			)
+			return nil, ErrInvalidArgument
+		}
+
 		mk := v.ToMapKey()
 		if nodesMap[mk] {
 			logger.Error("RegisterEntity: duplicate entries in node list",


### PR DESCRIPTION
Fixes #2379 

Note: This is a BREAKING change as it makes some existing serialized state invalid.