### PR TITLE
oasis-node/cmd: append git HEAD commit to oasis-node version

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -11,6 +11,14 @@ OASIS_GO ?= go
 #   migrate to a version of Go that has the fix, it can be removed.
 GOFLAGS ?= -trimpath -ldflags=-buildid= -v
 
+# Append git HEAD commit to the oasis node version, if git command exists and
+# this folder is in some git repository. Use a truncated commit hash and append
+# +, if the branch is dirty.
+VERSION_BUILD = $(shell git describe --always --match "" --dirty=+ 2>/dev/null)
+ifneq ($(VERSION_BUILD),)
+	GOFLAGS_VERSION_EXTRA = -ldflags "-X github.com/oasislabs/oasis-core/go/common/version.Build=+$(VERSION_BUILD)"
+endif
+
 all: generate build
 
 # Generate required files.
@@ -24,7 +32,7 @@ generate:
 # Build all the things.
 build: generate
 	@echo "Building Oasis node"
-	@env -u GOPATH $(OASIS_GO) build $(GOFLAGS) -o ./oasis-node/oasis-node ./oasis-node
+	@env -u GOPATH $(OASIS_GO) build $(GOFLAGS) $(GOFLAGS_VERSION_EXTRA) -o ./oasis-node/oasis-node ./oasis-node
 	@echo "Building Oasis test harness"
 	@env -u GOPATH $(OASIS_GO) build $(GOFLAGS) -o ./oasis-test-runner/oasis-test-runner ./oasis-test-runner
 	@echo "Building Oasis local network runner"

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -50,6 +50,9 @@ func (v Version) MajorMinor() Version {
 }
 
 var (
+	// Build stores current git HEAD and is set by the linker.
+	Build = ""
+
 	// RuntimeProtocol versions the protocol between the Oasis node(s) and
 	// the runtime.
 	//

--- a/go/oasis-node/cmd/root.go
+++ b/go/oasis-node/cmd/root.go
@@ -24,7 +24,7 @@ var (
 	rootCmd = &cobra.Command{
 		Use:     "oasis-node",
 		Short:   "Oasis Node",
-		Version: "0.2.0-alpha",
+		Version: "0.2.0-alpha" + version.Build,
 		Run:     node.Run,
 	}
 )


### PR DESCRIPTION
When talking to node operators I noticed some of them used an older version of `oasis-node` binary. This PR runs `git rev-parse HEAD` during compilation and appends this information to the oasis node's version. Running `oasis-node --version` will now produce:
```
oa@matevz-oa:~/oasis-core/go$ oasis-node/oasis-node --version
Software version: 0.2.0-alpha+d8c21ad1
Runtime protocol version: 0.9.0
Consensus protocol version: 0.18.0
Committee protocol version: 0.6.0
Tendermint core version: 0.32.7
ABCI library version: 0.16.1
```