### PR TITLE
registry validation consistency

### DIFF
--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -89,6 +89,12 @@ const (
 	RoleReserved RolesMask = ((1 << 32) - 1) & ^((RoleValidator << 1) - 1)
 )
 
+// IsSingleRole returns true if RolesMask encodes a single valid role.
+func (m RolesMask) IsSingleRole() bool {
+	// Ensures exactly one bit is set, and the set bit is a valid role.
+	return m != 0 && m&(m-1) == 0 && m&RoleReserved == 0
+}
+
 func (m RolesMask) String() string {
 	if m&RoleReserved != 0 {
 		return "[invalid roles]"

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -66,7 +66,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	ConsensusProtocol = Version{Major: 0, Minor: 18, Patch: 0}
+	ConsensusProtocol = Version{Major: 0, Minor: 19, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)

--- a/go/oasis-node/cmd/debug/byzantine/byzantine.go
+++ b/go/oasis-node/cmd/debug/byzantine/byzantine.go
@@ -113,7 +113,7 @@ func doComputeHonest(cmd *cobra.Command, args []string) {
 			panic(fmt.Sprintf("initFakeCapabilitiesSGX: %+v", err))
 		}
 	}
-	if err = registryRegisterNode(ht.service, defaultIdentity, common.DataDir(), fakeAddresses, ph.service.Info(), defaultRuntimeID, capabilities, node.RoleComputeWorker); err != nil {
+	if err = registryRegisterNode(ht.service, defaultIdentity, common.DataDir(), fakeAddresses, ph.service.Addresses(), defaultRuntimeID, capabilities, node.RoleComputeWorker); err != nil {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
@@ -231,7 +231,7 @@ func doComputeWrong(cmd *cobra.Command, args []string) {
 			panic(fmt.Sprintf("initFakeCapabilitiesSGX: %+v", err))
 		}
 	}
-	if err = registryRegisterNode(ht.service, defaultIdentity, common.DataDir(), fakeAddresses, ph.service.Info(), defaultRuntimeID, capabilities, node.RoleComputeWorker); err != nil {
+	if err = registryRegisterNode(ht.service, defaultIdentity, common.DataDir(), fakeAddresses, ph.service.Addresses(), defaultRuntimeID, capabilities, node.RoleComputeWorker); err != nil {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
@@ -348,7 +348,7 @@ func doComputeStraggler(cmd *cobra.Command, args []string) {
 			panic(fmt.Sprintf("initFakeCapabilitiesSGX: %+v", err))
 		}
 	}
-	if err = registryRegisterNode(ht.service, defaultIdentity, common.DataDir(), fakeAddresses, ph.service.Info(), defaultRuntimeID, capabilities, node.RoleComputeWorker); err != nil {
+	if err = registryRegisterNode(ht.service, defaultIdentity, common.DataDir(), fakeAddresses, ph.service.Addresses(), defaultRuntimeID, capabilities, node.RoleComputeWorker); err != nil {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
@@ -405,7 +405,7 @@ func doMergeHonest(cmd *cobra.Command, args []string) {
 		}
 	}()
 
-	if err = registryRegisterNode(ht.service, defaultIdentity, common.DataDir(), fakeAddresses, ph.service.Info(), defaultRuntimeID, nil, node.RoleMergeWorker); err != nil {
+	if err = registryRegisterNode(ht.service, defaultIdentity, common.DataDir(), fakeAddresses, ph.service.Addresses(), defaultRuntimeID, nil, node.RoleMergeWorker); err != nil {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
@@ -495,7 +495,7 @@ func doMergeWrong(cmd *cobra.Command, args []string) {
 		}
 	}()
 
-	if err = registryRegisterNode(ht.service, defaultIdentity, common.DataDir(), fakeAddresses, ph.service.Info(), defaultRuntimeID, nil, node.RoleMergeWorker); err != nil {
+	if err = registryRegisterNode(ht.service, defaultIdentity, common.DataDir(), fakeAddresses, ph.service.Addresses(), defaultRuntimeID, nil, node.RoleMergeWorker); err != nil {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
@@ -609,7 +609,7 @@ func doMergeStraggler(cmd *cobra.Command, args []string) {
 		}
 	}()
 
-	if err = registryRegisterNode(ht.service, defaultIdentity, common.DataDir(), fakeAddresses, ph.service.Info(), defaultRuntimeID, nil, node.RoleMergeWorker); err != nil {
+	if err = registryRegisterNode(ht.service, defaultIdentity, common.DataDir(), fakeAddresses, ph.service.Addresses(), defaultRuntimeID, nil, node.RoleMergeWorker); err != nil {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 

--- a/go/oasis-node/cmd/debug/byzantine/registry.go
+++ b/go/oasis-node/cmd/debug/byzantine/registry.go
@@ -15,7 +15,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/worker/registration"
 )
 
-func registryRegisterNode(svc service.TendermintService, id *identity.Identity, dataDir string, committeeAddresses []node.Address, p2pInfo node.P2PInfo, runtimeID signature.PublicKey, capabilities *node.Capabilities, roles node.RolesMask) error {
+func registryRegisterNode(svc service.TendermintService, id *identity.Identity, dataDir string, committeeAddresses []node.Address, p2pAddresses []node.Address, runtimeID signature.PublicKey, capabilities *node.Capabilities, roles node.RolesMask) error {
 	entityID, registrationSigner, err := registration.GetRegistrationSigner(logging.GetLogger("cmd/byzantine/registration"), dataDir, id)
 	if err != nil {
 		return errors.Wrap(err, "registration GetRegistrationSigner")
@@ -32,7 +32,10 @@ func registryRegisterNode(svc service.TendermintService, id *identity.Identity, 
 			Certificate: id.TLSCertificate.Certificate[0],
 			Addresses:   committeeAddresses,
 		},
-		P2P: p2pInfo,
+		P2P: node.P2PInfo{
+			ID:        id.P2PSigner.Public(),
+			Addresses: p2pAddresses,
+		},
 		Consensus: node.ConsensusInfo{
 			ID: id.ConsensusSigner.Public(),
 		},

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -259,6 +259,10 @@ func (n *Node) initWorkers(logger *logging.Logger) error {
 		n.commonStore,
 		n, // the delegate to be called on registration shutdown
 	)
+	if genesisDoc.Registry.Parameters.DebugAllowUnroutableAddresses {
+		registration.DebugForceAllowUnroutableAddresses()
+	}
+
 	if err != nil {
 		logger.Error("failed to initialize worker registration",
 			"err", err,

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -173,6 +173,10 @@ func testRegistryEntityNodes( // nolint: gocyclo
 				require.Error(err, "register node with invalid runtimes")
 				require.Equal(err, api.ErrInvalidArgument)
 
+				err = v.Register(consensus, v.SignedInvalidRegistration9)
+				require.Error(err, "register node with invalid consensus address")
+				require.Equal(err, api.ErrInvalidArgument)
+
 				err = v.Register(consensus, v.SignedRegistration)
 				require.NoError(err, "RegisterNode")
 
@@ -522,6 +526,7 @@ type TestNode struct {
 	SignedInvalidRegistration6  *node.SignedNode
 	SignedInvalidRegistration7  *node.SignedNode
 	SignedInvalidRegistration8  *node.SignedNode
+	SignedInvalidRegistration9  *node.SignedNode
 	SignedValidReRegistration   *node.SignedNode
 	SignedInvalidReRegistration *node.SignedNode
 }
@@ -655,6 +660,20 @@ func (ent *TestEntity) NewTestNodes(nCompute int, nStorage int, runtimes []*node
 		invalid8.Runtimes = []*node.Runtime{&node.Runtime{ID: ent.Signer.Public()}}
 
 		nod.SignedInvalidRegistration8, err = node.SignNode(ent.Signer, api.RegisterNodeSignatureContext, &invalid8)
+		if err != nil {
+			return nil, err
+		}
+
+		// Add a registration with invalid consensus address.
+		invalid9 := *nod.Node
+		invalid9.Consensus.Addresses = []node.ConsensusAddress{
+			node.ConsensusAddress{
+				// ID: invalid
+				Address: addr,
+			},
+		}
+
+		nod.SignedInvalidRegistration9, err = node.SignNode(ent.Signer, api.RegisterNodeSignatureContext, &invalid9)
 		if err != nil {
 			return nil, err
 		}

--- a/go/worker/common/p2p/p2p.go
+++ b/go/worker/common/p2p/p2p.go
@@ -35,7 +35,7 @@ var (
 	allowUnroutableAddresses bool
 )
 
-// DebugForceAllowUnroutableAddresses allows unroutable addresses.
+// DebugForceallowUnroutableAddresses allows unroutable addresses.
 func DebugForceAllowUnroutableAddresses() {
 	allowUnroutableAddresses = true
 }
@@ -85,11 +85,10 @@ func peerIDToPublicKey(peerID core.PeerID) (signature.PublicKey, error) {
 	return pubKeyToPublicKey(pk)
 }
 
-// Info returns the information needed to establish connections to this
-// node via the P2P transport.
-func (p *P2P) Info() node.P2PInfo {
+// Addresses returns the P2P addresses of the node.
+func (p *P2P) Addresses() []node.Address {
 	if p == nil {
-		return node.P2PInfo{}
+		return nil
 	}
 
 	var addrs []multiaddr.Multiaddr
@@ -116,15 +115,7 @@ func (p *P2P) Info() node.P2PInfo {
 		addresses = append(addresses, nodeAddr)
 	}
 
-	id, err := peerIDToPublicKey(p.host.ID())
-	if err != nil {
-		panic(err)
-	}
-
-	return node.P2PInfo{
-		ID:        id,
-		Addresses: addresses,
-	}
+	return addresses
 }
 
 func (p *P2P) addPeerInfo(peerID core.PeerID, addresses []node.Address) error {

--- a/go/worker/compute/worker.go
+++ b/go/worker/compute/worker.go
@@ -250,15 +250,13 @@ func newWorker(
 
 		// Register all configured runtimes.
 		for _, rt := range commonWorker.GetRuntimes() {
-			if err := w.registerRuntime(&cfg, rt); err != nil {
+			if err = w.registerRuntime(&cfg, rt); err != nil {
 				return nil, err
 			}
 		}
 
 		// Register compute worker role.
-		w.registration.RegisterRole(func(n *node.Node) error {
-			n.AddRoles(node.RoleComputeWorker)
-
+		if err := w.registration.RegisterRole(node.RoleComputeWorker, func(n *node.Node) error {
 			// Wait until all the runtimes are initialized.
 			for _, rt := range w.runtimes {
 				select {
@@ -305,7 +303,9 @@ func newWorker(
 			}
 
 			return nil
-		})
+		}); err != nil {
+			return nil, err
+		}
 	}
 
 	return w, nil

--- a/go/worker/keymanager/init.go
+++ b/go/worker/keymanager/init.go
@@ -93,7 +93,9 @@ func New(
 			return nil, fmt.Errorf("worker/keymanager: runtime binary not configured")
 		}
 
-		w.registration.RegisterRole(w.onNodeRegistration)
+		if err := w.registration.RegisterRole(node.RoleKeyManager, w.onNodeRegistration); err != nil {
+			return nil, fmt.Errorf("worker/keymanager: failed to register role: %w", err)
+		}
 
 		w.workerHostCfg = host.Config{
 			Role:           node.RoleKeyManager,

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -409,8 +409,6 @@ func (w *Worker) onNodeRegistration(n *node.Node) error {
 	rtDesc.Capabilities.TEE = tee
 	n.Runtimes = append(n.Runtimes, rtDesc)
 
-	n.AddRoles(node.RoleKeyManager)
-
 	return nil
 }
 

--- a/go/worker/merge/worker.go
+++ b/go/worker/merge/worker.go
@@ -220,10 +220,10 @@ func newWorker(
 		}
 
 		// Register merge worker role.
-		w.registrationWorker.RegisterRole(func(n *node.Node) error {
-			n.AddRoles(node.RoleMergeWorker)
-			return nil
-		})
+		if err := w.registrationWorker.RegisterRole(node.RoleMergeWorker,
+			func(n *node.Node) error { return nil }); err != nil {
+			return nil, err
+		}
 	}
 
 	return w, nil

--- a/go/worker/storage/worker.go
+++ b/go/worker/storage/worker.go
@@ -116,11 +116,10 @@ func New(
 		storage.NewGRPCServer(s.commonWorker.Grpc.Server(), s.commonWorker.Storage, s.grpcPolicy, viper.GetBool(CfgWorkerDebugIgnoreApply))
 
 		// Register storage worker role.
-		s.registrationWorker.RegisterRole(func(n *node.Node) error {
-			n.AddRoles(node.RoleStorageWorker)
-
-			return nil
-		})
+		if err := s.registrationWorker.RegisterRole(node.RoleStorageWorker,
+			func(n *node.Node) error { return nil }); err != nil {
+			return nil, err
+		}
 
 		// Start storage node for every runtime.
 		for _, runtimeID := range s.commonWorker.GetConfig().Runtimes {

--- a/go/worker/txnscheduler/worker.go
+++ b/go/worker/txnscheduler/worker.go
@@ -2,6 +2,7 @@ package txnscheduler
 
 import (
 	"fmt"
+
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
@@ -241,11 +242,10 @@ func newWorker(
 		}
 
 		// Register transaction scheduler worker role.
-		w.registration.RegisterRole(func(n *node.Node) error {
-			n.AddRoles(node.RoleTransactionScheduler)
-
-			return nil
-		})
+		if err := w.registration.RegisterRole(node.RoleTransactionScheduler,
+			func(n *node.Node) error { return nil }); err != nil {
+			return nil, err
+		}
 	}
 
 	return w, nil


### PR DESCRIPTION
Fixes: https://github.com/oasislabs/oasis-core/issues/2400

Changes: 
- `committee.Certificate` & `p2p.ID` are now both required fields in registry (note: this will likely break Genesis SanityCheck on a dump in existing deployments where validators have an invalid P2P ID by default - to mitigate this: should probably allow invalid P2P keys for the next few versions in Genesis)
- optional node addresses are now validated as well in the registry (before addresses were only validated if required)
- registration worker no longer registers with committee addresses unless role requires it, and provides all required IDs