### PR TITLE
go/cmd/identity: add command for generating node identity keys

### DIFF
--- a/go/oasis-node/cmd/identity/identity.go
+++ b/go/oasis-node/cmd/identity/identity.go
@@ -1,0 +1,63 @@
+// Package identity implements the identity sub-commands.
+package identity
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	fileSigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/file"
+	"github.com/oasislabs/oasis-core/go/common/identity"
+	"github.com/oasislabs/oasis-core/go/common/logging"
+	cmdCommon "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	cmdFlags "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
+)
+
+var (
+	identityCmd = &cobra.Command{
+		Use:   "identity",
+		Short: "identity interface utilities",
+	}
+
+	identityInitCmd = &cobra.Command{
+		Use:   "init",
+		Short: "initialize node identity",
+		Run:   doNodeInit,
+	}
+
+	logger = logging.GetLogger("cmd/identity")
+)
+
+func doNodeInit(cmd *cobra.Command, args []string) {
+	if err := cmdCommon.Init(); err != nil {
+		cmdCommon.EarlyLogAndExit(err)
+	}
+
+	dataDir := cmdCommon.DataDir()
+	if dataDir == "" {
+		logger.Error("data directory must be set")
+		os.Exit(1)
+	}
+
+	// Provision the node identity.
+	nodeSignerFactory := fileSigner.NewFactory(dataDir, signature.SignerNode, signature.SignerP2P, signature.SignerConsensus)
+	_, err := identity.LoadOrGenerate(dataDir, nodeSignerFactory)
+	if err != nil {
+		logger.Error("failed to load or generate node identity",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Generated identity files in: %s\n", dataDir)
+}
+
+// Register registers the client sub-command and all of it's children.
+func Register(parentCmd *cobra.Command) {
+	identityInitCmd.Flags().AddFlagSet(cmdFlags.VerboseFlags)
+	identityCmd.AddCommand(identityInitCmd)
+
+	parentCmd.AddCommand(identityCmd)
+}

--- a/go/oasis-node/cmd/root.go
+++ b/go/oasis-node/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/debug"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/genesis"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/ias"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/identity"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/keymanager"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/node"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/registry"
@@ -73,6 +74,7 @@ func init() {
 		debug.Register,
 		genesis.Register,
 		ias.Register,
+		identity.Register,
 		keymanager.Register,
 		registry.Register,
 		stake.Register,

--- a/go/oasis-test-runner/scenario/e2e/identity_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/identity_cli.go
@@ -1,0 +1,67 @@
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	fileSigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/file"
+	"github.com/oasislabs/oasis-core/go/common/identity"
+	"github.com/oasislabs/oasis-core/go/common/logging"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/scenario"
+)
+
+var (
+	// IdentityCLI is the identity CLI scenario.
+	IdentityCLI scenario.Scenario = &identityCLIImpl{
+		logger: logging.GetLogger("scenario/e2e/identity-cli"),
+	}
+)
+
+type identityCLIImpl struct {
+	nodeBinary string
+	dataDir    string
+
+	logger *logging.Logger
+}
+
+func (i *identityCLIImpl) Name() string {
+	return "identity-cli"
+}
+
+func (i *identityCLIImpl) Init(childEnv *env.Env, net *oasis.Network) error {
+	i.nodeBinary = viper.GetString(cfgNodeBinary)
+
+	dataDir, err := childEnv.NewSubDir("test-identity")
+	if err != nil {
+		return fmt.Errorf("scenario/e2e/identity_cli: init failed to create subdir: %w", err)
+	}
+	i.dataDir = dataDir.String()
+
+	return nil
+}
+
+func (i *identityCLIImpl) Fixture() (*oasis.NetworkFixture, error) {
+	return nil, nil
+}
+
+func (i *identityCLIImpl) Run(childEnv *env.Env) error {
+	args := []string{
+		"identity", "init",
+		"--datadir", i.dataDir,
+	}
+	if err := runSubCommand(childEnv, "identity-init", i.nodeBinary, args); err != nil {
+		return fmt.Errorf("scenario/e2e/identity_cli: failed provision node identity: %w", err)
+	}
+
+	// Load created identity.
+	factory := fileSigner.NewFactory(i.dataDir, signature.SignerNode, signature.SignerP2P, signature.SignerConsensus)
+	if _, err := identity.Load(i.dataDir, factory); err != nil {
+		return fmt.Errorf("scenario/e2e/identity_cli: failed to load node initialized identity: %w", err)
+	}
+
+	return nil
+}

--- a/go/oasis-test-runner/test-runner.go
+++ b/go/oasis-test-runner/test-runner.go
@@ -47,6 +47,8 @@ func main() {
 	_ = cmd.Register(e2e.NodeShutdown)
 	// Gas fees test.
 	_ = cmd.Register(e2e.GasFees)
+	// Identity CLI test.
+	_ = cmd.Register(e2e.IdentityCLI)
 
 	// Execute the command, now that everything has been initialized.
 	cmd.Execute()


### PR DESCRIPTION
Fixes: https://github.com/oasislabs/oasis-core/issues/2413

Usage:
```
oasis-node/oasis-node identity init --datadir /tmp/test
Generated identity files in: /tmp/test
```