### PR TITLE
go/common/cbor: Bump fxmacker/cbor to 1.2.0

### DIFF
--- a/go/client/grpc.go
+++ b/go/client/grpc.go
@@ -72,7 +72,7 @@ func (s *grpcServer) WatchBlocks(req *pbClient.WatchBlocksRequest, stream pbClie
 
 			blockHash := blk.Block.Header.EncodedHash()
 			pbBlk := &pbClient.WatchBlocksResponse{
-				Block:     blk.Block.MarshalCBOR(),
+				Block:     cbor.Marshal(blk.Block),
 				BlockHash: blockHash[:],
 			}
 			if err := stream.Send(pbBlk); err != nil {
@@ -99,7 +99,7 @@ func (s *grpcServer) GetBlock(ctx context.Context, req *pbClient.GetBlockRequest
 	}
 	blockHash := blk.Header.EncodedHash()
 	return &pbClient.GetBlockResponse{
-		Block:     blk.MarshalCBOR(),
+		Block:     cbor.Marshal(blk),
 		BlockHash: blockHash[:],
 	}, nil
 }
@@ -119,7 +119,7 @@ func (s *grpcServer) GetTxn(ctx context.Context, req *pbClient.GetTxnRequest) (*
 	}
 
 	return &pbClient.GetTxnResponse{
-		Result: tx.MarshalCBOR(),
+		Result: cbor.Marshal(tx),
 	}, nil
 }
 
@@ -143,7 +143,7 @@ func (s *grpcServer) GetTxnByBlockHash(ctx context.Context, req *pbClient.GetTxn
 	}
 
 	return &pbClient.GetTxnByBlockHashResponse{
-		Result: tx.MarshalCBOR(),
+		Result: cbor.Marshal(tx),
 	}, nil
 }
 
@@ -186,7 +186,7 @@ func (s *grpcServer) QueryBlock(ctx context.Context, req *pbClient.QueryBlockReq
 		return nil, err
 	}
 	return &pbClient.QueryBlockResponse{
-		Block: blk.MarshalCBOR(),
+		Block: cbor.Marshal(blk),
 	}, nil
 }
 
@@ -205,7 +205,7 @@ func (s *grpcServer) QueryTxn(ctx context.Context, req *pbClient.QueryTxnRequest
 	}
 
 	return &pbClient.QueryTxnResponse{
-		Result: tx.MarshalCBOR(),
+		Result: cbor.Marshal(tx),
 	}, nil
 }
 
@@ -216,7 +216,7 @@ func (s *grpcServer) QueryTxns(ctx context.Context, req *pbClient.QueryTxnsReque
 	}
 
 	var query Query
-	if err := query.UnmarshalCBOR(req.GetQuery()); err != nil {
+	if err := cbor.Unmarshal(req.GetQuery(), &query); err != nil {
 		return nil, err
 	}
 

--- a/go/client/indexer/backend.go
+++ b/go/client/indexer/backend.go
@@ -4,16 +4,10 @@ import (
 	"context"
 	"errors"
 
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
 	"github.com/oasislabs/oasis-core/go/runtime/transaction"
-)
-
-var (
-	_ cbor.Marshaler   = (*Query)(nil)
-	_ cbor.Unmarshaler = (*Query)(nil)
 )
 
 const (
@@ -50,16 +44,6 @@ type Query struct {
 	//
 	// A zero value means that the `maxQueryLimit` limit is used.
 	Limit uint64 `json:"limit"`
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (q *Query) MarshalCBOR() []byte {
-	return cbor.Marshal(q)
-}
-
-// UnmarshalCBOR decodes a CBOR marshaled query.
-func (q *Query) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, q)
 }
 
 // Result is a query result.

--- a/go/client/types.go
+++ b/go/client/types.go
@@ -4,14 +4,8 @@ import (
 	"math"
 
 	"github.com/oasislabs/oasis-core/go/client/indexer"
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
-)
-
-var (
-	_ cbor.Marshaler   = (*TxnResult)(nil)
-	_ cbor.Unmarshaler = (*TxnResult)(nil)
 )
 
 const (
@@ -35,14 +29,4 @@ type TxnResult struct {
 	Index     uint32       `json:"index"`
 	Input     []byte       `json:"input"`
 	Output    []byte       `json:"output"`
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (r *TxnResult) MarshalCBOR() []byte {
-	return cbor.Marshal(r)
-}
-
-// UnmarshalCBOR decodes a CBOR marshaled query result.
-func (r *TxnResult) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, r)
 }

--- a/go/common/cbor/cbor.go
+++ b/go/common/cbor/cbor.go
@@ -16,18 +16,6 @@ func FixSliceForSerde(b []byte) []byte {
 	return []byte{}
 }
 
-// Marshaler allows a type to be serialized into CBOR.
-type Marshaler interface {
-	// MarshalCBOR serializes the type into a CBOR byte vector.
-	MarshalCBOR() []byte
-}
-
-// Unmarshaler allows a type to be deserialized from CBOR.
-type Unmarshaler interface {
-	// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-	UnmarshalCBOR([]byte) error
-}
-
 // Marshal serializes a given type into a CBOR byte vector.
 func Marshal(src interface{}) []byte {
 	b, err := cbor.Marshal(src, cbor.EncOptions{

--- a/go/common/entity/entity.go
+++ b/go/common/entity/entity.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/memory"
 	pbCommon "github.com/oasislabs/oasis-core/go/grpc/common"
@@ -24,9 +23,6 @@ const (
 var (
 	// ErrNilProtobuf is the error returned when a protobuf is nil.
 	ErrNilProtobuf = errors.New("entity: Protobuf is nil")
-
-	_ cbor.Marshaler   = (*Entity)(nil)
-	_ cbor.Unmarshaler = (*Entity)(nil)
 
 	testEntity       Entity
 	testEntitySigner signature.Signer
@@ -97,21 +93,6 @@ func (e *Entity) ToProto() *pbCommon.Entity {
 	pb.Nodes = pbNodes
 
 	return pb
-}
-
-// ToSignable serializes the Entity into a signature compatible byte vector.
-func (e *Entity) ToSignable() []byte {
-	return e.MarshalCBOR()
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (e *Entity) MarshalCBOR() []byte {
-	return cbor.Marshal(e)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (e *Entity) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, e)
 }
 
 // Save saves the JSON serialized entity descriptor.

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -30,9 +30,6 @@ var (
 	ErrNilProtobuf = errors.New("node: Protobuf is nil")
 
 	teeHashContext = []byte("oasis-core/node: TEE RAK binding")
-
-	_ cbor.Marshaler   = (*Node)(nil)
-	_ cbor.Unmarshaler = (*Node)(nil)
 )
 
 // Node represents public connectivity information about an Oasis node.
@@ -456,7 +453,7 @@ func (c *CapabilityTEE) Verify(ts time.Time) error {
 	switch c.Hardware {
 	case TEEHardwareIntelSGX:
 		var avrBundle ias.AVRBundle
-		if err := avrBundle.UnmarshalCBOR(c.Attestation); err != nil {
+		if err := cbor.Unmarshal(c.Attestation, &avrBundle); err != nil {
 			return err
 		}
 
@@ -560,21 +557,6 @@ func (n *Node) ToProto() *pbCommon.Node {
 	pb.Roles = uint32(n.Roles)
 
 	return pb
-}
-
-// ToSignable serialized the Node into a signature compatible byte vector.
-func (n *Node) ToSignable() []byte {
-	return n.MarshalCBOR()
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (n *Node) MarshalCBOR() []byte {
-	return cbor.Marshal(n)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (n *Node) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, n)
 }
 
 // SignedNode is a signed blob containing a CBOR-serialized Node.

--- a/go/common/sgx/ias/avr.go
+++ b/go/common/sgx/ias/avr.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/sgx"
 )
 
@@ -72,9 +71,6 @@ var (
 	// test signing key that is used by default if no other signing key is
 	// specified.
 	FortanixTestMrSigner sgx.MrSigner
-
-	_ cbor.Marshaler   = (*AVRBundle)(nil)
-	_ cbor.Unmarshaler = (*AVRBundle)(nil)
 )
 
 // ISVEnclaveQuoteStatus is the status of an enclave quote.
@@ -189,16 +185,6 @@ type AVRBundle struct {
 	Body             []byte `json:"body"`
 	CertificateChain []byte `json:"certificate_chain"`
 	Signature        []byte `json:"signature"`
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (b *AVRBundle) MarshalCBOR() []byte {
-	return cbor.Marshal(b)
-}
-
-// UnmarshalCBOR deserializes a CBOR Byte vector into a given type.
-func (b *AVRBundle) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, b)
 }
 
 // Open decodes and validates the AVR contained in the bundle, and returns

--- a/go/common/sgx/ias/grpc.go
+++ b/go/common/sgx/ias/grpc.go
@@ -5,7 +5,6 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	pb "github.com/oasislabs/oasis-core/go/grpc/ias"
@@ -13,11 +12,6 @@ import (
 
 var (
 	_ pb.IASServer = (*grpcServer)(nil)
-
-	_ cbor.Marshaler   = (*Evidence)(nil)
-	_ cbor.Unmarshaler = (*Evidence)(nil)
-	_ cbor.Marshaler   = (*SignedEvidence)(nil)
-	_ cbor.Unmarshaler = (*SignedEvidence)(nil)
 
 	// EvidenceSignatureContext is the signature context used for verifying evidence.
 	EvidenceSignatureContext = signature.NewContext("oasis-core/sgx: ias evidence")
@@ -49,16 +43,6 @@ func (s *SignedEvidence) Open(context signature.Context, evidence *Evidence) err
 	return s.Signed.Open(context, evidence)
 }
 
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (s *SignedEvidence) MarshalCBOR() []byte {
-	return s.Signed.MarshalCBOR()
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (s *SignedEvidence) UnmarshalCBOR(data []byte) error {
-	return s.Signed.UnmarshalCBOR(data)
-}
-
 // Evidence is attestation evidence.
 type Evidence struct {
 	// ID is obviously the runtime ID of the enclave that's being attested.
@@ -66,16 +50,6 @@ type Evidence struct {
 	Quote       []byte              `json:"quote"`
 	PSEManifest []byte              `json:"pse_manifest"`
 	Nonce       string              `json:"nonce"`
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (e Evidence) MarshalCBOR() []byte {
-	return cbor.Marshal(e)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (e *Evidence) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, e)
 }
 
 type grpcServer struct {

--- a/go/consensus/tendermint/apps/registry/registry.go
+++ b/go/consensus/tendermint/apps/registry/registry.go
@@ -298,7 +298,7 @@ func (app *registryApplication) registerNode(
 ) error {
 	// Peek into the to-be-verified node to pull out the owning entity ID.
 	var untrustedNode node.Node
-	if err := untrustedNode.UnmarshalCBOR(sigNode.Blob); err != nil {
+	if err := cbor.Unmarshal(sigNode.Blob, &untrustedNode); err != nil {
 		app.logger.Error("RegisterNode: failed to extract entity",
 			"err", err,
 			"signed_node", sigNode,

--- a/go/consensus/tendermint/apps/registry/state/state.go
+++ b/go/consensus/tendermint/apps/registry/state/state.go
@@ -407,7 +407,7 @@ type MutableState struct {
 }
 
 func (s *MutableState) CreateEntity(ent *entity.Entity, sigEnt *entity.SignedEntity) {
-	s.tree.Set(signedEntityKeyFmt.Encode(&ent.ID), sigEnt.MarshalCBOR())
+	s.tree.Set(signedEntityKeyFmt.Encode(&ent.ID), cbor.Marshal(sigEnt))
 }
 
 func (s *MutableState) RemoveEntity(id signature.PublicKey) (*entity.Entity, error) {
@@ -431,7 +431,7 @@ func (s *MutableState) CreateNode(node *node.Node, signedNode *node.SignedNode) 
 		return registry.ErrNoSuchEntity
 	}
 
-	s.tree.Set(signedNodeKeyFmt.Encode(&node.ID), signedNode.MarshalCBOR())
+	s.tree.Set(signedNodeKeyFmt.Encode(&node.ID), cbor.Marshal(signedNode))
 	s.tree.Set(signedNodeByEntityKeyFmt.Encode(&node.EntityID, &node.ID), []byte(""))
 
 	address := []byte(tmcrypto.PublicKeyToTendermint(&node.Consensus.ID).Address())
@@ -459,7 +459,7 @@ func (s *MutableState) CreateRuntime(rt *registry.Runtime, sigRt *registry.Signe
 		return registry.ErrNoSuchEntity
 	}
 
-	s.tree.Set(signedRuntimeKeyFmt.Encode(&rt.ID), sigRt.MarshalCBOR())
+	s.tree.Set(signedRuntimeKeyFmt.Encode(&rt.ID), cbor.Marshal(sigRt))
 
 	return nil
 }

--- a/go/consensus/tendermint/apps/roothash/api.go
+++ b/go/consensus/tendermint/apps/roothash/api.go
@@ -1,7 +1,6 @@
 package roothash
 
 import (
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
@@ -62,16 +61,6 @@ type ValueFinalized struct {
 	Round uint64              `json:"round"`
 }
 
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (v *ValueFinalized) MarshalCBOR() []byte {
-	return cbor.Marshal(v)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into the given type.
-func (v *ValueFinalized) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, v)
-}
-
 // ValueMergeDiscrepancyDetected is the value component of a
 // TagMergeDiscrepancyDetected.
 type ValueMergeDiscrepancyDetected struct {
@@ -79,29 +68,9 @@ type ValueMergeDiscrepancyDetected struct {
 	ID    signature.PublicKey                    `json:"id"`
 }
 
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (v *ValueMergeDiscrepancyDetected) MarshalCBOR() []byte {
-	return cbor.Marshal(v)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into the given type.
-func (v *ValueMergeDiscrepancyDetected) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, v)
-}
-
 // ValueComputeDiscrepancyDetected is the value component of a
 // TagMergeDiscrepancyDetected.
 type ValueComputeDiscrepancyDetected struct {
 	ID    signature.PublicKey                      `json:"id"`
 	Event roothash.ComputeDiscrepancyDetectedEvent `json:"event"`
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (v *ValueComputeDiscrepancyDetected) MarshalCBOR() []byte {
-	return cbor.Marshal(v)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into the given type.
-func (v *ValueComputeDiscrepancyDetected) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, v)
 }

--- a/go/consensus/tendermint/apps/roothash/state/round.go
+++ b/go/consensus/tendermint/apps/roothash/state/round.go
@@ -4,15 +4,9 @@ import (
 	"errors"
 	"time"
 
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
 	"github.com/oasislabs/oasis-core/go/roothash/api/commitment"
-)
-
-var (
-	_ cbor.Marshaler   = (*Round)(nil)
-	_ cbor.Unmarshaler = (*Round)(nil)
 )
 
 // Round is a roothash round.
@@ -56,16 +50,6 @@ func (r *Round) AddMergeCommitment(commitment *commitment.MergeCommitment, sv co
 func (r *Round) Transition(blk *block.Block) {
 	r.CurrentBlock = blk
 	r.Reset()
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (r *Round) MarshalCBOR() []byte {
-	return cbor.Marshal(r)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (r *Round) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, r)
 }
 
 func NewRound(

--- a/go/consensus/tendermint/apps/roothash/state/state.go
+++ b/go/consensus/tendermint/apps/roothash/state/state.go
@@ -16,9 +16,6 @@ var (
 	//
 	// Value is CBOR-serialized runtime state.
 	runtimeKeyFmt = keyformat.New(0x20, &signature.PublicKey{})
-
-	_ cbor.Marshaler   = (*RuntimeState)(nil)
-	_ cbor.Unmarshaler = (*RuntimeState)(nil)
 )
 
 type RuntimeState struct {
@@ -27,14 +24,6 @@ type RuntimeState struct {
 	GenesisBlock *block.Block      `json:"genesis_block"`
 	Round        *Round            `json:"round"`
 	Timer        abci.Timer        `json:"timer"`
-}
-
-func (s *RuntimeState) MarshalCBOR() []byte {
-	return cbor.Marshal(s)
-}
-
-func (s *RuntimeState) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, s)
 }
 
 type ImmutableState struct {
@@ -57,7 +46,7 @@ func (s *ImmutableState) RuntimeState(id signature.PublicKey) (*RuntimeState, er
 	}
 
 	var state RuntimeState
-	err := state.UnmarshalCBOR(raw)
+	err := cbor.Unmarshal(raw, &state)
 	return &state, err
 }
 
@@ -99,5 +88,5 @@ func NewMutableState(tree *iavl.MutableTree) *MutableState {
 }
 
 func (s *MutableState) SetRuntimeState(state *RuntimeState) {
-	s.tree.Set(runtimeKeyFmt.Encode(&state.Runtime.ID), state.MarshalCBOR())
+	s.tree.Set(runtimeKeyFmt.Encode(&state.Runtime.ID), cbor.Marshal(state))
 }

--- a/go/consensus/tendermint/roothash/roothash.go
+++ b/go/consensus/tendermint/roothash/roothash.go
@@ -15,6 +15,7 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	beacon "github.com/oasislabs/oasis-core/go/beacon/api"
+	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/logging"
@@ -160,7 +161,7 @@ func (tb *tendermintBackend) WatchBlocks(id signature.PublicKey) (<-chan *api.An
 
 func (tb *tendermintBackend) getBlockFromFinalizedTag(ctx context.Context, rawValue []byte, height int64) (*block.Block, *app.ValueFinalized, error) {
 	var value app.ValueFinalized
-	if err := value.UnmarshalCBOR(rawValue); err != nil {
+	if err := cbor.Unmarshal(rawValue, &value); err != nil {
 		return nil, nil, errors.Wrap(err, "roothash: corrupt finalized tag")
 	}
 
@@ -488,7 +489,7 @@ func (tb *tendermintBackend) worker(ctx context.Context) { // nolint: gocyclo
 					})
 				} else if bytes.Equal(pair.GetKey(), app.KeyMergeDiscrepancyDetected) {
 					var value app.ValueMergeDiscrepancyDetected
-					if err := value.UnmarshalCBOR(pair.GetValue()); err != nil {
+					if err := cbor.Unmarshal(pair.GetValue(), &value); err != nil {
 						tb.logger.Error("worker: failed to get discrepancy from tag",
 							"err", err,
 						)
@@ -499,7 +500,7 @@ func (tb *tendermintBackend) worker(ctx context.Context) { // nolint: gocyclo
 					notifiers.eventNotifier.Broadcast(&api.Event{MergeDiscrepancyDetected: &value.Event})
 				} else if bytes.Equal(pair.GetKey(), app.KeyComputeDiscrepancyDetected) {
 					var value app.ValueComputeDiscrepancyDetected
-					if err := value.UnmarshalCBOR(pair.GetValue()); err != nil {
+					if err := cbor.Unmarshal(pair.GetValue(), &value); err != nil {
 						tb.logger.Error("worker: failed to get discrepancy from tag",
 							"err", err,
 						)

--- a/go/genesis/api/api.go
+++ b/go/genesis/api/api.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	beacon "github.com/oasislabs/oasis-core/go/beacon/api"
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	consensus "github.com/oasislabs/oasis-core/go/consensus/genesis"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	keymanager "github.com/oasislabs/oasis-core/go/keymanager/api"
@@ -17,11 +16,6 @@ import (
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
 	scheduler "github.com/oasislabs/oasis-core/go/scheduler/api"
 	staking "github.com/oasislabs/oasis-core/go/staking/api"
-)
-
-var (
-	_ cbor.Marshaler   = (*Document)(nil)
-	_ cbor.Unmarshaler = (*Document)(nil)
 )
 
 const filePerm = 0600
@@ -56,16 +50,6 @@ type Document struct {
 	// Extra data is arbitrary extra data that is part of the
 	// genesis block but is otherwise ignored by the protocol.
 	ExtraData map[string][]byte `json:"extra_data"`
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (d *Document) MarshalCBOR() []byte {
-	return cbor.Marshal(d)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (d *Document) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, d)
 }
 
 // WriteFileJSON writes the genesis document into a JSON file.

--- a/go/go.mod
+++ b/go/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 // indirect
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 // indirect
-	github.com/fxamacker/cbor v1.1.2
+	github.com/fxamacker/cbor v1.2.0
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect
 	github.com/go-kit/kit v0.9.0
 	github.com/golang/protobuf v1.3.2

--- a/go/go.sum
+++ b/go/go.sum
@@ -101,6 +101,8 @@ github.com/fxamacker/cbor v1.0.1-0.20191004235024-602ddc7eedd4 h1:UnFYtg+xBGcErA
 github.com/fxamacker/cbor v1.0.1-0.20191004235024-602ddc7eedd4/go.mod h1:Uy2lR31/2WfmW0yiA4i3t+we5kF3B/wzKsttcux+i/g=
 github.com/fxamacker/cbor v1.1.2 h1:UkCp92XlT4NCRfnyWSocC6XVRt/7ACKve6s1OP0TXSc=
 github.com/fxamacker/cbor v1.1.2/go.mod h1:Uy2lR31/2WfmW0yiA4i3t+we5kF3B/wzKsttcux+i/g=
+github.com/fxamacker/cbor v1.2.0 h1:O93CQxS1CEy48FDyuaO0c1LN0X6/8SXrpcOI2axAGNw=
+github.com/fxamacker/cbor v1.2.0/go.mod h1:Uy2lR31/2WfmW0yiA4i3t+we5kF3B/wzKsttcux+i/g=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/glycerine/go-unsnap-stream v0.0.0-20181221182339-f9677308dec2 h1:Ujru1hufTHVb++eG6OuNDKMxZnGIvF6o/u8q/8h2+I4=
 github.com/glycerine/go-unsnap-stream v0.0.0-20181221182339-f9677308dec2/go.mod h1:/20jfyN9Y5QPEAprSgKAUr+glWDY39ZiUEAYOEv5dsE=

--- a/go/oasis-node/cmd/debug/byzantine/compute.go
+++ b/go/oasis-node/cmd/debug/byzantine/compute.go
@@ -173,7 +173,7 @@ func (cbc *computeBatchContext) createCommitment(id *identity.Identity, rak sign
 		InputStorageSigs:  cbc.bd.StorageSignatures,
 	}
 	if rak != nil {
-		rakSig, err := signature.Sign(rak, commitment.ComputeResultsHeaderSignatureContext, header.MarshalCBOR())
+		rakSig, err := signature.Sign(rak, commitment.ComputeResultsHeaderSignatureContext, cbor.Marshal(header))
 		if err != nil {
 			return errors.Wrapf(err, "signature Sign RAK")
 		}

--- a/go/oasis-node/cmd/debug/roothash/roothash.go
+++ b/go/oasis-node/cmd/debug/roothash/roothash.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	clientGrpc "github.com/oasislabs/oasis-core/go/grpc/client"
@@ -115,7 +116,7 @@ func doExport(cmd *cobra.Command, args []string) {
 
 		// Update block header so the block will be suitable as the genesis block.
 		var latestBlock block.Block
-		err = latestBlock.UnmarshalCBOR(res.Block)
+		err = cbor.Unmarshal(res.Block, &latestBlock)
 		if err != nil {
 			logger.Error("failed to parse block",
 				"err", err,

--- a/go/oasis-node/cmd/debug/storage/storage.go
+++ b/go/oasis-node/cmd/debug/storage/storage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	clientGrpc "github.com/oasislabs/oasis-core/go/grpc/client"
@@ -156,7 +157,7 @@ func doCheckRoots(cmd *cobra.Command, args []string) {
 	}
 
 	var latestBlock block.Block
-	if err = latestBlock.UnmarshalCBOR(res.Block); err != nil {
+	if err = cbor.Unmarshal(res.Block, &latestBlock); err != nil {
 		logger.Error("failed to parse block",
 			"err", err,
 			"runtime_id", id,
@@ -215,7 +216,7 @@ func doCheckRoots(cmd *cobra.Command, args []string) {
 		}
 
 		var blk block.Block
-		if err = blk.UnmarshalCBOR(res.Block); err != nil {
+		if err = cbor.Unmarshal(res.Block, &blk); err != nil {
 			logger.Error("failed to parse block",
 				"err", err,
 				"runtime_id", id,

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -230,16 +230,6 @@ type NodeList struct {
 // Timestamp is a UNIX timestamp.
 type Timestamp uint64
 
-// MarshalCBOR serializes the Timestamp type into a CBOR byte vector.
-func (t *Timestamp) MarshalCBOR() []byte {
-	return cbor.Marshal(t)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into a Timestamp.
-func (t *Timestamp) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, t)
-}
-
 // VerifyRegisterEntityArgs verifies arguments for RegisterEntity.
 func VerifyRegisterEntityArgs(logger *logging.Logger, sigEnt *entity.SignedEntity, isGenesis bool) (*entity.Entity, error) {
 	var ent entity.Entity
@@ -531,7 +521,7 @@ func VerifyNodeRuntimeEnclaveIDs(logger *logging.Logger, rt *node.Runtime, regRu
 		// Check MRENCLAVE/MRSIGNER.
 		var eidValid bool
 		var avrBundle ias.AVRBundle
-		if err := avrBundle.UnmarshalCBOR(rt.Capabilities.TEE.Attestation); err != nil {
+		if err := cbor.Unmarshal(rt.Capabilities.TEE.Attestation, &avrBundle); err != nil {
 			return err
 		}
 

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/node"
@@ -25,9 +24,6 @@ var (
 
 	// ErrNilProtobuf is the error returned when a protobuf is nil.
 	ErrNilProtobuf = errors.New("node: Protobuf is nil")
-
-	_ cbor.Marshaler   = (*Runtime)(nil)
-	_ cbor.Unmarshaler = (*Runtime)(nil)
 )
 
 // RuntimeKind represents the runtime funtionality.
@@ -251,21 +247,6 @@ func (c *Runtime) ToProto() *pbRegistry.Runtime {
 	pb.Kind = uint32(c.Kind)
 
 	return pb
-}
-
-// ToSignable serializes the Runtime into a signature compatible byte vector.
-func (c *Runtime) ToSignable() []byte {
-	return c.MarshalCBOR()
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (c *Runtime) MarshalCBOR() []byte {
-	return cbor.Marshal(c)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (c *Runtime) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, c)
 }
 
 // SignedRuntime is a signed blob containing a CBOR-serialized Runtime.

--- a/go/registry/api/status.go
+++ b/go/registry/api/status.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 )
@@ -40,16 +39,6 @@ func (ns *NodeStatus) Unfreeze() {
 type UnfreezeNode struct {
 	NodeID    signature.PublicKey `json:"node_id"`
 	Timestamp uint64              `json:"timestamp"`
-}
-
-// MarshalCBOR serializes the UnfreezeNode type into a CBOR byte vector.
-func (u *UnfreezeNode) MarshalCBOR() []byte {
-	return cbor.Marshal(u)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into a UnfreezeNode.
-func (u *UnfreezeNode) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, u)
 }
 
 // SignedUnfreezeNode is a signed UnfreezeNode.

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
@@ -42,11 +41,6 @@ var (
 
 	// ErrNotFound is the error returned when a block is not found.
 	ErrNotFound = errors.New("roothash: block not found")
-
-	_ cbor.Marshaler   = (*ComputeDiscrepancyDetectedEvent)(nil)
-	_ cbor.Unmarshaler = (*ComputeDiscrepancyDetectedEvent)(nil)
-	_ cbor.Marshaler   = (*MergeDiscrepancyDetectedEvent)(nil)
-	_ cbor.Unmarshaler = (*MergeDiscrepancyDetectedEvent)(nil)
 )
 
 // Backend is a root hash implementation.
@@ -110,28 +104,8 @@ type ComputeDiscrepancyDetectedEvent struct {
 	Timeout bool `json:"timeout"`
 }
 
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (e *ComputeDiscrepancyDetectedEvent) MarshalCBOR() []byte {
-	return cbor.Marshal(e)
-}
-
-// UnmarshalCBOR decodes a CBOR marshaled event.
-func (e *ComputeDiscrepancyDetectedEvent) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, e)
-}
-
 // MergeDiscrepancyDetectedEvent is a merge discrepancy detected event.
 type MergeDiscrepancyDetectedEvent struct {
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (e *MergeDiscrepancyDetectedEvent) MarshalCBOR() []byte {
-	return cbor.Marshal(e)
-}
-
-// UnmarshalCBOR decodes a CBOR marshaled event.
-func (e *MergeDiscrepancyDetectedEvent) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, e)
 }
 
 // Event is a protocol event.

--- a/go/roothash/api/block/block.go
+++ b/go/roothash/api/block/block.go
@@ -1,15 +1,7 @@
 // Package block implements the roothash block and header.
 package block
 
-import (
-	"github.com/oasislabs/oasis-core/go/common/cbor"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
-)
-
-var (
-	_ cbor.Marshaler   = (*Block)(nil)
-	_ cbor.Unmarshaler = (*Block)(nil)
-)
+import "github.com/oasislabs/oasis-core/go/common/crypto/signature"
 
 // Block is an Oasis block.
 //
@@ -17,16 +9,6 @@ var (
 type Block struct {
 	// Header is the block header.
 	Header Header `json:"header"`
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (b *Block) MarshalCBOR() []byte {
-	return cbor.Marshal(b)
-}
-
-// UnmarshalCBOR decodes a CBOR marshaled block.
-func (b *Block) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, b)
 }
 
 // NewGenesisBlock creates a new empty genesis block given a runtime

--- a/go/roothash/api/block/header.go
+++ b/go/roothash/api/block/header.go
@@ -11,13 +11,8 @@ import (
 	storage "github.com/oasislabs/oasis-core/go/storage/api"
 )
 
-var (
-	// ErrInvalidVersion is the error returned when a version is invalid.
-	ErrInvalidVersion = errors.New("roothash: invalid version")
-
-	_ cbor.Marshaler   = (*Header)(nil)
-	_ cbor.Unmarshaler = (*Header)(nil)
-)
+// ErrInvalidVersion is the error returned when a version is invalid.
+var ErrInvalidVersion = errors.New("roothash: invalid version")
 
 // HeaderType is the type of header.
 type HeaderType uint8
@@ -91,16 +86,6 @@ func (h *Header) MostlyEqual(cmp *Header) bool {
 	return aHash.Equal(&bHash)
 }
 
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (h *Header) MarshalCBOR() []byte {
-	return cbor.Marshal(h)
-}
-
-// UnmarshalCBOR decodes a CBOR marshaled header.
-func (h *Header) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, h)
-}
-
 // EncodedHash returns the encoded cryptographic hash of the header.
 func (h *Header) EncodedHash() hash.Hash {
 	var hh hash.Hash
@@ -132,7 +117,7 @@ func (h *Header) VerifyStorageReceiptSignatures() error {
 		Roots:     h.RootsForStorageReceipt(),
 	}
 
-	if !signature.VerifyManyToOne(storage.ReceiptSignatureContext, receiptBody.MarshalCBOR(), h.StorageSignatures) {
+	if !signature.VerifyManyToOne(storage.ReceiptSignatureContext, cbor.Marshal(receiptBody), h.StorageSignatures) {
 		return signature.ErrVerifyFailed
 	}
 

--- a/go/roothash/api/commitment/compute.go
+++ b/go/roothash/api/commitment/compute.go
@@ -53,16 +53,6 @@ func (h *ComputeResultsHeader) EncodedHash() hash.Hash {
 	return hh
 }
 
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (h *ComputeResultsHeader) MarshalCBOR() []byte {
-	return cbor.Marshal(h)
-}
-
-// UnmarshalCBOR decodes a CBOR marshaled compute results header.
-func (h *ComputeResultsHeader) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, h)
-}
-
 // ComputeBody holds the data signed in a compute worker commitment.
 type ComputeBody struct {
 	CommitteeID       hash.Hash              `json:"cid"`
@@ -86,7 +76,7 @@ func (m *ComputeBody) VerifyTxnSchedSignature(header block.Header) bool {
 		Header:            header,
 	}
 
-	return m.TxnSchedSig.Verify(TxnSchedulerBatchDispatchSigCtx, dispatch.MarshalCBOR())
+	return m.TxnSchedSig.Verify(TxnSchedulerBatchDispatchSigCtx, cbor.Marshal(dispatch))
 }
 
 // RootsForStorageReceipt gets the merkle roots that must be part of
@@ -111,7 +101,7 @@ func (m *ComputeBody) VerifyStorageReceiptSignatures(ns common.Namespace, round 
 		Roots:     m.RootsForStorageReceipt(),
 	}
 
-	if !signature.VerifyManyToOne(storage.ReceiptSignatureContext, receiptBody.MarshalCBOR(), m.StorageSignatures) {
+	if !signature.VerifyManyToOne(storage.ReceiptSignatureContext, cbor.Marshal(receiptBody), m.StorageSignatures) {
 		return signature.ErrVerifyFailed
 	}
 
@@ -141,16 +131,6 @@ func (m *ComputeBody) VerifyStorageReceipt(ns common.Namespace, round uint64, re
 	}
 
 	return nil
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (m *ComputeBody) MarshalCBOR() []byte {
-	return cbor.Marshal(m)
-}
-
-// UnmarshalCBOR decodes a CBOR marshaled message.
-func (m *ComputeBody) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, m)
 }
 
 // ComputeCommitment is a roothash commitment from a compute worker.

--- a/go/roothash/api/commitment/merge.go
+++ b/go/roothash/api/commitment/merge.go
@@ -4,7 +4,6 @@ package commitment
 import (
 	"errors"
 
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
@@ -17,16 +16,6 @@ var MergeSignatureContext = signature.NewContext("oasis-core/roothash: merge com
 type MergeBody struct {
 	ComputeCommits []ComputeCommitment `json:"commits"`
 	Header         block.Header        `json:"header"`
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (m *MergeBody) MarshalCBOR() []byte {
-	return cbor.Marshal(m)
-}
-
-// UnmarshalCBOR decodes a CBOR marshaled message.
-func (m *MergeBody) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, m)
 }
 
 // MergeCommitment is a roothash commitment from a merge worker.

--- a/go/roothash/api/commitment/pool.go
+++ b/go/roothash/api/commitment/pool.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/logging"
@@ -147,7 +148,7 @@ func (p *Pool) addOpenComputeCommitment(blk *block.Block, sv SignatureVerifier, 
 	// Verify RAK-attestation.
 	if p.Runtime.TEEHardware != node.TEEHardwareInvalid {
 		rak := p.NodeInfo[id].Runtime.Capabilities.TEE.RAK
-		if !rak.Verify(ComputeResultsHeaderSignatureContext, header.MarshalCBOR(), body.RakSig[:]) {
+		if !rak.Verify(ComputeResultsHeaderSignatureContext, cbor.Marshal(header), body.RakSig[:]) {
 			return ErrRakSigInvalid
 		}
 	}
@@ -636,7 +637,7 @@ func (m *MultiPool) addComputeCommitments(blk *block.Block, sv SignatureVerifier
 	var hadError bool
 	for _, v := range commitments {
 		var body ComputeBody
-		if err := body.UnmarshalCBOR(v.Blob); err != nil {
+		if err := cbor.Unmarshal(v.Blob, &body); err != nil {
 			hadError = true
 			continue
 		}

--- a/go/roothash/api/commitment/pool_test.go
+++ b/go/roothash/api/commitment/pool_test.go
@@ -250,7 +250,7 @@ func TestPoolSingleCommitmentTEE(t *testing.T) {
 
 	// Generate a commitment.
 	childBlk, parentBlk, body := generateComputeBody(t, committee)
-	rakSig, err := signature.Sign(skRAK, ComputeResultsHeaderSignatureContext, body.Header.MarshalCBOR())
+	rakSig, err := signature.Sign(skRAK, ComputeResultsHeaderSignatureContext, cbor.Marshal(body.Header))
 	require.NoError(t, err, "Sign")
 	body.RakSig = rakSig.Signature
 

--- a/go/roothash/api/commitment/txnscheduler.go
+++ b/go/roothash/api/commitment/txnscheduler.go
@@ -1,7 +1,6 @@
 package commitment
 
 import (
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
@@ -29,16 +28,6 @@ type TxnSchedulerBatchDispatch struct {
 
 	// Header is the block header on which the batch should be based.
 	Header block.Header `json:"header"`
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (t *TxnSchedulerBatchDispatch) MarshalCBOR() []byte {
-	return cbor.Marshal(t)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (t *TxnSchedulerBatchDispatch) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, t)
 }
 
 // SignedTxnSchedulerBatchDispatch is a TxnSchedulerBatchDispatch, signed by

--- a/go/runtime/transaction/batch.go
+++ b/go/runtime/transaction/batch.go
@@ -1,26 +1,9 @@
 package transaction
 
-import "github.com/oasislabs/oasis-core/go/common/cbor"
-
-var (
-	_ cbor.Marshaler   = (*RawBatch)(nil)
-	_ cbor.Unmarshaler = (*RawBatch)(nil)
-)
-
 // RawBatch is a list of opaque bytes.
 type RawBatch [][]byte
 
 // String returns a string representation of a batch.
 func (b RawBatch) String() string {
 	return "<RawBatch>"
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (b RawBatch) MarshalCBOR() []byte {
-	return cbor.Marshal(b)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (b *RawBatch) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, b)
 }

--- a/go/runtime/transaction/rwset.go
+++ b/go/runtime/transaction/rwset.go
@@ -6,11 +6,6 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 )
 
-var (
-	_ cbor.Marshaler   = (*ReadWriteSet)(nil)
-	_ cbor.Unmarshaler = (*ReadWriteSet)(nil)
-)
-
 // CoarsenedKey is a coarsened key prefix that represents any key that
 // starts with this prefix.
 type CoarsenedKey []byte
@@ -42,16 +37,6 @@ type ReadWriteSet struct {
 	WriteSet CoarsenedSet `json:"write_set"`
 }
 
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (rw *ReadWriteSet) MarshalCBOR() []byte {
-	return cbor.Marshal(rw)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (rw *ReadWriteSet) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, rw)
-}
-
 // Equal checks whether the read/write set is equal to another.
 func (rw ReadWriteSet) Equal(other *ReadWriteSet) bool {
 	return rw.Granularity == other.Granularity && rw.ReadSet.Equal(other.ReadSet) && rw.WriteSet.Equal(other.WriteSet)
@@ -59,5 +44,5 @@ func (rw ReadWriteSet) Equal(other *ReadWriteSet) bool {
 
 // Size returns the size (in bytes) of the read/write set.
 func (rw ReadWriteSet) Size() uint64 {
-	return uint64(len(rw.MarshalCBOR()))
+	return uint64(len(cbor.Marshal(rw)))
 }

--- a/go/runtime/transaction/rwset_test.go
+++ b/go/runtime/transaction/rwset_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/oasislabs/oasis-core/go/common/cbor"
 )
 
 func TestReadWriteSetSerialization(t *testing.T) {
@@ -13,10 +15,10 @@ func TestReadWriteSetSerialization(t *testing.T) {
 		WriteSet:    CoarsenedSet{[]byte("moo")},
 	}
 
-	enc := rwSet.MarshalCBOR()
+	enc := cbor.Marshal(rwSet)
 
 	var decRwSet ReadWriteSet
-	err := decRwSet.UnmarshalCBOR(enc)
+	err := cbor.Unmarshal(enc, &decRwSet)
 	require.NoError(t, err, "serialization should round-trip")
 	require.EqualValues(t, rwSet, decRwSet, "serialization should round-trip")
 	require.True(t, decRwSet.Equal(&rwSet), "Equal should return true")

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
 	"github.com/oasislabs/oasis-core/go/common/quantity"
@@ -55,13 +54,6 @@ var (
 	// ErrInsufficientStake is the error returned when an operation fails
 	// due to insufficient stake.
 	ErrInsufficientStake = errors.New("staking: insufficient stake")
-
-	_ cbor.Marshaler   = (*Transfer)(nil)
-	_ cbor.Unmarshaler = (*Transfer)(nil)
-	_ cbor.Marshaler   = (*Burn)(nil)
-	_ cbor.Unmarshaler = (*Burn)(nil)
-	_ cbor.Marshaler   = (*Escrow)(nil)
-	_ cbor.Unmarshaler = (*Escrow)(nil)
 )
 
 // Backend is a staking token implementation.
@@ -175,32 +167,12 @@ type Transfer struct {
 	Tokens quantity.Quantity   `json:"xfer_tokens"`
 }
 
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (x *Transfer) MarshalCBOR() []byte {
-	return cbor.Marshal(x)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (x *Transfer) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, x)
-}
-
 // Burn is a token burn (destruction).
 type Burn struct {
 	Nonce uint64  `json:"nonce"`
 	Fee   gas.Fee `json:"fee"`
 
 	Tokens quantity.Quantity `json:"burn_tokens"`
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (b *Burn) MarshalCBOR() []byte {
-	return cbor.Marshal(b)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (b *Burn) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, b)
 }
 
 // Escrow is a token escrow.
@@ -212,16 +184,6 @@ type Escrow struct {
 	Tokens  quantity.Quantity   `json:"escrow_tokens"`
 }
 
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (e *Escrow) MarshalCBOR() []byte {
-	return cbor.Marshal(e)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (e *Escrow) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, e)
-}
-
 // ReclaimEscrow is a token escrow reclimation.
 type ReclaimEscrow struct {
 	Nonce uint64  `json:"nonce"`
@@ -229,16 +191,6 @@ type ReclaimEscrow struct {
 
 	Account signature.PublicKey `json:"escrow_account"`
 	Shares  quantity.Quantity   `json:"reclaim_shares"`
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (r *ReclaimEscrow) MarshalCBOR() []byte {
-	return cbor.Marshal(r)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into given type.
-func (r *ReclaimEscrow) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, r)
 }
 
 // SignedTransfer is a Transfer, signed by the owner (source) entity.

--- a/go/storage/api/api.go
+++ b/go/storage/api/api.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 
 	"github.com/oasislabs/oasis-core/go/common"
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/node"
@@ -61,11 +60,6 @@ var (
 
 	// ReceiptSignatureContext is the signature context used for verifying MKVS receipts.
 	ReceiptSignatureContext = signature.NewContext("oasis-core/storage: receipt", signature.WithChainSeparation())
-
-	_ cbor.Marshaler   = (*ReceiptBody)(nil)
-	_ cbor.Unmarshaler = (*ReceiptBody)(nil)
-	_ cbor.Marshaler   = (*Receipt)(nil)
-	_ cbor.Unmarshaler = (*Receipt)(nil)
 )
 
 // Config is the storage backend configuration.
@@ -122,29 +116,9 @@ type Receipt struct {
 	signature.Signed
 }
 
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (rb *ReceiptBody) MarshalCBOR() []byte {
-	return cbor.Marshal(rb)
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into the given type.
-func (rb *ReceiptBody) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, rb)
-}
-
 // Open first verifies the blob signature then unmarshals the blob.
 func (s *Receipt) Open(receipt *ReceiptBody) error {
 	return s.Signed.Open(ReceiptSignatureContext, receipt)
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (s *Receipt) MarshalCBOR() []byte {
-	return s.Signed.MarshalCBOR()
-}
-
-// UnmarshalCBOR deserializes a CBOR byte vector into the given type.
-func (s *Receipt) UnmarshalCBOR(data []byte) error {
-	return s.Signed.UnmarshalCBOR(data)
 }
 
 // SignReceipt signs a storage receipt for the given roots.

--- a/go/storage/client/client.go
+++ b/go/storage/client/client.go
@@ -595,8 +595,8 @@ func (b *storageClientBackend) SyncIterate(ctx context.Context, request *api.Ite
 
 func (b *storageClientBackend) GetDiff(ctx context.Context, startRoot api.Root, endRoot api.Root) (api.WriteLogIterator, error) {
 	var req storage.GetDiffRequest
-	req.StartRoot = startRoot.MarshalCBOR()
-	req.EndRoot = endRoot.MarshalCBOR()
+	req.StartRoot = cbor.Marshal(startRoot)
+	req.EndRoot = cbor.Marshal(endRoot)
 
 	respRaw, err := b.readWithClient(ctx, startRoot.Namespace, func(ctx context.Context, c storage.StorageClient) (interface{}, error) {
 		return c.GetDiff(ctx, &req)
@@ -640,7 +640,7 @@ func (b *storageClientBackend) GetDiff(ctx context.Context, startRoot api.Root, 
 
 func (b *storageClientBackend) GetCheckpoint(ctx context.Context, root api.Root) (api.WriteLogIterator, error) {
 	var req storage.GetCheckpointRequest
-	req.Root = root.MarshalCBOR()
+	req.Root = cbor.Marshal(root)
 
 	respRaw, err := b.readWithClient(ctx, root.Namespace, func(ctx context.Context, c storage.StorageClient) (interface{}, error) {
 		return c.GetCheckpoint(ctx, &req)

--- a/go/storage/grpc.go
+++ b/go/storage/grpc.go
@@ -325,10 +325,10 @@ func (s *writeLogService) SendWriteLogIterator() error {
 
 func (s *GrpcServer) GetDiff(req *pb.GetDiffRequest, stream pb.Storage_GetDiffServer) error {
 	var startRoot, endRoot api.Root
-	if err := startRoot.UnmarshalCBOR(req.GetStartRoot()); err != nil {
+	if err := cbor.Unmarshal(req.GetStartRoot(), &startRoot); err != nil {
 		return errors.Wrap(err, "storage: failed to unmarshal start root")
 	}
-	if err := endRoot.UnmarshalCBOR(req.GetEndRoot()); err != nil {
+	if err := cbor.Unmarshal(req.GetEndRoot(), &endRoot); err != nil {
 		return errors.Wrap(err, "storage: failed to unmarshal end root")
 	}
 
@@ -356,7 +356,7 @@ func (s *GrpcServer) GetDiff(req *pb.GetDiffRequest, stream pb.Storage_GetDiffSe
 
 func (s *GrpcServer) GetCheckpoint(req *pb.GetCheckpointRequest, stream pb.Storage_GetCheckpointServer) error {
 	var root api.Root
-	if err := root.UnmarshalCBOR(req.GetRoot()); err != nil {
+	if err := cbor.Unmarshal(req.GetRoot(), &root); err != nil {
 		return errors.Wrap(err, "storage: failed to unmarshal root")
 	}
 

--- a/go/storage/mkvs/urkel/node/node.go
+++ b/go/storage/mkvs/urkel/node/node.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/oasislabs/oasis-core/go/common"
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 )
 
@@ -51,8 +50,6 @@ var (
 	_ encoding.BinaryUnmarshaler = (*InternalNode)(nil)
 	_ encoding.BinaryMarshaler   = (*LeafNode)(nil)
 	_ encoding.BinaryUnmarshaler = (*LeafNode)(nil)
-	_ cbor.Marshaler             = (*Root)(nil)
-	_ cbor.Unmarshaler           = (*Root)(nil)
 )
 
 // Root is a storage root.
@@ -68,16 +65,6 @@ type Root struct {
 // String returns the string representation of a storage root.
 func (r Root) String() string {
 	return fmt.Sprintf("<Root ns=%s round=%d hash=%s>", r.Namespace, r.Round, r.Hash)
-}
-
-// MarshalCBOR serializes the type into a CBOR byte vector.
-func (r *Root) MarshalCBOR() []byte {
-	return cbor.Marshal(r)
-}
-
-// UnmarshalCBOR decodes a CBOR marshaled root.
-func (r *Root) UnmarshalCBOR(data []byte) error {
-	return cbor.Unmarshal(data, r)
 }
 
 // Empty sets the storage root to an empty root.

--- a/go/worker/common/host/sandboxed.go
+++ b/go/worker/common/host/sandboxed.go
@@ -415,7 +415,7 @@ func (st *teeStateIntelSGX) UpdateCapabilityTEE(worker *process) (*node.Capabili
 		return nil, errors.Wrap(err, "worker: error while configuring AVR")
 	}
 
-	attestation := avrBundle.MarshalCBOR()
+	attestation := cbor.Marshal(avrBundle)
 	capabilityTEE := &node.CapabilityTEE{
 		Hardware:    node.TEEHardwareIntelSGX,
 		RAK:         rakPub,

--- a/go/worker/compute/committee/node.go
+++ b/go/worker/compute/committee/node.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
@@ -258,7 +259,7 @@ func (n *Node) queueBatchBlocking(
 		Roots:     []hash.Hash{ioRootHash},
 	}
 	receipt := storage.Receipt{}
-	receipt.Signed.Blob = receiptBody.MarshalCBOR()
+	receipt.Signed.Blob = cbor.Marshal(receiptBody)
 	for _, sig := range storageSignatures {
 		receipt.Signed.Signature = sig
 		var tmp storage.ReceiptBody

--- a/go/worker/storage/grpc.go
+++ b/go/worker/storage/grpc.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/grpc"
 	pb "github.com/oasislabs/oasis-core/go/grpc/storage"
@@ -38,8 +39,8 @@ func (s *grpcServer) GetLastSyncedRound(ctx context.Context, req *pb.GetLastSync
 
 	resp := &pb.GetLastSyncedRoundResponse{
 		Round:     round,
-		IoRoot:    ioRoot.MarshalCBOR(),
-		StateRoot: stateRoot.MarshalCBOR(),
+		IoRoot:    cbor.Marshal(ioRoot),
+		StateRoot: cbor.Marshal(stateRoot),
 	}
 	return resp, nil
 }


### PR DESCRIPTION
This requires removing the conflicting Marshaler/Unmarshaler interfaces
as using them causes infinite recursion.