### PR TITLE
oasis-node: Deprecate `grpc.debug.port`

### DIFF
--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -251,9 +251,7 @@ func (app *rootHashApplication) onCommitteeChanged(ctx *abci.Context, epoch epoc
 				"runtime", rtID,
 				"committee_id", committeeID,
 			)
-			if _, ok := newDescriptors[rtID]; ok {
-				delete(newDescriptors, rtID)
-			}
+			delete(newDescriptors, rtID)
 			continue
 		}
 

--- a/go/oasis-node/cmd/common/grpc/grpc.go
+++ b/go/oasis-node/cmd/common/grpc/grpc.go
@@ -18,8 +18,6 @@ import (
 const (
 	// CfgServerPort configures the server port.
 	CfgServerPort = "grpc.port"
-	// CfgDebugPort configures the internal debug port.
-	CfgDebugPort = "grpc.debug.port"
 	// CfgDebugPort configures the remote address.
 	CfgAddress = "address"
 
@@ -63,11 +61,8 @@ func NewServerLocal(installWrapper bool) (*cmnGrpc.Server, error) {
 	}
 	path := filepath.Join(dataDir, localSocketFilename)
 
-	debugPort := uint16(viper.GetInt(CfgDebugPort))
-
 	config := &cmnGrpc.ServerConfig{
 		Name:           "internal",
-		Port:           debugPort,
 		Path:           path,
 		InstallWrapper: installWrapper,
 	}
@@ -92,8 +87,6 @@ func init() {
 	_ = viper.BindPFlags(ServerTCPFlags)
 	ServerTCPFlags.AddFlagSet(cmnGrpc.Flags)
 
-	ServerLocalFlags.Uint16(CfgDebugPort, 0, "gRPC server debug port (INSECURE/UNSAFE)")
-	_ = viper.BindPFlags(ServerLocalFlags)
 	ServerLocalFlags.AddFlagSet(cmnGrpc.Flags)
 
 	ClientFlags.StringP(CfgAddress, "a", defaultAddress, "remote gRPC address")

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -39,13 +39,6 @@ func (args *argBuilder) debugAllowTestKeys() *argBuilder {
 	return args
 }
 
-func (args *argBuilder) grpcDebugPort(port uint16) *argBuilder {
-	args.vec = append(args.vec, []string{
-		"--" + grpc.CfgDebugPort, strconv.Itoa(int(port)),
-	}...)
-	return args
-}
-
 func (args *argBuilder) grpcServerPort(port uint16) *argBuilder {
 	args.vec = append(args.vec, []string{
 		"--" + grpc.CfgServerPort, strconv.Itoa(int(port)),

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -26,7 +26,6 @@ type Validator struct {
 
 	tmAddress     string
 	consensusPort uint16
-	grpcDebugPort uint16
 }
 
 // ValidatorCfg is the Oasis validator provisioning configuration.
@@ -75,7 +74,6 @@ func (val *Validator) startNode() error {
 		consensusValidator().
 		tendermintCoreListenAddress(val.consensusPort).
 		tendermintMinGasPrice(val.minGasPrice).
-		grpcDebugPort(val.grpcDebugPort).
 		storageBackend("client").
 		appendNetwork(val.net).
 		appendEntity(val.entity)
@@ -117,7 +115,6 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 		minGasPrice:   cfg.MinGasPrice,
 		sentries:      cfg.Sentries,
 		consensusPort: net.nextNodePort,
-		grpcDebugPort: net.nextNodePort + 1,
 	}
 	val.doStartNode = val.startNode
 
@@ -181,7 +178,7 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 	val.tmAddress = crypto.PublicKeyToTendermint(&valPublicKey).Address().String()
 
 	net.validators = append(net.validators, val)
-	net.nextNodePort += 2
+	net.nextNodePort++
 
 	// Use the first validator as a controller.
 	if len(net.validators) == 1 {

--- a/runtime/src/transaction/dispatcher.rs
+++ b/runtime/src/transaction/dispatcher.rs
@@ -232,7 +232,7 @@ impl Dispatcher {
         }
 
         // Process batch.
-        let outputs = TxnBatch(
+        let outputs = TxnBatch::new(
             batch
                 .iter()
                 .map(|call| {

--- a/runtime/src/transaction/types.rs
+++ b/runtime/src/transaction/types.rs
@@ -66,6 +66,12 @@ mod batch_serialize {
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TxnBatch(#[serde(with = "batch_serialize")] pub Vec<Vec<u8>>);
 
+impl TxnBatch {
+    pub fn new(txs: Vec<Vec<u8>>) -> TxnBatch {
+        TxnBatch(txs)
+    }
+}
+
 impl Deref for TxnBatch {
     type Target = Vec<Vec<u8>>;
 


### PR DESCRIPTION
This is why we can't have nice things.

In retrospect, clearly marked foot+gun options are still foot+gun
options.  While the loss of convenience sucks, don't allow exposing the
internal gRPC service over TCP/IP at all.