### PR TITLE
go/common/crypto/signature: Change PublicKey to a fixed sized array

### DIFF
--- a/go/client/indexer/bleve.go
+++ b/go/client/indexer/bleve.go
@@ -26,9 +26,9 @@ const (
 
 var (
 	// txDocIDKeyFmt is the key format used for indexed transaction document IDs.
-	txDocIDKeyFmt = keyformat.New('T', &signature.MapKey{}, uint64(0), &hash.Hash{}, uint32(0))
+	txDocIDKeyFmt = keyformat.New('T', &signature.PublicKey{}, uint64(0), &hash.Hash{}, uint32(0))
 	// blockDocIDKeyFmt is the key format used for indexed block document IDs.
-	blockDocIDKeyFmt = keyformat.New('B', &signature.MapKey{}, uint64(0))
+	blockDocIDKeyFmt = keyformat.New('B', &signature.PublicKey{}, uint64(0))
 
 	// queryByKindBlock is a query matching documents of kind docTypeBlock.
 	queryByKindBlock bleveQuery.Query

--- a/go/common/crypto/signature/signers/file/file_signer.go
+++ b/go/common/crypto/signature/signers/file/file_signer.go
@@ -165,7 +165,9 @@ type Signer struct {
 
 // Public returns the PublicKey corresponding to the signer.
 func (s *Signer) Public() signature.PublicKey {
-	return signature.PublicKey(s.privateKey.Public().(ed25519.PublicKey))
+	var pk signature.PublicKey
+	_ = pk.UnmarshalBinary(s.privateKey.Public().(ed25519.PublicKey))
+	return pk
 }
 
 // ContextSign generates a signature with the private key over the context and

--- a/go/common/crypto/signature/signers/memory/memory_signer.go
+++ b/go/common/crypto/signature/signers/memory/memory_signer.go
@@ -55,7 +55,9 @@ type Signer struct {
 
 // Public returns the PublicKey corresponding to the signer.
 func (s *Signer) Public() signature.PublicKey {
-	return signature.PublicKey(s.privateKey.Public().(ed25519.PublicKey))
+	var pk signature.PublicKey
+	_ = pk.UnmarshalBinary(s.privateKey.Public().(ed25519.PublicKey))
+	return pk
 }
 
 // ContextSign generates a signature with the private key over the context and

--- a/go/common/grpc/policy.go
+++ b/go/common/grpc/policy.go
@@ -57,7 +57,7 @@ type DynamicRuntimePolicyChecker struct {
 	sync.RWMutex
 
 	// Map from runtime IDs to corresponding access control policies.
-	accessPolicies map[signature.MapKey]accessctl.Policy
+	accessPolicies map[signature.PublicKey]accessctl.Policy
 }
 
 // SetAccessPolicy sets the PolicyChecker's access policy.
@@ -67,7 +67,7 @@ func (c *DynamicRuntimePolicyChecker) SetAccessPolicy(policy accessctl.Policy, r
 	c.Lock()
 	defer c.Unlock()
 
-	c.accessPolicies[runtimeID.ToMapKey()] = policy
+	c.accessPolicies[runtimeID] = policy
 }
 
 // CheckAccessAllowed checks if the connected peer is allowed access to a server method according
@@ -97,7 +97,7 @@ func (c *DynamicRuntimePolicyChecker) CheckAccessAllowed(
 	}
 	peerCert := tlsAuth.State.PeerCertificates[0]
 	subject := accessctl.SubjectFromX509Certificate(peerCert)
-	policy := c.accessPolicies[runtimeID.ToMapKey()]
+	policy := c.accessPolicies[runtimeID]
 	if policy == nil || !policy.IsAllowed(subject, method) {
 		return ErrForbiddenByPolicy{
 			method:    method,
@@ -111,6 +111,6 @@ func (c *DynamicRuntimePolicyChecker) CheckAccessAllowed(
 // NewDynamicRuntimePolicyChecker creates a new dynamic runtime policy checker instance.
 func NewDynamicRuntimePolicyChecker() *DynamicRuntimePolicyChecker {
 	return &DynamicRuntimePolicyChecker{
-		accessPolicies: make(map[signature.MapKey]accessctl.Policy),
+		accessPolicies: make(map[signature.PublicKey]accessctl.Policy),
 	}
 }

--- a/go/common/keyformat/key_format_test.go
+++ b/go/common/keyformat/key_format_test.go
@@ -61,10 +61,7 @@ func TestKeyFormat(t *testing.T) {
 }
 
 func TestPublicKey(t *testing.T) {
-	// NOTE: When using a signature.PublicKey we must use MapKey in the format
-	//       specification to get the correct size. Then we can use PublicKey
-	//       during actual serialization/deserialization.
-	fmt := New('S', &signature.MapKey{})
+	fmt := New('S', &signature.PublicKey{})
 	require.Equal(t, 1+32, fmt.Size(), "format size")
 
 	var pk signature.PublicKey

--- a/go/common/node/node_test.go
+++ b/go/common/node/node_test.go
@@ -11,17 +11,20 @@ import (
 
 func TestSerialization(t *testing.T) {
 	key, _, _ := ed25519.GenerateKey(nil)
+	var publicKey signature.PublicKey
+	_ = publicKey.UnmarshalBinary(key)
+
 	n := Node{
-		ID:       signature.PublicKey(key),
-		EntityID: signature.PublicKey(key),
+		ID:       publicKey,
+		EntityID: publicKey,
 		Committee: CommitteeInfo{
 			Certificate: []byte("I moon o'er you, Inis Mona, As long as I breathe, I'll call you my home"),
 		},
 		P2P: P2PInfo{
-			ID: signature.PublicKey(key),
+			ID: publicKey,
 		},
 		Consensus: ConsensusInfo{
-			ID: signature.PublicKey(key),
+			ID: publicKey,
 		},
 		Expiration: 42,
 		Roles:      RoleComputeWorker,

--- a/go/consensus/tendermint/apps/keymanager/genesis.go
+++ b/go/consensus/tendermint/apps/keymanager/genesis.go
@@ -29,7 +29,7 @@ func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.Req
 	// before the keymanager, and just query the registry for the runtime
 	// list.
 	regSt := doc.Registry
-	rtMap := make(map[signature.MapKey]*registry.Runtime)
+	rtMap := make(map[signature.PublicKey]*registry.Runtime)
 	for _, v := range regSt.Runtimes {
 		rt, err := registry.VerifyRegisterRuntimeArgs(app.logger, v, true)
 		if err != nil {
@@ -40,14 +40,14 @@ func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.Req
 		}
 
 		if rt.Kind == registry.KindKeyManager {
-			rtMap[rt.ID.ToMapKey()] = rt
+			rtMap[rt.ID] = rt
 		}
 	}
 
 	var toEmit []*keymanager.Status
 	state := keymanagerState.NewMutableState(ctx.State())
 	for _, v := range st.Statuses {
-		rt := rtMap[v.ID.ToMapKey()]
+		rt := rtMap[v.ID]
 		if rt == nil {
 			app.logger.Error("InitChain: State for unknown runtime",
 				"id", v.ID,

--- a/go/consensus/tendermint/apps/keymanager/state/state.go
+++ b/go/consensus/tendermint/apps/keymanager/state/state.go
@@ -14,7 +14,7 @@ var (
 	// statusKeyFmt is the key manager status key format.
 	//
 	// Value is CBOR-serialized key manager status.
-	statusKeyFmt = keyformat.New(0x70, &signature.MapKey{})
+	statusKeyFmt = keyformat.New(0x70, &signature.PublicKey{})
 )
 
 type ImmutableState struct {

--- a/go/consensus/tendermint/apps/registry/genesis.go
+++ b/go/consensus/tendermint/apps/registry/genesis.go
@@ -84,10 +84,7 @@ func (app *registryApplication) InitChain(ctx *abci.Context, request types.Reque
 	}
 	var ns []*nodeStatus
 	for k, v := range st.NodeStatuses {
-		var id signature.PublicKey
-		id.FromMapKey(k)
-
-		ns = append(ns, &nodeStatus{id, v})
+		ns = append(ns, &nodeStatus{k, v})
 	}
 	// Make sure that we apply node status updates in a canonical order.
 	sort.SliceStable(ns, func(i, j int) bool { return bytes.Compare(ns[i].id[:], ns[j].id[:]) < 0 })

--- a/go/consensus/tendermint/apps/registry/state/state.go
+++ b/go/consensus/tendermint/apps/registry/state/state.go
@@ -19,20 +19,20 @@ var (
 	// signedEntityKeyFmt is the key format used for signed entities.
 	//
 	// Value is CBOR-serialized signed entity.
-	signedEntityKeyFmt = keyformat.New(0x10, &signature.MapKey{})
+	signedEntityKeyFmt = keyformat.New(0x10, &signature.PublicKey{})
 	// signedNodeKeyFmt is the key format used for signed nodes.
 	//
 	// Value is CBOR-serialized signed node.
-	signedNodeKeyFmt = keyformat.New(0x11, &signature.MapKey{})
+	signedNodeKeyFmt = keyformat.New(0x11, &signature.PublicKey{})
 	// signedNodeByEntityKeyFmt is the key format used for signed node by entity
 	// index.
 	//
 	// Value is empty.
-	signedNodeByEntityKeyFmt = keyformat.New(0x12, &signature.MapKey{}, &signature.MapKey{})
+	signedNodeByEntityKeyFmt = keyformat.New(0x12, &signature.PublicKey{}, &signature.PublicKey{})
 	// signedRuntimeKeyFmt is the key format used for signed runtimes.
 	//
 	// Value is CBOR-serialized signed runtime.
-	signedRuntimeKeyFmt = keyformat.New(0x13, &signature.MapKey{})
+	signedRuntimeKeyFmt = keyformat.New(0x13, &signature.PublicKey{})
 	// nodeByConsAddressKeyFmt is the key format used for the consensus address to
 	// node public key mapping.
 	//
@@ -45,7 +45,7 @@ var (
 	// nodeStatusKeyFmt is the key format used for node statuses.
 	//
 	// Value is CBOR-serialized node status.
-	nodeStatusKeyFmt = keyformat.New(0x15, &signature.MapKey{})
+	nodeStatusKeyFmt = keyformat.New(0x15, &signature.PublicKey{})
 	// parametersKeyFmt is the key format used for consensus parameters.
 	//
 	// Value is CBOR-serialized roothash.ConsensusParameters.
@@ -315,14 +315,14 @@ func (s *ImmutableState) NodeStatus(id signature.PublicKey) (*registry.NodeStatu
 	return &status, nil
 }
 
-func (s *ImmutableState) NodeStatuses() (map[signature.MapKey]*registry.NodeStatus, error) {
-	statuses := make(map[signature.MapKey]*registry.NodeStatus)
+func (s *ImmutableState) NodeStatuses() (map[signature.PublicKey]*registry.NodeStatus, error) {
+	statuses := make(map[signature.PublicKey]*registry.NodeStatus)
 	s.Snapshot.IterateRange(
 		nodeStatusKeyFmt.Encode(),
 		nil,
 		true,
 		func(key, value []byte) bool {
-			var nodeID signature.MapKey
+			var nodeID signature.PublicKey
 			if !nodeStatusKeyFmt.Decode(key, &nodeID) {
 				return true
 			}

--- a/go/consensus/tendermint/apps/roothash/genesis.go
+++ b/go/consensus/tendermint/apps/roothash/genesis.go
@@ -44,7 +44,7 @@ func (rq *rootHashQuerier) Genesis(ctx context.Context) (*roothash.Genesis, erro
 	runtimes := rq.state.Runtimes()
 
 	// Get per-runtime blocks.
-	blocks := make(map[signature.MapKey]*block.Block)
+	blocks := make(map[signature.PublicKey]*block.Block)
 	for _, rt := range runtimes {
 		blk := *rt.CurrentBlock
 		// Header should be a normal header for genesis.
@@ -55,7 +55,7 @@ func (rq *rootHashQuerier) Genesis(ctx context.Context) (*roothash.Genesis, erro
 		blk.Header.RoothashMessages = []*block.RoothashMessage{}
 		// No storage signatures.
 		blk.Header.StorageSignatures = []signature.Signature{}
-		blocks[rt.Runtime.ID.ToMapKey()] = &blk
+		blocks[rt.Runtime.ID] = &blk
 	}
 
 	params, err := rq.state.ConsensusParameters()

--- a/go/consensus/tendermint/apps/roothash/state/state.go
+++ b/go/consensus/tendermint/apps/roothash/state/state.go
@@ -18,7 +18,7 @@ var (
 	// runtimeKeyFmt is the key format used for per-runtime roothash state.
 	//
 	// Value is CBOR-serialized runtime state.
-	runtimeKeyFmt = keyformat.New(0x20, &signature.MapKey{})
+	runtimeKeyFmt = keyformat.New(0x20, &signature.PublicKey{})
 	// parametersKeyFmt is the key format used for consensus parameters.
 	//
 	// Value is CBOR-serialized roothash.ConsensusParameters.

--- a/go/consensus/tendermint/apps/scheduler/genesis.go
+++ b/go/consensus/tendermint/apps/scheduler/genesis.go
@@ -82,10 +82,10 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 		return fmt.Errorf("tendermint/scheduler: couldn't get nodes: %w", err)
 	}
 
-	registeredValidators := make(map[signature.MapKey]*node.Node)
+	registeredValidators := make(map[signature.PublicKey]*node.Node)
 	for _, v := range nodes {
 		if v.HasRoles(node.RoleValidator) {
-			registeredValidators[v.Consensus.ID.ToMapKey()] = v
+			registeredValidators[v.Consensus.ID] = v
 		}
 	}
 
@@ -120,7 +120,7 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 			return fmt.Errorf("scheduler: invalid genesis validator voting power: %v", power)
 		}
 
-		n := registeredValidators[id.ToMapKey()]
+		n := registeredValidators[id]
 		if n == nil {
 			app.logger.Error("genesis validator not in registry",
 				"id", id,

--- a/go/consensus/tendermint/apps/scheduler/state/state.go
+++ b/go/consensus/tendermint/apps/scheduler/state/state.go
@@ -17,7 +17,7 @@ var (
 	// committeeKeyFmt is the key format used for committees.
 	//
 	// Value is CBOR-serialized committee.
-	committeeKeyFmt = keyformat.New(0x60, uint8(0), &signature.MapKey{})
+	committeeKeyFmt = keyformat.New(0x60, uint8(0), &signature.PublicKey{})
 	// validatorsCurrentKeyFmt is the key format used for the current set of
 	// validators.
 	//

--- a/go/consensus/tendermint/apps/staking/genesis.go
+++ b/go/consensus/tendermint/apps/staking/genesis.go
@@ -48,8 +48,7 @@ func (app *stakingApplication) initLedger(state *stakingState.MutableState, st *
 
 	var ups []ledgerUpdate
 	for k, v := range st.Ledger {
-		var id signature.PublicKey
-		id.FromMapKey(k)
+		id := k
 
 		if !v.General.Balance.IsValid() {
 			app.logger.Error("InitChain: invalid genesis general balance",
@@ -120,15 +119,9 @@ func (app *stakingApplication) initDelegations(state *stakingState.MutableState,
 		delegation  *staking.Delegation
 	}
 	var dups []delegationUpdate
-	for keyEscrowID, delegations := range st.Delegations {
-		var escrowID signature.PublicKey
-		escrowID.FromMapKey(keyEscrowID)
-
+	for escrowID, delegations := range st.Delegations {
 		delegationShares := quantity.NewQuantity()
-		for keyDelegatorID, delegation := range delegations {
-			var delegatorID signature.PublicKey
-			delegatorID.FromMapKey(keyDelegatorID)
-
+		for delegatorID, delegation := range delegations {
 			if err := delegationShares.Add(&delegation.Shares); err != nil {
 				app.logger.Error("InitChain: failed to add delegation shares",
 					"err", err,
@@ -169,15 +162,9 @@ func (app *stakingApplication) initDebondingDelegations(state *stakingState.Muta
 		delegation  *staking.DebondingDelegation
 	}
 	var deups []debondingDelegationUpdate
-	for keyEscrowID, delegators := range st.DebondingDelegations {
-		var escrowID signature.PublicKey
-		escrowID.FromMapKey(keyEscrowID)
-
+	for escrowID, delegators := range st.DebondingDelegations {
 		debondingShares := quantity.NewQuantity()
-		for keyDelegatorID, delegations := range delegators {
-			var delegatorID signature.PublicKey
-			delegatorID.FromMapKey(keyDelegatorID)
-
+		for delegatorID, delegations := range delegators {
 			for idx, delegation := range delegations {
 				if err := debondingShares.Add(&delegation.Shares); err != nil {
 					app.logger.Error("InitChain: failed to add debonding delegation shares",
@@ -271,10 +258,10 @@ func (sq *stakingQuerier) Genesis(ctx context.Context) (*staking.Genesis, error)
 	if err != nil {
 		return nil, err
 	}
-	ledger := make(map[signature.MapKey]*staking.Account)
+	ledger := make(map[signature.PublicKey]*staking.Account)
 	for _, acctID := range accounts {
 		acct := sq.state.Account(acctID)
-		ledger[acctID.ToMapKey()] = acct
+		ledger[acctID] = acct
 	}
 
 	delegations, err := sq.state.Delegations()

--- a/go/consensus/tendermint/apps/staking/query.go
+++ b/go/consensus/tendermint/apps/staking/query.go
@@ -24,7 +24,7 @@ type Query interface {
 	DebondingInterval(context.Context) (epochtime.EpochTime, error)
 	Accounts(context.Context) ([]signature.PublicKey, error)
 	AccountInfo(context.Context, signature.PublicKey) (*staking.Account, error)
-	DebondingDelegations(context.Context, signature.PublicKey) (map[signature.MapKey][]*staking.DebondingDelegation, error)
+	DebondingDelegations(context.Context, signature.PublicKey) (map[signature.PublicKey][]*staking.DebondingDelegation, error)
 	Genesis(context.Context) (*staking.Genesis, error)
 }
 
@@ -85,7 +85,7 @@ func (sq *stakingQuerier) AccountInfo(ctx context.Context, id signature.PublicKe
 	return sq.state.Account(id), nil
 }
 
-func (sq *stakingQuerier) DebondingDelegations(ctx context.Context, id signature.PublicKey) (map[signature.MapKey][]*staking.DebondingDelegation, error) {
+func (sq *stakingQuerier) DebondingDelegations(ctx context.Context, id signature.PublicKey) (map[signature.PublicKey][]*staking.DebondingDelegation, error) {
 	return sq.state.DebondingDelegationsFor(id)
 }
 

--- a/go/consensus/tendermint/apps/staking/state/cache.go
+++ b/go/consensus/tendermint/apps/staking/state/cache.go
@@ -30,7 +30,7 @@ type StakeCache struct {
 	ctx *abci.Context
 
 	thresholds map[staking.ThresholdKind]quantity.Quantity
-	balances   map[signature.MapKey]*quantity.Quantity
+	balances   map[signature.PublicKey]*quantity.Quantity
 
 	lowestNonZeroThreshold quantity.Quantity
 }
@@ -82,11 +82,11 @@ func (sc *StakeCache) EnsureSufficientStake(id signature.PublicKey, thresholds [
 
 // GetEscrowBalance returns the escrow balance of the account owned by id.
 func (sc *StakeCache) GetEscrowBalance(id signature.PublicKey) quantity.Quantity {
-	escrowBalance := sc.balances[id.ToMapKey()]
+	escrowBalance := sc.balances[id]
 	if escrowBalance == nil {
 		state := NewMutableState(sc.ctx.State())
 		escrowBalance = state.EscrowBalance(id)
-		sc.balances[id.ToMapKey()] = escrowBalance
+		sc.balances[id] = escrowBalance
 	}
 
 	ret := escrowBalance.Clone()
@@ -114,7 +114,7 @@ func NewStakeCache(ctx *abci.Context) (*StakeCache, error) {
 	return &StakeCache{
 		ctx:                    ctx,
 		thresholds:             thresholds,
-		balances:               make(map[signature.MapKey]*quantity.Quantity),
+		balances:               make(map[signature.PublicKey]*quantity.Quantity),
 		lowestNonZeroThreshold: *lowestNonZeroThreshold,
 	}, nil
 }

--- a/go/consensus/tendermint/crypto/signature_test.go
+++ b/go/consensus/tendermint/crypto/signature_test.go
@@ -21,11 +21,11 @@ func TestSignatureConversions(t *testing.T) {
 
 	pk := signer.Public()
 	tmPk := tmSk.PubKey().(tmed.PubKeyEd25519)
-	require.Equal(t, []byte(pk[:]), tmPk[:], "Private key: Public keys")
+	require.Equal(t, pk[:], tmPk[:], "Private key: Public keys")
 
 	tmPk = PublicKeyToTendermint(&pk)
-	require.Equal(t, []byte(pk[:]), tmPk[:], "Public key: ToTendermint")
+	require.Equal(t, pk[:], tmPk[:], "Public key: ToTendermint")
 
 	pk2 := PublicKeyFromTendermint(&tmPk)
-	require.Equal(t, []byte(pk[:]), []byte(pk2[:]), "Public key: FromTendermint")
+	require.Equal(t, pk[:], pk2[:], "Public key: FromTendermint")
 }

--- a/go/consensus/tendermint/staking/staking.go
+++ b/go/consensus/tendermint/staking/staking.go
@@ -92,7 +92,7 @@ func (tb *tendermintBackend) AccountInfo(ctx context.Context, owner signature.Pu
 	return q.AccountInfo(ctx, owner)
 }
 
-func (tb *tendermintBackend) DebondingDelegations(ctx context.Context, owner signature.PublicKey, height int64) (map[signature.MapKey][]*api.DebondingDelegation, error) {
+func (tb *tendermintBackend) DebondingDelegations(ctx context.Context, owner signature.PublicKey, height int64) (map[signature.PublicKey][]*api.DebondingDelegation, error) {
 	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err

--- a/go/keymanager/api/policy_sgx.go
+++ b/go/keymanager/api/policy_sgx.go
@@ -28,7 +28,7 @@ type EnclavePolicySGX struct {
 	//
 	// TODO: This could be made more sophisticated and seggregate based on
 	// contract ID as well, but for now punt on the added complexity.
-	MayQuery map[signature.MapKey][]sgx.EnclaveIdentity `json:"may_query"`
+	MayQuery map[signature.PublicKey][]sgx.EnclaveIdentity `json:"may_query"`
 
 	// MayReplicate is the vector of enclave IDs that may retrieve the master
 	// secret (Note: Each enclave ID may always implicitly replicate from other

--- a/go/oasis-node/cmd/debug/roothash/roothash.go
+++ b/go/oasis-node/cmd/debug/roothash/roothash.go
@@ -103,7 +103,7 @@ func doExport(cmd *cobra.Command, args []string) {
 			"runtime_id", idHex,
 		)
 
-		res, berr := client.GetBlock(ctx, &clientGrpc.GetBlockRequest{RuntimeId: id, Round: math.MaxUint64})
+		res, berr := client.GetBlock(ctx, &clientGrpc.GetBlockRequest{RuntimeId: id[:], Round: math.MaxUint64})
 		if berr != nil {
 			logger.Error("failed to get latest block",
 				"err", berr,

--- a/go/oasis-node/cmd/debug/storage/storage.go
+++ b/go/oasis-node/cmd/debug/storage/storage.go
@@ -147,7 +147,7 @@ func doCheckRoots(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	res, err := client.GetBlock(ctx, &clientGrpc.GetBlockRequest{RuntimeId: id, Round: math.MaxUint64})
+	res, err := client.GetBlock(ctx, &clientGrpc.GetBlockRequest{RuntimeId: id[:], Round: math.MaxUint64})
 	if err != nil {
 		logger.Error("failed to get latest block from roothash",
 			"err", err,
@@ -169,7 +169,7 @@ func doCheckRoots(cmd *cobra.Command, args []string) {
 	retryCount := 0
 	for {
 		lastSyncedReq := &storageGrpc.GetLastSyncedRoundRequest{
-			RuntimeId: id,
+			RuntimeId: id[:],
 		}
 		resp, err = storageWorkerClient.GetLastSyncedRound(ctx, lastSyncedReq)
 		if err != nil {
@@ -205,7 +205,7 @@ func doCheckRoots(cmd *cobra.Command, args []string) {
 	emptyRoot := node.Root{}
 	emptyRoot.Hash.Empty()
 	for i := uint64(0); i <= latestBlock.Header.Round; i++ {
-		res, err = client.GetBlock(ctx, &clientGrpc.GetBlockRequest{RuntimeId: id, Round: i})
+		res, err = client.GetBlock(ctx, &clientGrpc.GetBlockRequest{RuntimeId: id[:], Round: i})
 		if err != nil {
 			logger.Error("failed to get block from roothash",
 				"err", err,
@@ -267,7 +267,7 @@ func doForceFinalize(cmd *cobra.Command, args []string) {
 		}
 
 		_, err := storageWorkerClient.ForceFinalize(ctx, &storageGrpc.ForceFinalizeRequest{
-			RuntimeId: id,
+			RuntimeId: id[:],
 			Round:     finalizeRound,
 		})
 		if err != nil {

--- a/go/oasis-node/cmd/ias/auth.go
+++ b/go/oasis-node/cmd/ias/auth.go
@@ -16,14 +16,14 @@ import (
 type enclaveStore struct {
 	sync.RWMutex
 
-	enclaves map[signature.MapKey][]sgx.EnclaveIdentity
+	enclaves map[signature.PublicKey][]sgx.EnclaveIdentity
 }
 
 func (st *enclaveStore) verifyEvidence(evidence *ias.Evidence) error {
 	st.RLock()
 	defer st.RUnlock()
 
-	enclaveIDs, ok := st.enclaves[evidence.ID.ToMapKey()]
+	enclaveIDs, ok := st.enclaves[evidence.ID]
 	if !ok {
 		return errors.New("ias: unknown runtime")
 	}
@@ -60,13 +60,13 @@ func (st *enclaveStore) addRuntime(runtime *registry.Runtime) (int, error) {
 		return len(st.enclaves), err
 	}
 
-	st.enclaves[runtime.ID.ToMapKey()] = vi.Enclaves
+	st.enclaves[runtime.ID] = vi.Enclaves
 
 	return len(st.enclaves), nil
 }
 
 func newEnclaveStore() *enclaveStore {
 	return &enclaveStore{
-		enclaves: make(map[signature.MapKey][]sgx.EnclaveIdentity),
+		enclaves: make(map[signature.PublicKey][]sgx.EnclaveIdentity),
 	}
 }

--- a/go/oasis-node/cmd/keymanager/keymanager.go
+++ b/go/oasis-node/cmd/keymanager/keymanager.go
@@ -137,7 +137,7 @@ func policyFromFlags() (*kmApi.PolicySGX, error) {
 
 			enclaves[kmEnclaveID] = &kmApi.EnclavePolicySGX{
 				MayReplicate: []sgx.EnclaveIdentity{},
-				MayQuery:     make(map[signature.MapKey][]sgx.EnclaveIdentity),
+				MayQuery:     make(map[signature.PublicKey][]sgx.EnclaveIdentity),
 			}
 
 			for curArgIdx = curArgIdx + 2; curArgIdx < len(os.Args); curArgIdx++ {
@@ -188,7 +188,7 @@ func policyFromFlags() (*kmApi.PolicySGX, error) {
 						}
 						queryEnclaveIDs = append(queryEnclaveIDs, queryEnclaveID)
 					}
-					enclaves[kmEnclaveID].MayQuery[qRuntimeID.ToMapKey()] = queryEnclaveIDs
+					enclaves[kmEnclaveID].MayQuery[qRuntimeID] = queryEnclaveIDs
 				}
 			}
 		}

--- a/go/oasis-node/cmd/registry/entity/entity.go
+++ b/go/oasis-node/cmd/registry/entity/entity.go
@@ -219,15 +219,13 @@ func doUpdate(cmd *cobra.Command, args []string) {
 	}
 
 	// De-duplicate the entity's nodes.
-	nodeMap := make(map[signature.MapKey]bool)
+	nodeMap := make(map[signature.PublicKey]bool)
 	for _, v := range ent.Nodes {
-		nodeMap[v.ToMapKey()] = true
+		nodeMap[v] = true
 	}
 	ent.Nodes = make([]signature.PublicKey, 0, len(nodeMap))
 	for k := range nodeMap {
-		var nodeID signature.PublicKey
-		nodeID.FromMapKey(k)
-		ent.Nodes = append(ent.Nodes, nodeID)
+		ent.Nodes = append(ent.Nodes, k)
 	}
 
 	// Save the entity descriptor.

--- a/go/oasis-test-runner/scenario/e2e/stake_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/stake_cli.go
@@ -108,7 +108,7 @@ func (s *stakeCLIImpl) Run(childEnv *env.Env) error {
 	if err = src.UnmarshalHex(srcAddress); err != nil {
 		return err
 	}
-	if !bytes.Equal(accounts[0], src) {
+	if !bytes.Equal(accounts[0][:], src[:]) {
 		return fmt.Errorf("scenario/e2e/stake: wrong src account: %s expected: %s", accounts[0].String(), src.String())
 	}
 	// Define a new destination account.

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -125,10 +125,6 @@ func (c *Runtime) FromProto(pb *pbRegistry.Runtime) error {
 		return ErrNilProtobuf
 	}
 
-	if c.ID == nil {
-		c.ID = signature.PublicKey{}
-	}
-
 	if err := c.ID.UnmarshalBinary(pb.GetId()); err != nil {
 		return err
 	}

--- a/go/registry/api/runtime_test.go
+++ b/go/registry/api/runtime_test.go
@@ -13,14 +13,18 @@ import (
 
 func TestSerialization(t *testing.T) {
 	key, _, _ := ed25519.GenerateKey(nil)
+
+	var publicKey signature.PublicKey
+	_ = publicKey.UnmarshalBinary(key)
+
 	c := Runtime{
-		ID:                       signature.PublicKey(key),
+		ID:                       publicKey,
 		TEEHardware:              node.TEEHardwareIntelSGX,
 		ReplicaGroupSize:         63,
 		ReplicaGroupBackupSize:   72,
 		ReplicaAllowedStragglers: 81,
 		StorageGroupSize:         90,
-		KeyManager:               signature.PublicKey(key),
+		KeyManager:               publicKey,
 		Kind:                     KindCompute,
 		Version: VersionInfo{
 			TEE:     []byte{},

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -167,7 +167,7 @@ type Genesis struct {
 	Parameters ConsensusParameters `json:"params"`
 
 	// Blocks is the per-runtime map of genesis blocks.
-	Blocks map[signature.MapKey]*block.Block `json:"blocks,omitempty"`
+	Blocks map[signature.PublicKey]*block.Block `json:"blocks,omitempty"`
 }
 
 // ConsensusParameters are the roothash consensus parameters.

--- a/go/roothash/api/commitment/pool_test.go
+++ b/go/roothash/api/commitment/pool_test.go
@@ -105,7 +105,7 @@ func TestPoolSingleCommitment(t *testing.T) {
 	require.NoError(t, err, "NewSigner")
 
 	// Generate a committee.
-	cID := sk.Public().ToMapKey()
+	cID := sk.Public()
 	committee := &scheduler.Committee{
 		Kind: scheduler.KindCompute,
 		Members: []*scheduler.CommitteeNode{
@@ -115,7 +115,7 @@ func TestPoolSingleCommitment(t *testing.T) {
 			},
 		},
 	}
-	nodeInfo := map[signature.MapKey]NodeInfo{
+	nodeInfo := map[signature.PublicKey]NodeInfo{
 		cID: NodeInfo{
 			CommitteeNode: 0,
 			Runtime: &node.Runtime{
@@ -215,7 +215,7 @@ func TestPoolSingleCommitmentTEE(t *testing.T) {
 	require.NoError(t, err, "NewSigner")
 
 	// Generate a committee.
-	cID := sk.Public().ToMapKey()
+	cID := sk.Public()
 	committee := &scheduler.Committee{
 		Kind: scheduler.KindCompute,
 		Members: []*scheduler.CommitteeNode{
@@ -225,7 +225,7 @@ func TestPoolSingleCommitmentTEE(t *testing.T) {
 			},
 		},
 	}
-	nodeInfo := map[signature.MapKey]NodeInfo{
+	nodeInfo := map[signature.PublicKey]NodeInfo{
 		cID: NodeInfo{
 			CommitteeNode: 0,
 			Runtime: &node.Runtime{
@@ -447,7 +447,7 @@ func TestPoolSerialization(t *testing.T) {
 	require.NoError(t, err, "NewSigner")
 
 	// Generate a committee.
-	cID := sk.Public().ToMapKey()
+	cID := sk.Public()
 	committee := &scheduler.Committee{
 		Kind: scheduler.KindCompute,
 		Members: []*scheduler.CommitteeNode{
@@ -457,7 +457,7 @@ func TestPoolSerialization(t *testing.T) {
 			},
 		},
 	}
-	nodeInfo := map[signature.MapKey]NodeInfo{
+	nodeInfo := map[signature.PublicKey]NodeInfo{
 		cID: NodeInfo{
 			CommitteeNode: 0,
 			Runtime: &node.Runtime{
@@ -1093,7 +1093,7 @@ func generateMockCommittee(t *testing.T) (
 	rt *registry.Runtime,
 	sks []signature.Signer,
 	committee *scheduler.Committee,
-	nodeInfo map[signature.MapKey]NodeInfo,
+	nodeInfo map[signature.PublicKey]NodeInfo,
 ) {
 	// Generate a non-TEE runtime.
 	var rtID signature.PublicKey
@@ -1114,9 +1114,9 @@ func generateMockCommittee(t *testing.T) (
 	sks = append(sks, sk1, sk2, sk3)
 
 	// Generate a committee.
-	c1ID := sk1.Public().ToMapKey()
-	c2ID := sk2.Public().ToMapKey()
-	c3ID := sk3.Public().ToMapKey()
+	c1ID := sk1.Public()
+	c2ID := sk2.Public()
+	c3ID := sk3.Public()
 	committee = &scheduler.Committee{
 		Kind: scheduler.KindCompute,
 		Members: []*scheduler.CommitteeNode{
@@ -1134,7 +1134,7 @@ func generateMockCommittee(t *testing.T) (
 			},
 		},
 	}
-	nodeInfo = map[signature.MapKey]NodeInfo{
+	nodeInfo = map[signature.PublicKey]NodeInfo{
 		c1ID: NodeInfo{
 			CommitteeNode: 0,
 			Runtime: &node.Runtime{

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -196,9 +196,9 @@ func testEpochTransitionBlock(t *testing.T, backend api.Backend, epochtime epoch
 func (s *runtimeState) testEpochTransitionBlock(t *testing.T, scheduler scheduler.Backend, epoch epochtime.EpochTime, ch <-chan *api.AnnotatedBlock) {
 	require := require.New(t)
 
-	nodes := make(map[signature.MapKey]*registryTests.TestNode)
+	nodes := make(map[signature.PublicKey]*registryTests.TestNode)
 	for _, node := range s.rt.TestNodes() {
-		nodes[node.Node.ID.ToMapKey()] = node
+		nodes[node.Node.ID] = node
 	}
 
 	s.computeCommittee, s.mergeCommittee, s.storageCommittee, s.txnSchedCommittee = mustGetCommittee(t, s.rt, epoch+1, scheduler, nodes)
@@ -671,7 +671,7 @@ func mustGetCommittee(
 	rt *registryTests.TestRuntime,
 	epoch epochtime.EpochTime,
 	sched scheduler.Backend,
-	nodes map[signature.MapKey]*registryTests.TestNode,
+	nodes map[signature.PublicKey]*registryTests.TestNode,
 ) (
 	computeCommittee *testCommittee,
 	mergeCommittee *testCommittee,
@@ -696,7 +696,7 @@ func mustGetCommittee(
 			var ret testCommittee
 			ret.committee = committee
 			for _, member := range committee.Members {
-				node := nodes[member.PublicKey.ToMapKey()]
+				node := nodes[member.PublicKey]
 				require.NotNil(node, "member is one of the nodes")
 				switch member.Role {
 				case scheduler.Worker:

--- a/go/scheduler/tests/tester.go
+++ b/go/scheduler/tests/tester.go
@@ -126,15 +126,15 @@ func SchedulerImplementationTests(t *testing.T, backend api.Backend, epochtime e
 func requireValidCommitteeMembers(t *testing.T, committee *api.Committee, runtime *registry.Runtime, nodes []*node.Node) {
 	require := require.New(t)
 
-	nodeMap := make(map[signature.MapKey]*node.Node)
+	nodeMap := make(map[signature.PublicKey]*node.Node)
 	for _, node := range nodes {
-		nodeMap[node.ID.ToMapKey()] = node
+		nodeMap[node.ID] = node
 	}
 
 	var leaders, workers, backups int
-	seenMap := make(map[signature.MapKey]bool)
+	seenMap := make(map[signature.PublicKey]bool)
 	for _, member := range committee.Members {
-		id := member.PublicKey.ToMapKey()
+		id := member.PublicKey
 		require.NotNil(nodeMap[id], "member is a node")
 		require.False(seenMap[id], "member is unique")
 		seenMap[id] = true

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -90,7 +90,7 @@ type Backend interface {
 
 	// DebondingDelegations returns the list of debonding delegations for
 	// the given owner (delegator).
-	DebondingDelegations(ctx context.Context, owner signature.PublicKey, height int64) (map[signature.MapKey][]*DebondingDelegation, error)
+	DebondingDelegations(ctx context.Context, owner signature.PublicKey, height int64) (map[signature.PublicKey][]*DebondingDelegation, error)
 
 	// Transfer executes a SignedTransfer.
 	Transfer(ctx context.Context, signedXfer *SignedTransfer) error
@@ -489,10 +489,10 @@ type Genesis struct {
 	TotalSupply quantity.Quantity `json:"total_supply"`
 	CommonPool  quantity.Quantity `json:"common_pool"`
 
-	Ledger map[signature.MapKey]*Account `json:"ledger,omitempty"`
+	Ledger map[signature.PublicKey]*Account `json:"ledger,omitempty"`
 
-	Delegations          map[signature.MapKey]map[signature.MapKey]*Delegation            `json:"delegations,omitempty"`
-	DebondingDelegations map[signature.MapKey]map[signature.MapKey][]*DebondingDelegation `json:"debonding_delegations,omitempty"`
+	Delegations          map[signature.PublicKey]map[signature.PublicKey]*Delegation            `json:"delegations,omitempty"`
+	DebondingDelegations map[signature.PublicKey]map[signature.PublicKey][]*DebondingDelegation `json:"debonding_delegations,omitempty"`
 }
 
 // ConsensusParameters are the staking consensus parameters.
@@ -500,7 +500,7 @@ type ConsensusParameters struct {
 	Thresholds              map[ThresholdKind]quantity.Quantity `json:"thresholds,omitempty"`
 	DebondingInterval       epochtime.EpochTime                 `json:"debonding_interval,omitempty"`
 	RewardSchedule          []RewardStep                        `json:"reward_schedule,omitempty"`
-	AcceptableTransferPeers map[signature.MapKey]bool           `json:"acceptable_transfer_peers,omitempty"`
+	AcceptableTransferPeers map[signature.PublicKey]bool        `json:"acceptable_transfer_peers,omitempty"`
 	Slashing                map[SlashReason]Slash               `json:"slashing,omitempty"`
 	GasCosts                gas.Costs                           `json:"gas_costs,omitempty"`
 	MinDelegationAmount     quantity.Quantity                   `json:"min_delegation,omitempty"`

--- a/go/staking/client/client.go
+++ b/go/staking/client/client.go
@@ -114,7 +114,7 @@ func (b *clientBackend) AccountInfo(ctx context.Context, owner signature.PublicK
 
 // DebondingDelegations returns the list of debonding delegations for
 // the given owner (delegator).
-func (b *clientBackend) DebondingDelegations(ctx context.Context, owner signature.PublicKey, height int64) (map[signature.MapKey][]*api.DebondingDelegation, error) {
+func (b *clientBackend) DebondingDelegations(ctx context.Context, owner signature.PublicKey, height int64) (map[signature.PublicKey][]*api.DebondingDelegation, error) {
 	id, _ := owner.MarshalBinary()
 
 	rsp, err := b.grpc.GetDebondingDelegations(ctx, &pb.GetDebondingDelegationsRequest{Owner: id, Height: height})
@@ -122,7 +122,7 @@ func (b *clientBackend) DebondingDelegations(ctx context.Context, owner signatur
 		return nil, err
 	}
 
-	var delegations map[signature.MapKey][]*api.DebondingDelegation
+	var delegations map[signature.PublicKey][]*api.DebondingDelegation
 	if err := cbor.Unmarshal(rsp.GetDelegations(), &delegations); err != nil {
 		return nil, fmt.Errorf("staking: malformed response: %w", err)
 	}

--- a/go/staking/tests/debug_stake.go
+++ b/go/staking/tests/debug_stake.go
@@ -23,9 +23,9 @@ var (
 				api.KindCompute:   QtyFromInt(3),
 				api.KindStorage:   QtyFromInt(4),
 			},
-			AcceptableTransferPeers: map[signature.MapKey]bool{
+			AcceptableTransferPeers: map[signature.PublicKey]bool{
 				// test runtime 0 from roothash tester
-				publicKeyFromHex("612b31ddd66fc99e41cc9996f4029ea84752785d7af329d4595c4bcf8f5e4215").ToMapKey(): true,
+				publicKeyFromHex("612b31ddd66fc99e41cc9996f4029ea84752785d7af329d4595c4bcf8f5e4215"): true,
 			},
 			Slashing: map[api.SlashReason]api.Slash{
 				api.SlashDoubleSigning: api.Slash{
@@ -36,8 +36,8 @@ var (
 			MinDelegationAmount: QtyFromInt(10),
 		},
 		TotalSupply: DebugStateTestTotalSupply,
-		Ledger: map[signature.MapKey]*api.Account{
-			DebugStateSrcID.ToMapKey(): &api.Account{
+		Ledger: map[signature.PublicKey]*api.Account{
+			DebugStateSrcID: &api.Account{
 				General: api.GeneralAccount{
 					Balance: DebugStateTestTotalSupply,
 				},

--- a/go/staking/tests/tester.go
+++ b/go/staking/tests/tester.go
@@ -430,7 +430,7 @@ func testEscrowEx(
 	debs, err = backend.DebondingDelegations(context.Background(), srcID, 0)
 	require.NoError(err, "DebondingDelegations - after (in debonding)")
 	require.Len(debs, 1, "one debonding delegation after reclaiming escrow")
-	require.Len(debs[dstID.ToMapKey()], 1, "one debonding delegation after reclaiming escrow")
+	require.Len(debs[dstID], 1, "one debonding delegation after reclaiming escrow")
 
 	// Advance epoch to trigger debonding.
 	epochtimeTests.MustAdvanceEpoch(t, timeSource, 1)

--- a/go/storage/client/init.go
+++ b/go/storage/client/init.go
@@ -78,14 +78,15 @@ func New(
 		client := storage.NewStorageClient(conn)
 
 		testRuntimeSigner := memorySigner.NewTestSigner(debugModeFakeRuntimeSeed)
+		debugRuntimeID := testRuntimeSigner.Public()
 		b := &storageClientBackend{
 			ctx:             ctx,
 			initCh:          make(chan struct{}),
 			logger:          logger,
-			debugRuntimeID:  testRuntimeSigner.Public(),
+			debugRuntimeID:  &debugRuntimeID,
 			scheduler:       schedulerBackend,
 			registry:        registryBackend,
-			runtimeWatchers: make(map[signature.MapKey]storageWatcher),
+			runtimeWatchers: make(map[signature.PublicKey]storageWatcher),
 			identity:        ident,
 		}
 		state := &clientState{
@@ -93,7 +94,7 @@ func New(
 			conn:   conn,
 		}
 		close(b.initCh)
-		b.runtimeWatchers[b.debugRuntimeID.ToMapKey()] = newDebugWatcher(state)
+		b.runtimeWatchers[debugRuntimeID] = newDebugWatcher(state)
 		return b, nil
 	}
 
@@ -103,7 +104,7 @@ func New(
 		logger:          logger,
 		scheduler:       schedulerBackend,
 		registry:        registryBackend,
-		runtimeWatchers: make(map[signature.MapKey]storageWatcher),
+		runtimeWatchers: make(map[signature.PublicKey]storageWatcher),
 		identity:        ident,
 	}
 

--- a/go/storage/client/tests/tests.go
+++ b/go/storage/client/tests/tests.go
@@ -100,12 +100,12 @@ recvLoop:
 			if cm.Kind != scheduler.KindStorage {
 				continue
 			}
-			if cm.RuntimeID.ToMapKey() != rt.Runtime.ID.ToMapKey() {
+			if cm.RuntimeID != rt.Runtime.ID {
 				continue
 			}
 			for _, cn := range cm.Members {
 				for _, n := range nodes {
-					if n.ID.ToMapKey() == cn.PublicKey.ToMapKey() {
+					if n.ID == cn.PublicKey {
 						scheduledStorageNodes = append(scheduledStorageNodes, n)
 					}
 				}

--- a/go/worker/common/config.go
+++ b/go/worker/common/config.go
@@ -68,7 +68,7 @@ type RuntimeHostRuntimeConfig struct {
 type RuntimeHostConfig struct {
 	Backend  string
 	Loader   string
-	Runtimes map[signature.MapKey]RuntimeHostRuntimeConfig
+	Runtimes map[signature.PublicKey]RuntimeHostRuntimeConfig
 }
 
 // GetNodeAddresses returns worker node addresses.
@@ -159,13 +159,13 @@ func newConfig() (*Config, error) {
 		cfg.RuntimeHost = &RuntimeHostConfig{
 			Backend:  viper.GetString(CfgRuntimeBackend),
 			Loader:   runtimeLoader,
-			Runtimes: make(map[signature.MapKey]RuntimeHostRuntimeConfig),
+			Runtimes: make(map[signature.PublicKey]RuntimeHostRuntimeConfig),
 		}
 
 		for idx, runtimeBinary := range runtimeBinaries {
 			runtimeID := runtimes[idx]
 
-			cfg.RuntimeHost.Runtimes[runtimeID.ToMapKey()] = RuntimeHostRuntimeConfig{
+			cfg.RuntimeHost.Runtimes[runtimeID] = RuntimeHostRuntimeConfig{
 				ID:     runtimeID,
 				Binary: runtimeBinary,
 			}

--- a/go/worker/common/enclaverpc/enclaverpc.go
+++ b/go/worker/common/enclaverpc/enclaverpc.go
@@ -34,7 +34,7 @@ func (c *Client) CallEnclave(ctx context.Context, request []byte, runtimeID sign
 	req := erpcGrpc.CallEnclaveRequest{
 		Endpoint: c.endpoint,
 		Payload:  request,
-		Runtime:  runtimeID,
+		Runtime:  runtimeID[:],
 	}
 	res, err := c.client.CallEnclave(ctx, &req)
 	if err != nil {

--- a/go/worker/common/p2p/crypto.go
+++ b/go/worker/common/p2p/crypto.go
@@ -55,18 +55,18 @@ func signerToPrivKey(signer signature.Signer) libp2pCrypto.PrivKey {
 }
 
 func pubKeyToPublicKey(pubKey libp2pCrypto.PubKey) (signature.PublicKey, error) {
+	var pk signature.PublicKey
 	if pubKey.Type() != libp2pCrypto.Ed25519 {
-		return nil, errCryptoNotSupported
+		return pk, errCryptoNotSupported
 	}
 
 	raw, err := pubKey.Raw()
 	if err != nil {
-		return nil, err
+		return pk, err
 	}
 
-	var pk signature.PublicKey
 	if err = pk.UnmarshalBinary(raw); err != nil {
-		return nil, err
+		return pk, err
 	}
 
 	return pk, nil
@@ -96,7 +96,7 @@ func (k *libp2pPublicKey) Equals(other libp2pCrypto.Key) bool {
 }
 
 func (k *libp2pPublicKey) Raw() ([]byte, error) {
-	return k.inner, nil
+	return k.inner[:], nil
 }
 
 func (k *libp2pPublicKey) Type() libp2pCryptoPb.KeyType {

--- a/go/worker/common/runtime_host.go
+++ b/go/worker/common/runtime_host.go
@@ -150,7 +150,7 @@ func (f *runtimeWorkerHostSandboxedFactory) NewWorkerHost(cfg host.Config) (host
 // NewRuntimeWorkerHostFactory creates a new worker host factory for the given runtime.
 func (rw *RuntimeHostWorker) NewRuntimeWorkerHostFactory(role node.RolesMask, id signature.PublicKey) (h host.Factory, err error) {
 	cfg := rw.commonWorker.GetConfig().RuntimeHost
-	rtCfg, ok := cfg.Runtimes[id.ToMapKey()]
+	rtCfg, ok := cfg.Runtimes[id]
 	if !ok {
 		return nil, fmt.Errorf("runtime host: unknown runtime: %s", id)
 	}

--- a/go/worker/common/worker.go
+++ b/go/worker/common/worker.go
@@ -65,7 +65,7 @@ type Worker struct {
 	LocalStorage     *host.LocalStorage
 	GenesisDoc       *genesis.Document
 
-	runtimes map[signature.MapKey]*Runtime
+	runtimes map[signature.PublicKey]*Runtime
 
 	quitCh chan struct{}
 	initCh chan struct{}
@@ -180,7 +180,7 @@ func (w *Worker) GetConfig() Config {
 }
 
 // GetRuntimes returns a map of registered runtimes.
-func (w *Worker) GetRuntimes() map[signature.MapKey]*Runtime {
+func (w *Worker) GetRuntimes() map[signature.PublicKey]*Runtime {
 	return w.runtimes
 }
 
@@ -189,7 +189,7 @@ func (w *Worker) GetRuntimes() map[signature.MapKey]*Runtime {
 // In case the runtime with the specified id was not registered it
 // returns nil.
 func (w *Worker) GetRuntime(id signature.PublicKey) *Runtime {
-	rt, ok := w.runtimes[id.ToMapKey()]
+	rt, ok := w.runtimes[id]
 	if !ok {
 		return nil
 	}
@@ -211,7 +211,7 @@ func (w *Worker) NewUnmanagedCommitteeNode(id signature.PublicKey, enableP2P boo
 		// Make sure that there is no other (managed) runtime already registered
 		// with the same identifier as registering another will overwrite the
 		// P2P handler.
-		if w.runtimes[id.ToMapKey()] != nil {
+		if w.runtimes[id] != nil {
 			return nil, fmt.Errorf("worker/common: managed runtime with id %s already exists", id)
 		}
 		p2p = w.P2P
@@ -247,7 +247,7 @@ func (w *Worker) registerRuntime(id signature.PublicKey) error {
 		version: version.Version{Major: 0, Minor: 0, Patch: 0}, // Version is populated once the runtime has been loaded. -Matevz
 		node:    node,
 	}
-	w.runtimes[rt.id.ToMapKey()] = rt
+	w.runtimes[rt.id] = rt
 
 	w.logger.Info("new runtime registered",
 		"runtime_id", rt.id,
@@ -302,7 +302,7 @@ func newWorker(
 		KeyManager:       keyManager,
 		KeyManagerClient: keyManagerClient,
 		GenesisDoc:       genesisDoc,
-		runtimes:         make(map[signature.MapKey]*Runtime),
+		runtimes:         make(map[signature.PublicKey]*Runtime),
 		quitCh:           make(chan struct{}),
 		initCh:           make(chan struct{}),
 		logger:           logging.GetLogger("worker/common"),

--- a/go/worker/compute/committee/node.go
+++ b/go/worker/compute/committee/node.go
@@ -205,7 +205,7 @@ func (n *Node) HandlePeerMessage(ctx context.Context, message *p2p.Message) (boo
 		// actually signed by the current transaction scheduler.
 		epoch := n.commonNode.Group.GetEpochSnapshot()
 		txsc := epoch.GetTransactionSchedulerCommittee()
-		if !txsc.PublicKeys[sbd.Signature.PublicKey.ToMapKey()] {
+		if !txsc.PublicKeys[sbd.Signature.PublicKey] {
 			// Not signed by a current txn scheduler!
 			return false, errMsgFromNonTxnSched
 		}
@@ -235,7 +235,7 @@ func (n *Node) queueBatchBlocking(
 	txnSchedSig signature.Signature,
 ) error {
 	// Quick check to see if header is compatible.
-	if !bytes.Equal(hdr.Namespace[:], n.commonNode.RuntimeID) {
+	if !bytes.Equal(hdr.Namespace[:], n.commonNode.RuntimeID[:]) {
 		n.logger.Warn("received incompatible header in external batch",
 			"header", hdr,
 		)

--- a/go/worker/compute/worker.go
+++ b/go/worker/compute/worker.go
@@ -45,7 +45,7 @@ type Worker struct {
 	merge        *merge.Worker
 	registration *registration.Worker
 
-	runtimes map[signature.MapKey]*Runtime
+	runtimes map[signature.PublicKey]*Runtime
 
 	ctx       context.Context
 	cancelCtx context.CancelFunc
@@ -160,7 +160,7 @@ func (w *Worker) GetConfig() Config {
 // In case the runtime with the specified id was not registered it
 // returns nil.
 func (w *Worker) GetRuntime(id signature.PublicKey) *Runtime {
-	rt, ok := w.runtimes[id.ToMapKey()]
+	rt, ok := w.runtimes[id]
 	if !ok {
 		return nil
 	}
@@ -203,7 +203,7 @@ func (w *Worker) registerRuntime(cfg *Config, rt *workerCommon.Runtime) error {
 		id:   rt.GetID(),
 		node: node,
 	}
-	w.runtimes[crt.id.ToMapKey()] = crt
+	w.runtimes[crt.id] = crt
 
 	w.logger.Info("new runtime registered",
 		"runtime_id", rt.GetID(),
@@ -228,7 +228,7 @@ func newWorker(
 		commonWorker: commonWorker,
 		merge:        merge,
 		registration: registration,
-		runtimes:     make(map[signature.MapKey]*Runtime),
+		runtimes:     make(map[signature.PublicKey]*Runtime),
 		ctx:          ctx,
 		cancelCtx:    cancelCtx,
 		quitCh:       make(chan struct{}),
@@ -271,7 +271,7 @@ func newWorker(
 			for _, rt := range n.Runtimes {
 				var err error
 
-				workerRT := w.runtimes[rt.ID.ToMapKey()]
+				workerRT := w.runtimes[rt.ID]
 				if workerRT == nil {
 					continue
 				}

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -431,7 +431,7 @@ func (w *Worker) worker() {
 
 	// Subscribe to runtime registrations in order to know which runtimes
 	// are using us as a key manager.
-	clientRuntimes := make(map[signature.MapKey]*clientRuntimeWatcher)
+	clientRuntimes := make(map[signature.PublicKey]*clientRuntimeWatcher)
 	clientRuntimesQuitCh := make(chan *clientRuntimeWatcher)
 	defer close(clientRuntimesQuitCh)
 	rtCh, rtSub := w.commonWorker.Registry.WatchRuntimes()
@@ -494,7 +494,7 @@ func (w *Worker) worker() {
 			if rt.Kind != registry.KindCompute || !rt.KeyManager.Equal(w.runtimeID) {
 				continue
 			}
-			if clientRuntimes[rt.ID.ToMapKey()] != nil {
+			if clientRuntimes[rt.ID] != nil {
 				continue
 			}
 
@@ -536,7 +536,7 @@ func (w *Worker) worker() {
 				}
 			}()
 
-			clientRuntimes[rt.ID.ToMapKey()] = crw
+			clientRuntimes[rt.ID] = crw
 		case crw := <-clientRuntimesQuitCh:
 			w.logger.Error("client runtime watcher quit unexpectedly, terminating",
 				"runtme_id", crw.node.RuntimeID,

--- a/go/worker/merge/committee/node.go
+++ b/go/worker/merge/committee/node.go
@@ -212,7 +212,7 @@ func (n *Node) newStateWaitingForResultsLocked(epoch *committee.EpochSnapshot) S
 	}
 
 	for cID, ci := range epoch.GetComputeCommittees() {
-		nodeInfo := make(map[signature.MapKey]commitment.NodeInfo, len(ci.Nodes))
+		nodeInfo := make(map[signature.PublicKey]commitment.NodeInfo, len(ci.Nodes))
 		for idx, nd := range ci.Nodes {
 			var nodeRuntime *node.Runtime
 			for _, r := range nd.Runtimes {
@@ -231,7 +231,7 @@ func (n *Node) newStateWaitingForResultsLocked(epoch *committee.EpochSnapshot) S
 				continue
 			}
 
-			nodeInfo[nd.ID.ToMapKey()] = commitment.NodeInfo{
+			nodeInfo[nd.ID] = commitment.NodeInfo{
 				CommitteeNode: idx,
 				Runtime:       nodeRuntime,
 			}

--- a/go/worker/merge/worker.go
+++ b/go/worker/merge/worker.go
@@ -38,7 +38,7 @@ type Worker struct {
 	commonWorker       *workerCommon.Worker
 	registrationWorker *registration.Worker
 
-	runtimes map[signature.MapKey]*Runtime
+	runtimes map[signature.PublicKey]*Runtime
 
 	ctx       context.Context
 	cancelCtx context.CancelFunc
@@ -147,7 +147,7 @@ func (w *Worker) Initialized() <-chan struct{} {
 // In case the runtime with the specified id was not registered it
 // returns nil.
 func (w *Worker) GetRuntime(id signature.PublicKey) *Runtime {
-	rt, ok := w.runtimes[id.ToMapKey()]
+	rt, ok := w.runtimes[id]
 	if !ok {
 		return nil
 	}
@@ -177,7 +177,7 @@ func (w *Worker) registerRuntime(id signature.PublicKey) error {
 		id:   id,
 		node: node,
 	}
-	w.runtimes[id.ToMapKey()] = rt
+	w.runtimes[id] = rt
 
 	w.logger.Info("new runtime registered",
 		"runtime_id", id,
@@ -199,7 +199,7 @@ func newWorker(
 		cfg:                cfg,
 		commonWorker:       commonWorker,
 		registrationWorker: registrationWorker,
-		runtimes:           make(map[signature.MapKey]*Runtime),
+		runtimes:           make(map[signature.PublicKey]*Runtime),
 		ctx:                ctx,
 		cancelCtx:          cancelCtx,
 		quitCh:             make(chan struct{}),

--- a/go/worker/storage/grpc.go
+++ b/go/worker/storage/grpc.go
@@ -29,7 +29,7 @@ func (s *grpcServer) GetLastSyncedRound(ctx context.Context, req *pb.GetLastSync
 	}
 
 	var node *committee.Node
-	node, ok := s.w.runtimes[id.ToMapKey()]
+	node, ok := s.w.runtimes[id]
 	if !ok {
 		return nil, ErrRuntimeNotFound
 	}
@@ -53,7 +53,7 @@ func (s *grpcServer) ForceFinalize(ctx context.Context, req *pb.ForceFinalizeReq
 	round := req.GetRound()
 
 	var node *committee.Node
-	node, ok := s.w.runtimes[id.ToMapKey()]
+	node, ok := s.w.runtimes[id]
 	if !ok {
 		return nil, ErrRuntimeNotFound
 	}

--- a/go/worker/storage/worker.go
+++ b/go/worker/storage/worker.go
@@ -56,7 +56,7 @@ type Worker struct {
 	initCh chan struct{}
 	quitCh chan struct{}
 
-	runtimes   map[signature.MapKey]*committee.Node
+	runtimes   map[signature.PublicKey]*committee.Node
 	watchState *persistent.ServiceStore
 	fetchPool  *workerpool.Pool
 
@@ -79,7 +79,7 @@ func New(
 		logger:             logging.GetLogger("worker/storage"),
 		initCh:             make(chan struct{}),
 		quitCh:             make(chan struct{}),
-		runtimes:           make(map[signature.MapKey]*committee.Node),
+		runtimes:           make(map[signature.PublicKey]*committee.Node),
 	}
 
 	if s.enabled {
@@ -143,7 +143,7 @@ func (s *Worker) registerRuntime(rt *workerCommon.Runtime) error {
 		return err
 	}
 	commonNode.AddHooks(node)
-	s.runtimes[commonNode.RuntimeID.ToMapKey()] = node
+	s.runtimes[commonNode.RuntimeID] = node
 	return nil
 }
 

--- a/go/worker/txnscheduler/grpc.go
+++ b/go/worker/txnscheduler/grpc.go
@@ -25,9 +25,8 @@ func (s *grpcServer) SubmitTx(ctx context.Context, req *pb.SubmitTxRequest) (*pb
 	if err := runtimeID.UnmarshalBinary(req.GetRuntimeId()); err != nil {
 		return nil, err
 	}
-	mapKey := runtimeID.ToMapKey()
 
-	runtime, ok := s.worker.runtimes[mapKey]
+	runtime, ok := s.worker.runtimes[runtimeID]
 	if !ok {
 		return nil, errors.New("unknown runtime")
 	}
@@ -48,14 +47,13 @@ func (s *grpcServer) IsTransactionQueued(ctx context.Context, req *pb.IsTransact
 	if err := runtimeID.UnmarshalBinary(req.GetRuntimeId()); err != nil {
 		return nil, err
 	}
-	mapKey := runtimeID.ToMapKey()
 
 	var id hash.Hash
 	if err := id.UnmarshalBinary(req.GetHash()); err != nil {
 		return nil, err
 	}
 
-	runtime, ok := s.worker.runtimes[mapKey]
+	runtime, ok := s.worker.runtimes[runtimeID]
 	if !ok {
 		return nil, errors.New("unknown runtime")
 	}

--- a/go/worker/txnscheduler/worker.go
+++ b/go/worker/txnscheduler/worker.go
@@ -52,7 +52,7 @@ type Worker struct {
 	registration *registration.Worker
 	compute      *compute.Worker
 
-	runtimes map[signature.MapKey]*Runtime
+	runtimes map[signature.PublicKey]*Runtime
 
 	quitCh chan struct{}
 	initCh chan struct{}
@@ -164,7 +164,7 @@ func (w *Worker) GetConfig() Config {
 // In case the runtime with the specified id was not registered it
 // returns nil.
 func (w *Worker) GetRuntime(id signature.PublicKey) *Runtime {
-	rt, ok := w.runtimes[id.ToMapKey()]
+	rt, ok := w.runtimes[id]
 	if !ok {
 		return nil
 	}
@@ -200,7 +200,7 @@ func (w *Worker) registerRuntime(cfg *Config, rtCfg *RuntimeConfig) error {
 		cfg:  rtCfg,
 		node: node,
 	}
-	w.runtimes[rt.cfg.ID.ToMapKey()] = rt
+	w.runtimes[rt.cfg.ID] = rt
 
 	w.logger.Info("new runtime registered",
 		"runtime_id", rt.cfg.ID,
@@ -222,7 +222,7 @@ func newWorker(
 		commonWorker: commonWorker,
 		registration: registration,
 		compute:      compute,
-		runtimes:     make(map[signature.MapKey]*Runtime),
+		runtimes:     make(map[signature.PublicKey]*Runtime),
 		quitCh:       make(chan struct{}),
 		initCh:       make(chan struct{}),
 		logger:       logging.GetLogger("worker/txnscheduler"),


### PR DESCRIPTION
Not sure if this is actually breaking, it might not be.  I would be very sad if I need to rebase this.

Fixes #2392.