### PR TITLE
Add development docker to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,3 +89,12 @@ clean: clean-go clean-runtimes
 	@$(ECHO) "$(CYAN)*** Cleaning up...$(OFF)"
 	@cargo clean
 
+docker-shell:
+	@docker run -t -i \
+	  --name oasis-core \
+	  --security-opt apparmor:unconfined \
+	  --security-opt seccomp=unconfined \
+	  -v $(pwd):/code \
+	  -w /code \
+	  oasislabs/development:0.3.0 \
+	  bash

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ host system, you can use our development Docker image. This requires that you ha
 Oasis development environment with all the dependencies preinstalled is available
 in the `oasislabs/development:0.3.0` image. To run a container do something like the
 following in the top-level directory:
+```bash
+make docker-shell
+```
+
+if you are curious, this target will internally run the following command:
 ```
 docker run -t -i \
   --name oasis-core \


### PR DESCRIPTION
I find myself frequently going to the README.md to find the right parameters to run the docker container used for development.

I thought it was worth adding this to the Makefile and sharing the change.


Note: There is an old existing issue with the container. Files created inside the container are using the root user id, so later they are not easy to access/delete. This is something that could be fixed by creating the right user ids inside the docker container. This is anyway unrelated to the this and can be fixed later.