### PR TITLE
abci: move calling InitChain on apps from BeginBlock to mux InitChain

### DIFF
--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -69,7 +69,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	ConsensusProtocol = Version{Major: 0, Minor: 19, Patch: 0}
+	ConsensusProtocol = Version{Major: 0, Minor: 20, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)

--- a/go/consensus/tendermint/apps/beacon/query.go
+++ b/go/consensus/tendermint/apps/beacon/query.go
@@ -21,16 +21,27 @@ type QueryFactory struct {
 
 // QueryAt returns the beacon query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := beaconState.NewImmutableState(sf.app.state, height)
-	if err != nil {
-		return nil, err
+	var state *beaconState.ImmutableState
+	var err error
+	abciCtx := abci.FromCtx(ctx)
+
+	// If this request was made from InitChain, no blocks and states have been
+	// submitted yet, so we use the existing state instead.
+	if abciCtx != nil && abciCtx.IsInitChain() {
+		state = beaconState.NewMutableState(abciCtx.State()).ImmutableState
+	} else {
+		state, err = beaconState.NewImmutableState(sf.app.state, height)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// If this request was made from an ABCI app, make sure to use the associated
 	// context for querying state instead of the default one.
-	if abciCtx := abci.FromCtx(ctx); abciCtx != nil && height == abciCtx.BlockHeight()+1 {
+	if abciCtx != nil && height == abciCtx.BlockHeight()+1 {
 		state.Snapshot = abciCtx.State().ImmutableTree
 	}
+
 	return &beaconQuerier{state}, nil
 }
 

--- a/go/consensus/tendermint/apps/epochtime_mock/query.go
+++ b/go/consensus/tendermint/apps/epochtime_mock/query.go
@@ -19,16 +19,27 @@ type QueryFactory struct {
 
 // QueryAt returns the mock epochtime query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := newImmutableState(sf.app.state, height)
-	if err != nil {
-		return nil, err
+	var state *immutableState
+	var err error
+	abciCtx := abci.FromCtx(ctx)
+
+	// If this request was made from InitChain, no blocks and states have been
+	// submitted yet, so we use the existing state instead.
+	if abciCtx != nil && abciCtx.IsInitChain() {
+		state = newMutableState(abciCtx.State()).immutableState
+	} else {
+		state, err = newImmutableState(sf.app.state, height)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// If this request was made from an ABCI app, make sure to use the associated
 	// context for querying state instead of the default one.
-	if abciCtx := abci.FromCtx(ctx); abciCtx != nil && height == abciCtx.BlockHeight()+1 {
+	if abciCtx != nil && height == abciCtx.BlockHeight()+1 {
 		state.Snapshot = abciCtx.State().ImmutableTree
 	}
+
 	return &epochtimeMockQuerier{state}, nil
 }
 

--- a/go/consensus/tendermint/apps/keymanager/query.go
+++ b/go/consensus/tendermint/apps/keymanager/query.go
@@ -23,16 +23,27 @@ type QueryFactory struct {
 
 // QueryAt returns the key manager query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := keymanagerState.NewImmutableState(sf.app.state, height)
-	if err != nil {
-		return nil, err
+	var state *keymanagerState.ImmutableState
+	var err error
+	abciCtx := abci.FromCtx(ctx)
+
+	// If this request was made from InitChain, no blocks and states have been
+	// submitted yet, so we use the existing state instead.
+	if abciCtx != nil && abciCtx.IsInitChain() {
+		state = keymanagerState.NewMutableState(abciCtx.State()).ImmutableState
+	} else {
+		state, err = keymanagerState.NewImmutableState(sf.app.state, height)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// If this request was made from an ABCI app, make sure to use the associated
 	// context for querying state instead of the default one.
-	if abciCtx := abci.FromCtx(ctx); abciCtx != nil && height == abciCtx.BlockHeight()+1 {
+	if abciCtx != nil && height == abciCtx.BlockHeight()+1 {
 		state.Snapshot = abciCtx.State().ImmutableTree
 	}
+
 	return &keymanagerQuerier{state}, nil
 }
 

--- a/go/consensus/tendermint/apps/registry/query.go
+++ b/go/consensus/tendermint/apps/registry/query.go
@@ -31,16 +31,27 @@ type QueryFactory struct {
 
 // QueryAt returns the registry query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := registryState.NewImmutableState(sf.app.state, height)
-	if err != nil {
-		return nil, err
+	var state *registryState.ImmutableState
+	var err error
+	abciCtx := abci.FromCtx(ctx)
+
+	// If this request was made from InitChain, no blocks and states have been
+	// submitted yet, so we use the existing state instead.
+	if abciCtx != nil && abciCtx.IsInitChain() {
+		state = registryState.NewMutableState(abciCtx.State()).ImmutableState
+	} else {
+		state, err = registryState.NewImmutableState(sf.app.state, height)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// If this request was made from an ABCI app, make sure to use the associated
 	// context for querying state instead of the default one.
-	if abciCtx := abci.FromCtx(ctx); abciCtx != nil && height == abciCtx.BlockHeight()+1 {
+	if abciCtx != nil && height == abciCtx.BlockHeight()+1 {
 		state.Snapshot = abciCtx.State().ImmutableTree
 	}
+
 	return &registryQuerier{sf.app, state, height}, nil
 }
 

--- a/go/consensus/tendermint/apps/roothash/query.go
+++ b/go/consensus/tendermint/apps/roothash/query.go
@@ -24,16 +24,27 @@ type QueryFactory struct {
 
 // QueryAt returns the roothash query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := roothashState.NewImmutableState(sf.app.state, height)
-	if err != nil {
-		return nil, err
+	var state *roothashState.ImmutableState
+	var err error
+	abciCtx := abci.FromCtx(ctx)
+
+	// If this request was made from InitChain, no blocks and states have been
+	// submitted yet, so we use the existing state instead.
+	if abciCtx != nil && abciCtx.IsInitChain() {
+		state = roothashState.NewMutableState(abciCtx.State()).ImmutableState
+	} else {
+		state, err = roothashState.NewImmutableState(sf.app.state, height)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// If this request was made from an ABCI app, make sure to use the associated
 	// context for querying state instead of the default one.
-	if abciCtx := abci.FromCtx(ctx); abciCtx != nil && height == abciCtx.BlockHeight()+1 {
+	if abciCtx != nil && height == abciCtx.BlockHeight()+1 {
 		state.Snapshot = abciCtx.State().ImmutableTree
 	}
+
 	return &rootHashQuerier{state}, nil
 }
 

--- a/go/consensus/tendermint/apps/scheduler/query.go
+++ b/go/consensus/tendermint/apps/scheduler/query.go
@@ -24,16 +24,27 @@ type QueryFactory struct {
 
 // QueryAt returns the scheduler query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := schedulerState.NewImmutableState(sf.app.state, height)
-	if err != nil {
-		return nil, err
+	var state *schedulerState.ImmutableState
+	var err error
+	abciCtx := abci.FromCtx(ctx)
+
+	// If this request was made from InitChain, no blocks and states have been
+	// submitted yet, so we use the existing state instead.
+	if abciCtx != nil && abciCtx.IsInitChain() {
+		state = schedulerState.NewMutableState(abciCtx.State()).ImmutableState
+	} else {
+		state, err = schedulerState.NewImmutableState(sf.app.state, height)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// If this request was made from an ABCI app, make sure to use the associated
 	// context for querying state instead of the default one.
-	if abciCtx := abci.FromCtx(ctx); abciCtx != nil && height == abciCtx.BlockHeight()+1 {
+	if abciCtx != nil && height == abciCtx.BlockHeight()+1 {
 		state.Snapshot = abciCtx.State().ImmutableTree
 	}
+
 	return &schedulerQuerier{state}, nil
 }
 

--- a/go/consensus/tendermint/apps/staking/query.go
+++ b/go/consensus/tendermint/apps/staking/query.go
@@ -35,16 +35,27 @@ type QueryFactory struct {
 
 // QueryAt returns the staking query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := stakingState.NewImmutableState(sf.app.state, height)
-	if err != nil {
-		return nil, err
+	var state *stakingState.ImmutableState
+	var err error
+	abciCtx := abci.FromCtx(ctx)
+
+	// If this request was made from InitChain, no blocks and states have been
+	// submitted yet, so we use the existing state instead.
+	if abciCtx != nil && abciCtx.IsInitChain() {
+		state = stakingState.NewMutableState(abciCtx.State()).ImmutableState
+	} else {
+		state, err = stakingState.NewImmutableState(sf.app.state, height)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// If this request was made from an ABCI app, make sure to use the associated
 	// context for querying state instead of the default one.
-	if abciCtx := abci.FromCtx(ctx); abciCtx != nil && height == abciCtx.BlockHeight()+1 {
+	if abciCtx != nil && height == abciCtx.BlockHeight()+1 {
 		state.Snapshot = abciCtx.State().ImmutableTree
 	}
+
 	return &stakingQuerier{state}, nil
 }
 

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -141,7 +141,7 @@ func newFailMonitor(logger *logging.Logger, fn func()) *failMonitor {
 	return &m
 }
 
-// IsSeed retuns true iff the node is configured as a seed node.
+// IsSeed returns true iff the node is configured as a seed node.
 func IsSeed() bool {
 	return viper.GetBool(CfgP2PSeedMode)
 }

--- a/go/worker/common/worker.go
+++ b/go/worker/common/worker.go
@@ -7,7 +7,6 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/grpc"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/logging"
-	"github.com/oasislabs/oasis-core/go/common/version"
 	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
 	genesis "github.com/oasislabs/oasis-core/go/genesis/api"
 	"github.com/oasislabs/oasis-core/go/ias"
@@ -27,8 +26,7 @@ const LocalStorageFile = "worker-local-storage.bolt.db"
 
 // Runtime is a single runtime.
 type Runtime struct {
-	id      signature.PublicKey
-	version version.Version
+	id signature.PublicKey
 
 	node *committee.Node
 }
@@ -243,9 +241,9 @@ func (w *Worker) registerRuntime(id signature.PublicKey) error {
 	}
 
 	rt := &Runtime{
-		id:      id,
-		version: version.Version{Major: 0, Minor: 0, Patch: 0}, // Version is populated once the runtime has been loaded. -Matevz
-		node:    node,
+		id: id,
+		// Version is populated once the runtime has been loaded.
+		node: node,
 	}
 	w.runtimes[rt.id] = rt
 


### PR DESCRIPTION
PR for https://github.com/oasislabs/oasis-core/issues/2122:
* Moves `InitChain()` calls to applications from `BeginBlock()` of mux to `InitChain()` where it should be.
* Temporarily stores the events emitted during `InitChain()` and prepends them to `BeginBlock` events during the first `BeginBlock()` call in mux.
* Replaces immutable state calls with `NewMutableState(abciCtx.State())` in `QueryAt()` functions when called from `InitChain`.