### PR TITLE
ci: put coverage aside

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -271,5 +271,6 @@ steps:
       - .buildkite/scripts/upload_coverage.sh
     artifact_paths:
       - merged-coverage.txt
+    soft_fail: true
     plugins:
       <<: *docker_plugin

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -55,7 +55,9 @@ RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
     GO111MODULE=on go get github.com/golang/protobuf/protoc-gen-go@v${GO_PROTOC_GEN_GO_VERSION} && \
     # Install golangci-lint.
     curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /tmp/bin v${GOLANGCILINT_VERSION} && \
-    mv /tmp/bin/golangci-lint /go/bin
+    mv /tmp/bin/golangci-lint /go/bin && \
+    # Install gocovmerge for e2e coverage.
+    GO111MODULE=on go get github.com/wadey/gocovmerge@b5bfa59ec0adc420475f97f89b58045c721d761c
 
 # Install node / npm / truffle.
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -5,6 +5,7 @@ ARG GO_VERSION=1.13.4
 ARG GO_PROTOC_VERSION=3.6.1
 ARG GO_PROTOC_GEN_GO_VERSION=1.2.0
 ARG GOLANGCILINT_VERSION=1.18.0
+ARG GOCOVMERGE_VERSION=b5bfa59ec0adc420475f97f89b58045c721d761c
 ARG RUST_NIGHTLY_VERSION=2019-08-26
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -57,7 +58,7 @@ RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
     curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /tmp/bin v${GOLANGCILINT_VERSION} && \
     mv /tmp/bin/golangci-lint /go/bin && \
     # Install gocovmerge for e2e coverage.
-    GO111MODULE=on go get github.com/wadey/gocovmerge@b5bfa59ec0adc420475f97f89b58045c721d761c
+    GO111MODULE=on go get github.com/wadey/gocovmerge@${GOCOVMERGE_VERSION}
 
 # Install node / npm / truffle.
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -52,11 +52,7 @@ RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
     rm go${GO_VERSION}.linux-amd64.tar.gz && \
     mkdir -p /go/bin && \
     # Install a specific version of protoc-gen-go.
-    go get -d github.com/golang/protobuf/protoc-gen-go && \
-    cd /go/src/github.com/golang/protobuf && \
-    git checkout v${GO_PROTOC_GEN_GO_VERSION} && \
-    cd protoc-gen-go && \
-    go install && \
+    GO111MODULE=on go get github.com/golang/protobuf/protoc-gen-go@v${GO_PROTOC_GEN_GO_VERSION} && \
     # Install golangci-lint.
     curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /tmp/bin v${GOLANGCILINT_VERSION} && \
     mv /tmp/bin/golangci-lint /go/bin

--- a/docker/testing/Dockerfile
+++ b/docker/testing/Dockerfile
@@ -37,6 +37,3 @@ RUN wget -O codecov https://codecov.io/bash && \
 # Install tarpaulin.
 RUN RUSTFLAGS="--cfg procmacro2_semver_exempt" \
     cargo install --version 0.9.1 cargo-tarpaulin
-
-# Install gocovmerge for e2e coverage.
-RUN GO111MODULE=on go get github.com/wadey/gocovmerge@b5bfa59ec0adc420475f97f89b58045c721d761c

--- a/docker/testing/Dockerfile
+++ b/docker/testing/Dockerfile
@@ -37,3 +37,6 @@ RUN wget -O codecov https://codecov.io/bash && \
 # Install tarpaulin.
 RUN RUSTFLAGS="--cfg procmacro2_semver_exempt" \
     cargo install --version 0.9.1 cargo-tarpaulin
+
+# Install gocovmerge for e2e coverage.
+RUN GO111MODULE=on go get github.com/wadey/gocovmerge@b5bfa59ec0adc420475f97f89b58045c721d761c


### PR DESCRIPTION
don't fail when coverage data is corrupted.

also install gocovmerge in the container