### PR TITLE
Revert "tests: Test the untrusted local storage"

### DIFF
--- a/tests/clients/simple-keyvalue/src/main.rs
+++ b/tests/clients/simple-keyvalue/src/main.rs
@@ -99,25 +99,6 @@ fn main() {
         }
     }
 
-    // Test local_[set,get] calls.
-    let local_kv = KeyValue {
-        key: String::from("local_key"),
-        value: String::from("local_value"),
-    };
-    println!(
-        "Storing \"{}\" as key and \"{}\" as value to untrusted local storage...",
-        local_kv.key, local_kv.value
-    );
-    rt.block_on(kv_client.local_insert(local_kv)).unwrap();
-    let val = rt
-        .block_on(kv_client.local_get("local_key".to_string()))
-        .unwrap();
-    println!("Got \"{}\"", val);
-    assert_eq!(val, "local_value");
-
-    // Test local_get call.
-    println!("Geting \"local_key\"...");
-
     // Test get_latest_block call.
     println!("Getting latest block...");
     let snapshot = rt

--- a/tests/runtimes/simple-keyvalue/api/src/api.rs
+++ b/tests/runtimes/simple-keyvalue/api/src/api.rs
@@ -28,10 +28,4 @@ runtime_api! {
 
     // (encrypted) Removes value associated with the given key and returns old value, if any.
     pub fn enc_remove(String) -> Option<String>;
-
-    // Inserts key and corresponding value to the runtime's untrusted local storage.
-    pub fn local_insert(KeyValue) -> ();
-
-    // Gets the value associated with given key from the runtime's untrusted local storage.
-    pub fn local_get(String) -> String;
 }

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -134,21 +134,6 @@ fn enc_remove(args: &String, ctx: &mut TxnContext) -> Fallible<Option<String>> {
     Ok(existing.map(|v| String::from_utf8(v)).transpose()?)
 }
 
-/// Insert a key/value pair (untrusted local).
-fn local_insert(args: &KeyValue, _ctx: &mut TxnContext) -> Fallible<()> {
-    StorageContext::with_current(|_mkvs, untrusted_local| {
-        untrusted_local.insert(args.key.as_bytes().to_vec(), args.value.as_bytes().to_vec())
-    })
-}
-
-/// Retrive a key (untrusted local).
-fn local_get(args: &String, _ctx: &mut TxnContext) -> Fallible<String> {
-    let existing = StorageContext::with_current(|_mkvs, untrusted_local| {
-        untrusted_local.get(args.as_bytes().to_vec())
-    })?;
-    Ok(String::from_utf8(existing)?)
-}
-
 /// A keyed storage encryption context, for use with a MKVS instance.
 struct EncryptionContext {
     d2: DeoxysII,


### PR DESCRIPTION
This reverts commit 8f8ea0b22f29d6b763ad751b1a5d8f533b6f62b6.

for #2405

we can't run this test as part of the simple-keyvalue client. the simple-keyvalue client is meant to work under committee changes in the middle of the test (although we should have been more careful that we consistently exercise that).

if we really want to support this, please reinstate this test in a scenario with a fixed compute committee.