### PR TITLE
Makefile docker-shell improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ clean: clean-go clean-runtimes
 	@cargo clean
 
 docker-shell:
-	@docker run -t -i \
+	@docker run -t -i --rm \
 	  --name oasis-core \
 	  --security-opt apparmor:unconfined \
 	  --security-opt seccomp=unconfined \

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ docker-shell:
 	  --name oasis-core \
 	  --security-opt apparmor:unconfined \
 	  --security-opt seccomp=unconfined \
-	  -v $(pwd):/code \
+	  -v $(shell pwd):/code \
 	  -w /code \
 	  oasislabs/development:0.3.0 \
 	  bash


### PR DESCRIPTION
This PR includes two changes:
- `shell` was missing because the command executed inside a makefile.
- Adds `--rm` so the container is removed on exit. Otherwise, the name remains registered
