### PR TITLE
go/registry/api: Allow deployments without a KM operator

### DIFF
--- a/go/consensus/tendermint/apps/registry/genesis.go
+++ b/go/consensus/tendermint/apps/registry/genesis.go
@@ -29,9 +29,17 @@ func (app *registryApplication) InitChain(ctx *abci.Context, request types.Reque
 	state := registryState.NewMutableState(ctx.State())
 	state.SetConsensusParameters(&st.Parameters)
 
-	app.logger.Debug("InitChain: Registering key manager operator",
-		"id", st.Parameters.KeyManagerOperator,
-	)
+	if st.Parameters.KeyManagerOperator.IsValid() {
+		app.logger.Debug("InitChain: Registering key manager operator",
+			"id", st.Parameters.KeyManagerOperator,
+		)
+	} else {
+		// This is informational for now since there are configurations
+		// that do not have a key manager.
+		app.logger.Warn("InitChain: Invalid key manager operator, key maanger will not work",
+			"id", st.Parameters.KeyManagerOperator,
+		)
+	}
 
 	for _, v := range st.Entities {
 		app.logger.Debug("InitChain: Registering genesis entity",

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -353,6 +353,11 @@ func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []stri
 		}
 
 		regSt.Parameters.KeyManagerOperator = ent.ID
+	} else {
+		l.Warn("no key manager operator specified")
+
+		var zeroPk [signature.PublicKeySize]byte
+		regSt.Parameters.KeyManagerOperator = signature.PublicKey(zeroPk[:])
 	}
 
 	for _, v := range runtimes {

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -911,9 +911,8 @@ type ConsensusParameters struct {
 
 // SanityCheck does basic sanity checking on the genesis state.
 func (g *Genesis) SanityCheck() error { // nolint: gocyclo
-	if !g.Parameters.KeyManagerOperator.IsValid() {
-		return fmt.Errorf("registry: sanity check failed: key manager operator's public key is invalid")
-	}
+	// This could check KeyManagerOperator, but some configurations don't
+	// use a key manager, so the parameter is optional.
 
 	// Check entities.
 	seenEntities := make(map[signature.MapKey]bool)


### PR DESCRIPTION
Fixes #2381.