### PR TITLE
oasis-test-runner: Log watcher fixes and improvements

### DIFF
--- a/go/oasis-test-runner/log/handlers.go
+++ b/go/oasis-test-runner/log/handlers.go
@@ -6,6 +6,15 @@ import (
 	"strings"
 )
 
+var (
+	_ WatcherHandler        = (*assertBaseHandler)(nil)
+	_ WatcherHandler        = (*assertContainsHandler)(nil)
+	_ WatcherHandler        = (*assertJSONContainsHandler)(nil)
+	_ WatcherHandlerFactory = (*assertBaseFactory)(nil)
+	_ WatcherHandlerFactory = (*assertContainsFactory)(nil)
+	_ WatcherHandlerFactory = (*assertJSONContainsFactory)(nil)
+)
+
 type assertBase struct {
 	message string
 }
@@ -14,53 +23,90 @@ func (a *assertBase) fail() error {
 	return fmt.Errorf("log assertion failed: %s", a.message)
 }
 
-func (a *assertBase) Line(line string) error {
+func (a *assertBase) String() string {
+	return fmt.Sprintf("assertBase{message: %s}", a.message)
+}
+
+type assertBaseHandler assertBase
+
+func (h *assertBaseHandler) Line(line string) error {
 	return nil
 }
 
-func (a *assertBase) Finish() error {
+func (h *assertBaseHandler) Finish() error {
 	return nil
+}
+
+type assertBaseFactory assertBase
+
+func (fac *assertBaseFactory) New() (WatcherHandler, error) {
+	return &assertBaseHandler{
+		message: fac.message,
+	}, nil
 }
 
 type assertContains struct {
 	assertBase
 
 	text     string
-	seen     bool
 	expected bool
 }
 
-func (a *assertContains) Line(line string) error {
-	if strings.Contains(line, a.text) {
-		a.seen = true
+func (a *assertContains) String() string {
+	return fmt.Sprintf("assertContains{message: %s text: %s expected: %t}", a.message, a.text, a.expected)
+}
+
+type assertContainsHandler struct {
+	assertContains
+
+	seen bool
+}
+
+func (h *assertContainsHandler) Line(line string) error {
+	if strings.Contains(line, h.text) {
+		h.seen = true
 	}
 	return nil
 }
 
-func (a *assertContains) Finish() error {
-	if a.seen != a.expected {
-		return a.fail()
+func (h *assertContainsHandler) Finish() error {
+	if h.seen != h.expected {
+		return h.fail()
 	}
 	return nil
 }
 
-// AssertContains returns a handler which checks that given text is
-// contained in the log output.
-func AssertContains(text, message string) WatcherHandler {
-	return &assertContains{
-		assertBase: assertBase{message},
-		text:       text,
-		expected:   true,
+type assertContainsFactory struct {
+	assertContains
+}
+
+func (fac *assertContainsFactory) New() (WatcherHandler, error) {
+	return &assertContainsHandler{
+		assertContains: fac.assertContains,
+	}, nil
+}
+
+// AssertContains returns a factory of log handlers which check that the given
+// text is contained in the log output.
+func AssertContains(text, message string) WatcherHandlerFactory {
+	return &assertContainsFactory{
+		assertContains: assertContains{
+			assertBase: assertBase{message},
+			text:       text,
+			expected:   true,
+		},
 	}
 }
 
-// AssertNotContains returns a handler which checks that given text
-// is not contained in the log output.
-func AssertNotContains(text, message string) WatcherHandler {
-	return &assertContains{
-		assertBase: assertBase{message},
-		text:       text,
-		expected:   false,
+// AssertNotContains returns a factory of log handlers which check that the
+// given text is not contained in the log output.
+func AssertNotContains(text, message string) WatcherHandlerFactory {
+	return &assertContainsFactory{
+		assertContains: assertContains{
+			assertBase: assertBase{message},
+			text:       text,
+			expected:   false,
+		},
 	}
 }
 
@@ -69,18 +115,27 @@ type assertJSONContains struct {
 
 	key      string
 	value    string
-	seen     bool
 	expected bool
 }
 
-func (a *assertJSONContains) Line(line string) error {
+func (a *assertJSONContains) String() string {
+	return fmt.Sprintf("assertJSONContains{message: %s key: %s value: %s expected: %t}", a.message, a.key, a.value, a.expected)
+}
+
+type assertJSONContainsHandler struct {
+	assertJSONContains
+
+	seen bool
+}
+
+func (h *assertJSONContainsHandler) Line(line string) error {
 	var kvs map[string]interface{}
 	if err := json.Unmarshal([]byte(line), &kvs); err != nil {
 		return nil
 	}
 
 	// TODO: Support arbitrary nested paths as keys.
-	v := kvs[a.key]
+	v := kvs[h.key]
 	if v == nil {
 		return nil
 	}
@@ -88,39 +143,53 @@ func (a *assertJSONContains) Line(line string) error {
 	// TODO: Support other types.
 	switch v.(type) {
 	case string:
-		if v == a.value {
-			a.seen = true
+		if v == h.value {
+			h.seen = true
 		}
 	}
 
 	return nil
 }
 
-func (a *assertJSONContains) Finish() error {
-	if a.seen != a.expected {
-		return a.fail()
+func (h *assertJSONContainsHandler) Finish() error {
+	if h.seen != h.expected {
+		return h.fail()
 	}
 	return nil
 }
 
-// AssertJSONContains returns a handler which checks that a given key/value
-// pair is contained encoded as JSON in the log output.
-func AssertJSONContains(key, value, message string) WatcherHandler {
-	return &assertJSONContains{
-		assertBase: assertBase{message},
-		key:        key,
-		value:      value,
-		expected:   true,
+type assertJSONContainsFactory struct {
+	assertJSONContains
+}
+
+func (fac *assertJSONContainsFactory) New() (WatcherHandler, error) {
+	return &assertJSONContainsHandler{
+		assertJSONContains: fac.assertJSONContains,
+	}, nil
+}
+
+// AssertJSONContains returns a factory of log handlers which check that the
+// given key/value pair is contained encoded as JSON in the log output.
+func AssertJSONContains(key, value, message string) WatcherHandlerFactory {
+	return &assertJSONContainsFactory{
+		assertJSONContains: assertJSONContains{
+			assertBase: assertBase{message},
+			key:        key,
+			value:      value,
+			expected:   true,
+		},
 	}
 }
 
-// AssertNotJSONContains returns a handler which checks that a given key/value
-// pair is not contained encoded as JSON in the log output.
-func AssertNotJSONContains(key, value, message string) WatcherHandler {
-	return &assertJSONContains{
-		assertBase: assertBase{message},
-		key:        key,
-		value:      value,
-		expected:   false,
+// AssertNotJSONContains returns a factory of log handlers which check that the
+// given key/value pair is not contained encoded as JSON in the log output.
+func AssertNotJSONContains(key, value, message string) WatcherHandlerFactory {
+	return &assertJSONContainsFactory{
+		assertJSONContains: assertJSONContains{
+			assertBase: assertBase{message},
+			key:        key,
+			value:      value,
+			expected:   false,
+		},
 	}
 }

--- a/go/oasis-test-runner/log/log.go
+++ b/go/oasis-test-runner/log/log.go
@@ -6,6 +6,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+// WatcherHandlerFactory is a factory interface for log file watcher handlers.
+type WatcherHandlerFactory interface {
+	// New will create and return a WatcherHandler ready for use.
+	New() (WatcherHandler, error)
+}
+
 // WatcherHandler is a log file watcher handler.
 type WatcherHandler interface {
 	// Line is called for each processed line.

--- a/go/oasis-test-runner/oasis/byzantine.go
+++ b/go/oasis-test-runner/oasis/byzantine.go
@@ -98,9 +98,11 @@ func (net *Network) NewByzantine(cfg *ByzantineCfg) (*Byzantine, error) {
 
 	worker := &Byzantine{
 		Node: Node{
-			Name: byzantineName,
-			net:  net,
-			dir:  byzantineDir,
+			Name:                                     byzantineName,
+			net:                                      net,
+			dir:                                      byzantineDir,
+			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
+			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 		},
 		script:        cfg.Script,
 		entity:        cfg.Entity,
@@ -111,6 +113,14 @@ func (net *Network) NewByzantine(cfg *ByzantineCfg) (*Byzantine, error) {
 
 	net.byzantine = append(net.byzantine, worker)
 	net.nextNodePort += 2
+
+	if err := net.AddLogWatcher(&worker.Node); err != nil {
+		net.logger.Error("failed to add log watcher",
+			"err", err,
+			"byzantine_name", byzantineName,
+		)
+		return nil, fmt.Errorf("oasis/byzantine: failed to add log watcher for %s: %w", byzantineName, err)
+	}
 
 	return worker, nil
 }

--- a/go/oasis-test-runner/oasis/byzantine.go
+++ b/go/oasis-test-runner/oasis/byzantine.go
@@ -47,8 +47,15 @@ func (worker *Byzantine) startNode() error {
 	}
 
 	var err error
-	if worker.cmd, worker.exitCh, err = worker.net.startOasisNode(worker.dir, []string{"debug", "byzantine", worker.script}, args, "byzantine", true, false); err != nil {
-		return errors.Wrap(err, "oasis/byzantine: failed to launch node")
+	if worker.cmd, worker.exitCh, err = worker.net.startOasisNode(
+		worker.dir,
+		[]string{"debug", "byzantine", worker.script},
+		args,
+		worker.Name,
+		true,
+		false,
+	); err != nil {
+		return fmt.Errorf("oasis/byzantine: failed to launch node %s: %w", worker.Name, err)
 	}
 
 	return nil
@@ -91,8 +98,9 @@ func (net *Network) NewByzantine(cfg *ByzantineCfg) (*Byzantine, error) {
 
 	worker := &Byzantine{
 		Node: Node{
-			net: net,
-			dir: byzantineDir,
+			Name: byzantineName,
+			net:  net,
+			dir:  byzantineDir,
 		},
 		script:        cfg.Script,
 		entity:        cfg.Entity,

--- a/go/oasis-test-runner/oasis/client.go
+++ b/go/oasis-test-runner/oasis/client.go
@@ -32,8 +32,15 @@ func (client *Client) startNode() error {
 	}
 
 	var err error
-	if client.cmd, client.exitCh, err = client.net.startOasisNode(client.dir, nil, args, "client", false, false); err != nil {
-		return errors.Wrap(err, "oasis/client: failed to launch node")
+	if client.cmd, client.exitCh, err = client.net.startOasisNode(
+		client.dir,
+		nil,
+		args,
+		client.Name,
+		false,
+		false,
+	); err != nil {
+		return fmt.Errorf("oasis/client: failed to launch node %s: %w", client.Name, err)
 	}
 
 	return nil
@@ -54,8 +61,9 @@ func (net *Network) NewClient() (*Client, error) {
 
 	client := &Client{
 		Node: Node{
-			net: net,
-			dir: clientDir,
+			Name: clientName,
+			net:  net,
+			dir:  clientDir,
 		},
 		consensusPort: net.nextNodePort,
 	}

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -88,8 +88,15 @@ func (worker *Compute) startNode() error {
 	}
 
 	var err error
-	if worker.cmd, worker.exitCh, err = worker.net.startOasisNode(worker.dir, nil, args, "compute", false, worker.restartable); err != nil {
-		return errors.Wrap(err, "oasis/compute: failed to launch node")
+	if worker.cmd, worker.exitCh, err = worker.net.startOasisNode(
+		worker.dir,
+		nil,
+		args,
+		worker.Name,
+		false,
+		worker.restartable,
+	); err != nil {
+		return fmt.Errorf("oasis/compute: failed to launch node %s: %w", worker.Name, err)
 	}
 
 	return nil
@@ -130,6 +137,7 @@ func (net *Network) NewCompute(cfg *ComputeCfg) (*Compute, error) {
 
 	worker := &Compute{
 		Node: Node{
+			Name:        computeName,
 			net:         net,
 			dir:         computeDir,
 			restartable: cfg.Restartable,

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -137,10 +137,12 @@ func (net *Network) NewCompute(cfg *ComputeCfg) (*Compute, error) {
 
 	worker := &Compute{
 		Node: Node{
-			Name:        computeName,
-			net:         net,
-			dir:         computeDir,
-			restartable: cfg.Restartable,
+			Name:                                     computeName,
+			net:                                      net,
+			dir:                                      computeDir,
+			restartable:                              cfg.Restartable,
+			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
+			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 		},
 		entity:         cfg.Entity,
 		runtimeBackend: cfg.RuntimeBackend,
@@ -152,6 +154,14 @@ func (net *Network) NewCompute(cfg *ComputeCfg) (*Compute, error) {
 
 	net.computeWorkers = append(net.computeWorkers, worker)
 	net.nextNodePort += 3
+
+	if err := net.AddLogWatcher(&worker.Node); err != nil {
+		net.logger.Error("failed to add log watcher",
+			"err", err,
+			"compute_name", computeName,
+		)
+		return nil, fmt.Errorf("oasis/compute: failed to add log watcher for %s: %w", computeName, err)
+	}
 
 	return worker, nil
 }

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -7,6 +7,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/sgx"
 	"github.com/oasislabs/oasis-core/go/common/sgx/ias"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/log"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
 )
 
@@ -118,6 +119,8 @@ type ValidatorFixture struct {
 
 	Entity int `json:"entity"`
 
+	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
+
 	MinGasPrice uint64 `json:"min_gas_price"`
 
 	Sentries []int `json:"sentries,omitempty"`
@@ -136,7 +139,8 @@ func (f *ValidatorFixture) Create(net *Network) (*Validator, error) {
 
 	return net.NewValidator(&ValidatorCfg{
 		NodeCfg: NodeCfg{
-			Restartable: f.Restartable,
+			Restartable:                f.Restartable,
+			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
 		},
 		Entity:      entity,
 		MinGasPrice: f.MinGasPrice,
@@ -201,6 +205,8 @@ type KeymanagerFixture struct {
 	Entity  int `json:"entity"`
 
 	Restartable bool `json:"restartable"`
+
+	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
 }
 
 // Create instantiates the key manager described by the fixture.
@@ -216,7 +222,8 @@ func (f *KeymanagerFixture) Create(net *Network) (*Keymanager, error) {
 
 	return net.NewKeymanager(&KeymanagerCfg{
 		NodeCfg: NodeCfg{
-			Restartable: f.Restartable,
+			Restartable:                f.Restartable,
+			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
 		},
 		Runtime: runtime,
 		Entity:  entity,
@@ -227,6 +234,8 @@ func (f *KeymanagerFixture) Create(net *Network) (*Keymanager, error) {
 type StorageWorkerFixture struct {
 	Backend string `json:"backend"`
 	Entity  int    `json:"entity"`
+
+	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
 
 	IgnoreApplies bool `json:"ignore_applies,omitempty"`
 }
@@ -239,6 +248,9 @@ func (f *StorageWorkerFixture) Create(net *Network) (*Storage, error) {
 	}
 
 	return net.NewStorage(&StorageCfg{
+		NodeCfg: NodeCfg{
+			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
+		},
 		Backend:       f.Backend,
 		Entity:        entity,
 		IgnoreApplies: f.IgnoreApplies,
@@ -252,6 +264,8 @@ type ComputeWorkerFixture struct {
 	RuntimeBackend string `json:"runtime_backend"`
 
 	Restartable bool `json:"restartable"`
+
+	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
 }
 
 // Create instantiates the compute worker described by the fixture.
@@ -263,7 +277,8 @@ func (f *ComputeWorkerFixture) Create(net *Network) (*Compute, error) {
 
 	return net.NewCompute(&ComputeCfg{
 		NodeCfg: NodeCfg{
-			Restartable: f.Restartable,
+			Restartable:                f.Restartable,
+			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
 		},
 		Entity:         entity,
 		RuntimeBackend: f.RuntimeBackend,
@@ -272,12 +287,17 @@ func (f *ComputeWorkerFixture) Create(net *Network) (*Compute, error) {
 
 // SentryFixture is a sentry node fixture.
 type SentryFixture struct {
+	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
+
 	Validators []int `json:"validators"`
 }
 
 // Create instantiates the client node described by the fixture.
 func (f *SentryFixture) Create(net *Network) (*Sentry, error) {
 	return net.NewSentry(&SentryCfg{
+		NodeCfg: NodeCfg{
+			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
+		},
 		ValidatorIndices: f.Validators,
 	})
 }
@@ -296,6 +316,9 @@ type ByzantineFixture struct {
 	Script       string `json:"script"`
 	IdentitySeed string `json:"identity_seed"`
 	Entity       int    `json:"entity"`
+
+	EnableDefaultLogWatcherHandlerFactories bool                        `json:"enable_default_log_fac"`
+	LogWatcherHandlerFactories              []log.WatcherHandlerFactory `json:"-"`
 }
 
 // Create instantiates the byzantine node described by the fixture.
@@ -306,6 +329,10 @@ func (f *ByzantineFixture) Create(net *Network) (*Byzantine, error) {
 	}
 
 	return net.NewByzantine(&ByzantineCfg{
+		NodeCfg: NodeCfg{
+			DisableDefaultLogWatcherHandlerFactories: !f.EnableDefaultLogWatcherHandlerFactories,
+			LogWatcherHandlerFactories:               f.LogWatcherHandlerFactories,
+		},
 		Script:       f.Script,
 		IdentitySeed: f.IdentitySeed,
 		Entity:       entity,

--- a/go/oasis-test-runner/oasis/ias.go
+++ b/go/oasis-test-runner/oasis/ias.go
@@ -2,6 +2,7 @@ package oasis
 
 import (
 	"encoding/hex"
+	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -33,8 +34,15 @@ func (ias *iasProxy) startNode() error {
 		iasSPID(mockSPID)
 
 	var err error
-	if ias.cmd, ias.exitCh, err = ias.net.startOasisNode(ias.dir, []string{"ias", "proxy"}, args, "ias-proxy", false, false); err != nil {
-		return errors.Wrap(err, "oasis/ias: failed to launch node")
+	if ias.cmd, ias.exitCh, err = ias.net.startOasisNode(
+		ias.dir,
+		[]string{"ias", "proxy"},
+		args,
+		ias.Name,
+		false,
+		false,
+	); err != nil {
+		return fmt.Errorf("oasis/ias: failed to launch node %s: %w", ias.Name, err)
 	}
 
 	return nil
@@ -45,7 +53,9 @@ func (net *Network) newIASProxy() (*iasProxy, error) {
 		return nil, errors.New("oasis/ias: already provisioned")
 	}
 
-	iasDir, err := net.baseDir.NewSubDir("ias")
+	iasName := "ias-proxy"
+
+	iasDir, err := net.baseDir.NewSubDir(iasName)
 	if err != nil {
 		net.logger.Error("failed to create ias proxy subdir",
 			"err", err,
@@ -65,8 +75,9 @@ func (net *Network) newIASProxy() (*iasProxy, error) {
 
 	net.iasProxy = &iasProxy{
 		Node: Node{
-			net: net,
-			dir: iasDir,
+			Name: iasName,
+			net:  net,
+			dir:  iasDir,
 		},
 		grpcPort: net.nextNodePort,
 	}

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -191,8 +191,8 @@ func (km *Keymanager) startNode() error {
 	}
 
 	var err error
-	if km.cmd, km.exitCh, err = km.net.startOasisNode(km.dir, nil, args, "keymanager", false, km.restartable); err != nil {
-		return errors.Wrap(err, "oasis/keymanager: failed to launch node")
+	if km.cmd, km.exitCh, err = km.net.startOasisNode(km.dir, nil, args, km.Name, false, km.restartable); err != nil {
+		return fmt.Errorf("oasis/keymanager: failed to launch node %s: %w", km.Name, err)
 	}
 
 	return nil
@@ -205,7 +205,9 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 		return nil, errors.New("oasis/keymanager: already provisioned")
 	}
 
-	kmDir, err := net.baseDir.NewSubDir("keymanager")
+	kmName := "keymanager"
+
+	kmDir, err := net.baseDir.NewSubDir(kmName)
 	if err != nil {
 		net.logger.Error("failed to create keymanager subdir",
 			"err", err,
@@ -224,6 +226,7 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 
 	km := &Keymanager{
 		Node: Node{
+			Name:        kmName,
 			net:         net,
 			dir:         kmDir,
 			restartable: cfg.Restartable,

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -226,10 +226,12 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 
 	km := &Keymanager{
 		Node: Node{
-			Name:        kmName,
-			net:         net,
-			dir:         kmDir,
-			restartable: cfg.Restartable,
+			Name:                                     kmName,
+			net:                                      net,
+			dir:                                      kmDir,
+			restartable:                              cfg.Restartable,
+			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
+			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 		},
 		runtime:          cfg.Runtime,
 		entity:           cfg.Entity,
@@ -240,6 +242,13 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 
 	net.keymanager = km
 	net.nextNodePort += 2
+
+	if err := net.AddLogWatcher(&km.Node); err != nil {
+		net.logger.Error("failed to add log watcher",
+			"err", err,
+		)
+		return nil, fmt.Errorf("oasis/keymanager: failed to add log watcher: %w", err)
+	}
 
 	return km, nil
 }

--- a/go/oasis-test-runner/oasis/log.go
+++ b/go/oasis-test-runner/oasis/log.go
@@ -9,60 +9,60 @@ import (
 
 // LogAssertEvent returns a handler which checks whether a specific log event was
 // emitted based on JSON log output.
-func LogAssertEvent(event, message string) log.WatcherHandler {
+func LogAssertEvent(event, message string) log.WatcherHandlerFactory {
 	return log.AssertJSONContains(logging.LogEvent, event, message)
 }
 
 // LogAssertNotEvent returns a handler which checks whether a specific log event
 // was not emitted based on JSON log output.
-func LogAssertNotEvent(event, message string) log.WatcherHandler {
+func LogAssertNotEvent(event, message string) log.WatcherHandlerFactory {
 	return log.AssertNotJSONContains(logging.LogEvent, event, message)
 }
 
 // LogAssertTimeouts returns a handler which checks whether a timeout was
 // detected based on JSON log output.
-func LogAssertTimeouts() log.WatcherHandler {
+func LogAssertTimeouts() log.WatcherHandlerFactory {
 	return LogAssertEvent(roothash.LogEventTimerFired, "timeout not detected")
 }
 
 // LogAssertNoTimeouts returns a handler which checks whether a timeout was
 // detected based on JSON log output.
-func LogAssertNoTimeouts() log.WatcherHandler {
+func LogAssertNoTimeouts() log.WatcherHandlerFactory {
 	return LogAssertNotEvent(roothash.LogEventTimerFired, "timeout detected")
 }
 
 // LogAssertNoRoundFailures returns a handler which checks whether a round failure
 // was detected based on JSON log output.
-func LogAssertNoRoundFailures() log.WatcherHandler {
+func LogAssertNoRoundFailures() log.WatcherHandlerFactory {
 	return LogAssertNotEvent(roothash.LogEventRoundFailed, "round failure detected")
 }
 
 // LogAssertComputeDiscrepancyDetected returns a handler which checks whether a
 // compute discrepancy was detected based on JSON log output.
-func LogAssertComputeDiscrepancyDetected() log.WatcherHandler {
+func LogAssertComputeDiscrepancyDetected() log.WatcherHandlerFactory {
 	return LogAssertEvent(roothash.LogEventComputeDiscrepancyDetected, "compute discrepancy not detected")
 }
 
 // LogAssertNoComputeDiscrepancyDetected returns a handler which checks whether a
 // compute discrepancy was not detected based on JSON log output.
-func LogAssertNoComputeDiscrepancyDetected() log.WatcherHandler {
+func LogAssertNoComputeDiscrepancyDetected() log.WatcherHandlerFactory {
 	return LogAssertNotEvent(roothash.LogEventComputeDiscrepancyDetected, "compute discrepancy detected")
 }
 
 // LogAssertMergeDiscrepancyDetected returns a handler which checks whether a
 // merge discrepancy was detected based on JSON log output.
-func LogAssertMergeDiscrepancyDetected() log.WatcherHandler {
+func LogAssertMergeDiscrepancyDetected() log.WatcherHandlerFactory {
 	return LogAssertEvent(roothash.LogEventMergeDiscrepancyDetected, "merge discrepancy not detected")
 }
 
 // LogAssertNoMergeDiscrepancyDetected returns a handler which checks whether a
 // merge discrepancy was not detected based on JSON log output.
-func LogAssertNoMergeDiscrepancyDetected() log.WatcherHandler {
+func LogAssertNoMergeDiscrepancyDetected() log.WatcherHandlerFactory {
 	return LogAssertNotEvent(roothash.LogEventMergeDiscrepancyDetected, "merge discrepancy detected")
 }
 
 // LogAssertPeerExchangeDisabled returns a handler which checks whether a peer
 // exchange disabled event was detected based on JSON log output.
-func LogAssertPeerExchangeDisabled() log.WatcherHandler {
+func LogAssertPeerExchangeDisabled() log.WatcherHandlerFactory {
 	return LogAssertEvent(tendermint.LogEventPeerExchangeDisabled, "peer exchange not disabled")
 }

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -46,7 +46,7 @@ const (
 )
 
 // Node defines the common fields for all node types.
-type Node struct {
+type Node struct { // nolint: maligned
 	Name string
 
 	net *Network
@@ -57,6 +57,9 @@ type Node struct {
 
 	restartable bool
 	doStartNode func() error
+
+	disableDefaultLogWatcherHandlerFactories bool
+	logWatcherHandlerFactories               []log.WatcherHandlerFactory
 }
 
 // Exit returns a channel that will close once the node shuts down.
@@ -98,6 +101,9 @@ func (n *Node) Restart() error {
 // NodeCfg defines the common node configuration options.
 type NodeCfg struct {
 	Restartable bool
+
+	DisableDefaultLogWatcherHandlerFactories bool
+	LogWatcherHandlerFactories               []log.WatcherHandlerFactory
 }
 
 // CmdAttrs is the SysProcAttr that will ensure graceful cleanup.
@@ -171,7 +177,7 @@ type NetworkCfg struct { // nolint: maligned
 
 	// A set of log watcher handler factories used by default on all nodes
 	// created in this test network.
-	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
+	DefaultLogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
 }
 
 // Config returns the network configuration.
@@ -241,6 +247,42 @@ func (net *Network) NumRegisterNodes() int {
 		len(net.storageWorkers) +
 		len(net.computeWorkers) +
 		len(net.byzantine)
+}
+
+// AddLogWatcher adds a log watcher for the given node and creates log watcher
+// handlers from the networks's default and node's specific log watcher handler
+// factories.
+func (net *Network) AddLogWatcher(node *Node) error {
+	var logWatcherHandlers []log.WatcherHandler
+	// Add network's default log watcher handlers.
+	if !node.disableDefaultLogWatcherHandlerFactories {
+		for _, logWatcherHandlerFactory := range net.cfg.DefaultLogWatcherHandlerFactories {
+			logWatcherHandler, err := logWatcherHandlerFactory.New()
+			if err != nil {
+				return err
+			}
+			logWatcherHandlers = append(logWatcherHandlers, logWatcherHandler)
+		}
+	}
+	// Add node's specific log watcher handlers.
+	for _, logWatcherHandlerFactory := range node.logWatcherHandlerFactories {
+		logWatcherHandler, err := logWatcherHandlerFactory.New()
+		if err != nil {
+			return err
+		}
+		logWatcherHandlers = append(logWatcherHandlers, logWatcherHandler)
+	}
+	logFileWatcher, err := log.NewWatcher(&log.WatcherConfig{
+		Name:     fmt.Sprintf("%s/log", node.Name),
+		File:     nodeLogPath(node.dir),
+		Handlers: logWatcherHandlers,
+	})
+	if err != nil {
+		return err
+	}
+	net.env.AddOnCleanup(logFileWatcher.Cleanup)
+	net.logWatchers = append(net.logWatchers, logFileWatcher)
+	return nil
 }
 
 // CloseLogWatchers closes all log watchers and checks if any errors were reported
@@ -489,27 +531,6 @@ func (net *Network) startOasisNode(
 
 	if err = cmd.Start(); err != nil {
 		return nil, nil, errors.Wrap(err, "oasis: failed to start node")
-	}
-
-	if len(net.cfg.LogWatcherHandlerFactories) > 0 {
-		var logWatcherHandlers []log.WatcherHandler
-		for _, logWatcherHandlerFactory := range net.cfg.LogWatcherHandlerFactories {
-			logWatcherHandler, err := logWatcherHandlerFactory.New()
-			if err != nil {
-				return nil, nil, err
-			}
-			logWatcherHandlers = append(logWatcherHandlers, logWatcherHandler)
-		}
-		logFileWatcher, err := log.NewWatcher(&log.WatcherConfig{
-			Name:     fmt.Sprintf("%s/log", descr),
-			File:     nodeLogPath(dir),
-			Handlers: logWatcherHandlers,
-		})
-		if err != nil {
-			return nil, nil, err
-		}
-		net.env.AddOnCleanup(logFileWatcher.Cleanup)
-		net.logWatchers = append(net.logWatchers, logFileWatcher)
 	}
 
 	doneCh := net.env.AddTermOnCleanup(cmd)

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -47,6 +47,8 @@ const (
 
 // Node defines the common fields for all node types.
 type Node struct {
+	Name string
+
 	net *Network
 	dir *env.Dir
 	cmd *exec.Cmd

--- a/go/oasis-test-runner/oasis/seed.go
+++ b/go/oasis-test-runner/oasis/seed.go
@@ -1,6 +1,8 @@
 package oasis
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
@@ -24,8 +26,8 @@ func (seed *seedNode) startNode() error {
 		tendermintSeedMode()
 
 	var err error
-	if seed.cmd, seed.exitCh, err = seed.net.startOasisNode(seed.dir, nil, args, "seed", false, false); err != nil {
-		return errors.Wrap(err, "oasis/seed: failed to launch node")
+	if seed.cmd, seed.exitCh, err = seed.net.startOasisNode(seed.dir, nil, args, seed.Name, false, false); err != nil {
+		return fmt.Errorf("oasis/seed: failed to launch node %s: %w", seed.Name, err)
 	}
 
 	return nil
@@ -39,7 +41,9 @@ func (net *Network) newSeedNode() (*seedNode, error) {
 	// Why, yes, this *could* probably just use Oasis node's integrated seed
 	// node as a library, but this is more "realistic" for tests.
 
-	seedDir, err := net.baseDir.NewSubDir("seed")
+	seedName := "seed"
+
+	seedDir, err := net.baseDir.NewSubDir(seedName)
 	if err != nil {
 		net.logger.Error("failed to create seed node subdir",
 			"err", err,
@@ -59,8 +63,9 @@ func (net *Network) newSeedNode() (*seedNode, error) {
 
 	seedNode := &seedNode{
 		Node: Node{
-			net: net,
-			dir: seedDir,
+			Name: seedName,
+			net:  net,
+			dir:  seedDir,
 		},
 		tmAddress:     crypto.PublicKeyToTendermint(&seedPublicKey).Address().String(),
 		consensusPort: net.nextNodePort,

--- a/go/oasis-test-runner/oasis/sentry.go
+++ b/go/oasis-test-runner/oasis/sentry.go
@@ -46,8 +46,8 @@ func (sentry *Sentry) startNode() error {
 		appendNetwork(sentry.net).
 		addValidatorsAsPrivatePeers(validators)
 
-	if sentry.cmd, _, err = sentry.net.startOasisNode(sentry.dir, nil, args, "sentry", false, false); err != nil {
-		return fmt.Errorf("oasis/sentry: failed to launch node: %w", err)
+	if sentry.cmd, _, err = sentry.net.startOasisNode(sentry.dir, nil, args, sentry.Name, false, false); err != nil {
+		return fmt.Errorf("oasis/sentry: failed to launch node %s: %w", sentry.Name, err)
 	}
 
 	return nil
@@ -82,8 +82,9 @@ func (net *Network) NewSentry(cfg *SentryCfg) (*Sentry, error) {
 
 	sentry := &Sentry{
 		Node: Node{
-			net: net,
-			dir: sentryDir,
+			Name: sentryName,
+			net:  net,
+			dir:  sentryDir,
 		},
 		validatorIndices: cfg.ValidatorIndices,
 		publicKey:        sentryPublicKey,

--- a/go/oasis-test-runner/oasis/storage.go
+++ b/go/oasis-test-runner/oasis/storage.go
@@ -126,9 +126,11 @@ func (net *Network) NewStorage(cfg *StorageCfg) (*Storage, error) {
 
 	worker := &Storage{
 		Node: Node{
-			Name: storageName,
-			net:  net,
-			dir:  storageDir,
+			Name:                                     storageName,
+			net:                                      net,
+			dir:                                      storageDir,
+			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
+			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 		},
 		backend:       cfg.Backend,
 		entity:        cfg.Entity,
@@ -141,6 +143,14 @@ func (net *Network) NewStorage(cfg *StorageCfg) (*Storage, error) {
 
 	net.storageWorkers = append(net.storageWorkers, worker)
 	net.nextNodePort += 3
+
+	if err := net.AddLogWatcher(&worker.Node); err != nil {
+		net.logger.Error("failed to add log watcher",
+			"err", err,
+			"storage_name", storageName,
+		)
+		return nil, fmt.Errorf("oasis/storage: failed to add log watcher for %s: %w", storageName, err)
+	}
 
 	return worker, nil
 }

--- a/go/oasis-test-runner/oasis/storage.go
+++ b/go/oasis-test-runner/oasis/storage.go
@@ -88,8 +88,15 @@ func (worker *Storage) startNode() error {
 	}
 
 	var err error
-	if worker.cmd, worker.exitCh, err = worker.net.startOasisNode(worker.dir, nil, args, "storage", false, false); err != nil {
-		return errors.Wrap(err, "oasis/storage: failed to launch node")
+	if worker.cmd, worker.exitCh, err = worker.net.startOasisNode(
+		worker.dir,
+		nil,
+		args,
+		worker.Name,
+		false,
+		false,
+	); err != nil {
+		return fmt.Errorf("oasis/storage: failed to launch node %s: %w", worker.Name, err)
 	}
 
 	return nil
@@ -119,8 +126,9 @@ func (net *Network) NewStorage(cfg *StorageCfg) (*Storage, error) {
 
 	worker := &Storage{
 		Node: Node{
-			net: net,
-			dir: storageDir,
+			Name: storageName,
+			net:  net,
+			dir:  storageDir,
 		},
 		backend:       cfg.Backend,
 		entity:        cfg.Entity,

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -113,10 +113,12 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 
 	val := &Validator{
 		Node: Node{
-			Name:        valName,
-			net:         net,
-			dir:         valDir,
-			restartable: cfg.Restartable,
+			Name:                                     valName,
+			net:                                      net,
+			dir:                                      valDir,
+			restartable:                              cfg.Restartable,
+			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
+			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
 		},
 		entity:        cfg.Entity,
 		minGasPrice:   cfg.MinGasPrice,
@@ -188,6 +190,14 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 		if net.controller, err = NewController(val.SocketPath()); err != nil {
 			return nil, errors.Wrap(err, "oasis/validator: failed to create controller")
 		}
+	}
+
+	if err := net.AddLogWatcher(&val.Node); err != nil {
+		net.logger.Error("failed to add log watcher",
+			"err", err,
+			"validator_name", valName,
+		)
+		return nil, fmt.Errorf("oasis/validator: failed to add log watcher for %s: %w", valName, err)
 	}
 
 	return val, nil

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -84,8 +84,15 @@ func (val *Validator) startNode() error {
 	}
 
 	var err error
-	if val.cmd, val.exitCh, err = val.net.startOasisNode(val.dir, nil, args, "validator", false, val.restartable); err != nil {
-		return fmt.Errorf("oasis/validator: failed to launch node: %w", err)
+	if val.cmd, val.exitCh, err = val.net.startOasisNode(
+		val.dir,
+		nil,
+		args,
+		val.Name,
+		false,
+		val.restartable,
+	); err != nil {
+		return fmt.Errorf("oasis/validator: failed to launch node %s: %w", val.Name, err)
 	}
 
 	return nil
@@ -106,6 +113,7 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 
 	val := &Validator{
 		Node: Node{
+			Name:        valName,
 			net:         net,
 			dir:         valDir,
 			restartable: cfg.Restartable,

--- a/go/oasis-test-runner/scenario/e2e/basic.go
+++ b/go/oasis-test-runner/scenario/e2e/basic.go
@@ -30,8 +30,9 @@ var (
 		clientBinary: "simple-keyvalue-enc-client",
 	}
 
-	// DefaultBasicLogWatcherHandlers is a list of default basic log watcher handlers.
-	DefaultBasicLogWatcherHandlers = []log.WatcherHandler{
+	// DefaultBasicLogWatcherHandlerFactories is a list of default basic log
+	// watcher handler factories.
+	DefaultBasicLogWatcherHandlerFactories = []log.WatcherHandlerFactory{
 		oasis.LogAssertNoTimeouts(),
 		oasis.LogAssertNoRoundFailures(),
 		oasis.LogAssertNoComputeDiscrepancyDetected(),
@@ -76,9 +77,9 @@ func (sc *basicImpl) Fixture() (*oasis.NetworkFixture, error) {
 			MrSigner: mrSigner,
 		},
 		Network: oasis.NetworkCfg{
-			NodeBinary:          viper.GetString(cfgNodeBinary),
-			RuntimeLoaderBinary: viper.GetString(cfgRuntimeLoader),
-			LogWatcherHandlers:  DefaultBasicLogWatcherHandlers,
+			NodeBinary:                 viper.GetString(cfgNodeBinary),
+			RuntimeLoaderBinary:        viper.GetString(cfgRuntimeLoader),
+			LogWatcherHandlerFactories: DefaultBasicLogWatcherHandlerFactories,
 		},
 		Entities: []oasis.EntityCfg{
 			oasis.EntityCfg{IsDebugTestEntity: true},

--- a/go/oasis-test-runner/scenario/e2e/basic.go
+++ b/go/oasis-test-runner/scenario/e2e/basic.go
@@ -30,8 +30,8 @@ var (
 		clientBinary: "simple-keyvalue-enc-client",
 	}
 
-	// DefaultBasicLogWatcherHandlerFactories is a list of default basic log
-	// watcher handler factories.
+	// DefaultBasicLogWatcherHandlerFactories is a list of default log watcher
+	// handler factories for the basic scenario.
 	DefaultBasicLogWatcherHandlerFactories = []log.WatcherHandlerFactory{
 		oasis.LogAssertNoTimeouts(),
 		oasis.LogAssertNoRoundFailures(),
@@ -77,9 +77,9 @@ func (sc *basicImpl) Fixture() (*oasis.NetworkFixture, error) {
 			MrSigner: mrSigner,
 		},
 		Network: oasis.NetworkCfg{
-			NodeBinary:                 viper.GetString(cfgNodeBinary),
-			RuntimeLoaderBinary:        viper.GetString(cfgRuntimeLoader),
-			LogWatcherHandlerFactories: DefaultBasicLogWatcherHandlerFactories,
+			NodeBinary:                        viper.GetString(cfgNodeBinary),
+			RuntimeLoaderBinary:               viper.GetString(cfgRuntimeLoader),
+			DefaultLogWatcherHandlerFactories: DefaultBasicLogWatcherHandlerFactories,
 		},
 		Entities: []oasis.EntityCfg{
 			oasis.EntityCfg{IsDebugTestEntity: true},

--- a/go/oasis-test-runner/scenario/e2e/byzantine.go
+++ b/go/oasis-test-runner/scenario/e2e/byzantine.go
@@ -90,9 +90,9 @@ func (sc *byzantineImpl) Fixture() (*oasis.NetworkFixture, error) {
 	// The byzantine scenario requires mock epochtime as the byzantine node
 	// doesn't know how to handle epochs in which it is not scheduled.
 	f.Network.EpochtimeMock = true
-	// Change the default log watcher handlers if configured.
+	// Change the default network log watcher handler factories if configured.
 	if sc.logWatcherHandlerFactories != nil {
-		f.Network.LogWatcherHandlerFactories = sc.logWatcherHandlerFactories
+		f.Network.DefaultLogWatcherHandlerFactories = sc.logWatcherHandlerFactories
 	}
 	// Provision a Byzantine node.
 	f.ByzantineNodes = []oasis.ByzantineFixture{

--- a/go/oasis-test-runner/scenario/e2e/byzantine.go
+++ b/go/oasis-test-runner/scenario/e2e/byzantine.go
@@ -19,14 +19,14 @@ var (
 	// ByzantineComputeHonest is the byzantine compute honest scenario.
 	ByzantineComputeHonest scenario.Scenario = newByzantineImpl("compute-honest", nil)
 	// ByzantineComputeWrong is the byzantine compute wrong scenario.
-	ByzantineComputeWrong scenario.Scenario = newByzantineImpl("compute-wrong", []log.WatcherHandler{
+	ByzantineComputeWrong scenario.Scenario = newByzantineImpl("compute-wrong", []log.WatcherHandlerFactory{
 		oasis.LogAssertNoTimeouts(),
 		oasis.LogAssertNoRoundFailures(),
 		oasis.LogAssertComputeDiscrepancyDetected(),
 		oasis.LogAssertNoMergeDiscrepancyDetected(),
 	})
 	// ByzantineComputeStraggler is the byzantine compute straggler scenario.
-	ByzantineComputeStraggler scenario.Scenario = newByzantineImpl("compute-straggler", []log.WatcherHandler{
+	ByzantineComputeStraggler scenario.Scenario = newByzantineImpl("compute-straggler", []log.WatcherHandlerFactory{
 		oasis.LogAssertTimeouts(),
 		oasis.LogAssertNoRoundFailures(),
 		oasis.LogAssertComputeDiscrepancyDetected(),
@@ -36,14 +36,14 @@ var (
 	// ByzantineMergeHonest is the byzantine merge honest scenario.
 	ByzantineMergeHonest scenario.Scenario = newByzantineImpl("merge-honest", nil)
 	// ByzantineMergeWrong is the byzantine merge wrong scenario.
-	ByzantineMergeWrong scenario.Scenario = newByzantineImpl("merge-wrong", []log.WatcherHandler{
+	ByzantineMergeWrong scenario.Scenario = newByzantineImpl("merge-wrong", []log.WatcherHandlerFactory{
 		oasis.LogAssertNoTimeouts(),
 		oasis.LogAssertNoRoundFailures(),
 		oasis.LogAssertNoComputeDiscrepancyDetected(),
 		oasis.LogAssertMergeDiscrepancyDetected(),
 	})
 	// ByzantineMergeStraggler is the byzantine merge straggler scenario.
-	ByzantineMergeStraggler scenario.Scenario = newByzantineImpl("merge-straggler", []log.WatcherHandler{
+	ByzantineMergeStraggler scenario.Scenario = newByzantineImpl("merge-straggler", []log.WatcherHandlerFactory{
 		oasis.LogAssertTimeouts(),
 		oasis.LogAssertNoRoundFailures(),
 		oasis.LogAssertNoComputeDiscrepancyDetected(),
@@ -54,23 +54,23 @@ var (
 type byzantineImpl struct {
 	basicImpl
 
-	script             string
-	identitySeed       string
-	logWatcherHandlers []log.WatcherHandler
+	script                     string
+	identitySeed               string
+	logWatcherHandlerFactories []log.WatcherHandlerFactory
 
 	logger *logging.Logger
 }
 
-func newByzantineImpl(script string, logWatcherHandlers []log.WatcherHandler) scenario.Scenario {
+func newByzantineImpl(script string, logWatcherHandlerFactories []log.WatcherHandlerFactory) scenario.Scenario {
 	sc := &byzantineImpl{
 		basicImpl: basicImpl{
 			clientBinary: "simple-keyvalue-ops-client",
 			clientArgs:   []string{"set", "hello_key", "hello_value"},
 		},
-		script:             script,
-		identitySeed:       byzantineDefaultIdentitySeed,
-		logWatcherHandlers: logWatcherHandlers,
-		logger:             logging.GetLogger("scenario/e2e/byzantine/" + script),
+		script:                     script,
+		identitySeed:               byzantineDefaultIdentitySeed,
+		logWatcherHandlerFactories: logWatcherHandlerFactories,
+		logger:                     logging.GetLogger("scenario/e2e/byzantine/" + script),
 	}
 	return sc
 }
@@ -91,8 +91,8 @@ func (sc *byzantineImpl) Fixture() (*oasis.NetworkFixture, error) {
 	// doesn't know how to handle epochs in which it is not scheduled.
 	f.Network.EpochtimeMock = true
 	// Change the default log watcher handlers if configured.
-	if sc.logWatcherHandlers != nil {
-		f.Network.LogWatcherHandlers = sc.logWatcherHandlers
+	if sc.logWatcherHandlerFactories != nil {
+		f.Network.LogWatcherHandlerFactories = sc.logWatcherHandlerFactories
 	}
 	// Provision a Byzantine node.
 	f.ByzantineNodes = []oasis.ByzantineFixture{

--- a/go/oasis-test-runner/scenario/e2e/gas_fees.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees.go
@@ -60,11 +60,11 @@ func (sc *gasFeesImpl) Fixture() (*oasis.NetworkFixture, error) {
 			MrSigner: mrSigner,
 		},
 		Network: oasis.NetworkCfg{
-			NodeBinary:          viper.GetString(cfgNodeBinary),
-			RuntimeLoaderBinary: viper.GetString(cfgRuntimeLoader),
-			EpochtimeMock:       true,
-			StakingGenesis:      "tests/fixture-data/gas-fees/staking-genesis.json",
-			LogWatcherHandlers:  DefaultBasicLogWatcherHandlers,
+			NodeBinary:                 viper.GetString(cfgNodeBinary),
+			RuntimeLoaderBinary:        viper.GetString(cfgRuntimeLoader),
+			EpochtimeMock:              true,
+			StakingGenesis:             "tests/fixture-data/gas-fees/staking-genesis.json",
+			LogWatcherHandlerFactories: DefaultBasicLogWatcherHandlerFactories,
 		},
 		Entities: []oasis.EntityCfg{
 			oasis.EntityCfg{IsDebugTestEntity: true},

--- a/go/oasis-test-runner/scenario/e2e/gas_fees.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees.go
@@ -60,11 +60,11 @@ func (sc *gasFeesImpl) Fixture() (*oasis.NetworkFixture, error) {
 			MrSigner: mrSigner,
 		},
 		Network: oasis.NetworkCfg{
-			NodeBinary:                 viper.GetString(cfgNodeBinary),
-			RuntimeLoaderBinary:        viper.GetString(cfgRuntimeLoader),
-			EpochtimeMock:              true,
-			StakingGenesis:             "tests/fixture-data/gas-fees/staking-genesis.json",
-			LogWatcherHandlerFactories: DefaultBasicLogWatcherHandlerFactories,
+			NodeBinary:                        viper.GetString(cfgNodeBinary),
+			RuntimeLoaderBinary:               viper.GetString(cfgRuntimeLoader),
+			EpochtimeMock:                     true,
+			StakingGenesis:                    "tests/fixture-data/gas-fees/staking-genesis.json",
+			DefaultLogWatcherHandlerFactories: DefaultBasicLogWatcherHandlerFactories,
 		},
 		Entities: []oasis.EntityCfg{
 			oasis.EntityCfg{IsDebugTestEntity: true},

--- a/go/oasis-test-runner/scenario/e2e/roothash_messages.go
+++ b/go/oasis-test-runner/scenario/e2e/roothash_messages.go
@@ -61,10 +61,10 @@ func (sc *roothashMessagesImpl) Fixture() (*oasis.NetworkFixture, error) {
 			RuntimeLoaderBinary: viper.GetString(cfgRuntimeLoader),
 			EpochtimeMock:       true,
 			StakingGenesis:      "tests/fixture-data/roothash-messages/staking-genesis.json",
-			LogWatcherHandlers: append([]log.WatcherHandler{
+			LogWatcherHandlerFactories: append([]log.WatcherHandlerFactory{
 				oasis.LogAssertNotEvent(roothash.LogEventMessageUnsat, "unsatisfactory roothash message detected"),
 				oasis.LogAssertEvent(staking.LogEventGeneralAdjustment, "balance adjustment not detected"),
-			}, DefaultBasicLogWatcherHandlers...),
+			}, DefaultBasicLogWatcherHandlerFactories...),
 		},
 		Entities: []oasis.EntityCfg{
 			oasis.EntityCfg{IsDebugTestEntity: true},

--- a/go/oasis-test-runner/scenario/e2e/roothash_messages.go
+++ b/go/oasis-test-runner/scenario/e2e/roothash_messages.go
@@ -22,6 +22,13 @@ import (
 var (
 	// RoothashMessages is the roothash messages scenario.
 	RoothashMessages scenario.Scenario = &roothashMessagesImpl{}
+
+	// DefaultRoothashLogWatcherHandlerFactories is a list of default log
+	// watcher handler factories for the roothash messages scenario.
+	DefaultRoothashLogWatcherHandlerFactories = append([]log.WatcherHandlerFactory{
+		oasis.LogAssertNotEvent(roothash.LogEventMessageUnsat, "unsatisfactory roothash message detected"),
+		oasis.LogAssertEvent(staking.LogEventGeneralAdjustment, "balance adjustment not detected"),
+	}, DefaultBasicLogWatcherHandlerFactories...)
 )
 
 type roothashMessagesImpl struct {
@@ -57,14 +64,11 @@ func (sc *roothashMessagesImpl) Fixture() (*oasis.NetworkFixture, error) {
 			MrSigner: mrSigner,
 		},
 		Network: oasis.NetworkCfg{
-			NodeBinary:          viper.GetString(cfgNodeBinary),
-			RuntimeLoaderBinary: viper.GetString(cfgRuntimeLoader),
-			EpochtimeMock:       true,
-			StakingGenesis:      "tests/fixture-data/roothash-messages/staking-genesis.json",
-			LogWatcherHandlerFactories: append([]log.WatcherHandlerFactory{
-				oasis.LogAssertNotEvent(roothash.LogEventMessageUnsat, "unsatisfactory roothash message detected"),
-				oasis.LogAssertEvent(staking.LogEventGeneralAdjustment, "balance adjustment not detected"),
-			}, DefaultBasicLogWatcherHandlerFactories...),
+			NodeBinary:                        viper.GetString(cfgNodeBinary),
+			RuntimeLoaderBinary:               viper.GetString(cfgRuntimeLoader),
+			EpochtimeMock:                     true,
+			StakingGenesis:                    "tests/fixture-data/roothash-messages/staking-genesis.json",
+			DefaultLogWatcherHandlerFactories: DefaultRoothashLogWatcherHandlerFactories,
 		},
 		Entities: []oasis.EntityCfg{
 			oasis.EntityCfg{IsDebugTestEntity: true},

--- a/go/oasis-test-runner/scenario/e2e/sentry.go
+++ b/go/oasis-test-runner/scenario/e2e/sentry.go
@@ -79,8 +79,8 @@ func (s *sentryImpl) Fixture() (*oasis.NetworkFixture, error) {
 		},
 	}
 
-	f.Network.LogWatcherHandlers = append(
-		f.Network.LogWatcherHandlers,
+	f.Network.LogWatcherHandlerFactories = append(
+		f.Network.LogWatcherHandlerFactories,
 		// NOTE: This currently works because logs from all nodes are checked
 		// by the same log watcher handler.
 		// It needs to be properly implemented after:

--- a/go/oasis-test-runner/scenario/e2e/sentry.go
+++ b/go/oasis-test-runner/scenario/e2e/sentry.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"github.com/oasislabs/oasis-core/go/common/logging"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/log"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/oasis"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/scenario"
 )
@@ -9,6 +10,10 @@ import (
 var (
 	// Sentry is the Tendermint Sentry node scenario.
 	Sentry scenario.Scenario = newSentryImpl()
+
+	ValidatorExtraLogWatcherHandlerFactories = []log.WatcherHandlerFactory{
+		oasis.LogAssertPeerExchangeDisabled(),
+	}
 )
 
 type sentryImpl struct {
@@ -66,29 +71,21 @@ func (s *sentryImpl) Fixture() (*oasis.NetworkFixture, error) {
 	}
 	f.Validators = []oasis.ValidatorFixture{
 		oasis.ValidatorFixture{
-			Entity:   1,
-			Sentries: []int{0, 1},
+			Entity:                     1,
+			LogWatcherHandlerFactories: ValidatorExtraLogWatcherHandlerFactories,
+			Sentries:                   []int{0, 1},
 		},
 		oasis.ValidatorFixture{
-			Entity:   1,
-			Sentries: []int{2},
+			Entity:                     1,
+			LogWatcherHandlerFactories: ValidatorExtraLogWatcherHandlerFactories,
+			Sentries:                   []int{2},
 		},
 		oasis.ValidatorFixture{
-			Entity:   1,
-			Sentries: []int{2},
+			Entity:                     1,
+			LogWatcherHandlerFactories: ValidatorExtraLogWatcherHandlerFactories,
+			Sentries:                   []int{2},
 		},
 	}
-
-	f.Network.LogWatcherHandlerFactories = append(
-		f.Network.LogWatcherHandlerFactories,
-		// NOTE: This currently works because logs from all nodes are checked
-		// by the same log watcher handler.
-		// It needs to be properly implemented after:
-		// - https://github.com/oasislabs/oasis-core/issues/2355
-		// - https://github.com/oasislabs/oasis-core/issues/2356
-		// are implemented.
-		oasis.LogAssertPeerExchangeDisabled(),
-	)
 
 	return f, nil
 }


### PR DESCRIPTION
This PR:

- Implements log watcher handler factories which makes it easy for each node to get its own set log watcher handlers.
- Enables specifying different log watcher handler factories for each node.

TODO:
- [x] Fix [End-to-End tests that fail](https://buildkite.com/oasislabs/oasis-core-ci/builds/672) due to this change.
- [x] Implement #2356 to enable fixing some failing End-to-End tests.

Closes #2355.
Closes #2356.