### PR TITLE
Use genesis document hash instead of ChainID for chain domain separation

### DIFF
--- a/go/common/crypto/signature/signer.go
+++ b/go/common/crypto/signature/signer.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	chainContextMaxSize   = 32
+	chainContextMaxSize   = 64
 	chainContextSeparator = " for chain "
 )
 
@@ -97,6 +97,18 @@ func NewContext(rawContext string, opts ...ContextOption) Context {
 	registeredContexts.Store(ctx, &opt)
 
 	return ctx
+}
+
+// UnsafeResetChainContext resets the chain context.
+//
+// This function should NOT be used during normal operation as changing
+// the chain context while an application is running is unsafe. The main
+// use case for having this function is unit tests.
+func UnsafeResetChainContext() {
+	chainContextLock.Lock()
+	defer chainContextLock.Unlock()
+
+	chainContext = Context("")
 }
 
 // SetChainContext configures the chain domain separation context that is

--- a/go/common/crypto/signature/signer_test.go
+++ b/go/common/crypto/signature/signer_test.go
@@ -59,9 +59,8 @@ func TestContext(t *testing.T) {
 
 	// Manually change the chain context to test that this generates different
 	// messages with different contexts (this is otherwise not allowed).
-	chainContextLock.Lock()
-	chainContext = Context("test: oasis-core tests")
-	chainContextLock.Unlock()
+	UnsafeResetChainContext()
+	SetChainContext("test: oasis-core tests")
 
 	msg2, err = PrepareSignerMessage(chainCtx, []byte("message"))
 	require.NoError(err, "PrepareSignerMessage should work with chain context")

--- a/go/consensus/tendermint/seed.go
+++ b/go/consensus/tendermint/seed.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/p2p/pex"
+	"github.com/tendermint/tendermint/types"
 	"github.com/tendermint/tendermint/version"
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
@@ -119,7 +120,7 @@ func NewSeed(dataDir string, identity *identity.Identity, genesisProvider genesi
 		),
 		ID_:        nodeKey.ID(),
 		ListenAddr: viper.GetString(CfgCoreListenAddress),
-		Network:    doc.ChainID,
+		Network:    doc.ChainContext()[:types.MaxChainIDLen],
 		Version:    "0.0.1",
 		Channels:   []byte{pex.PexChannel},
 		Moniker:    "oasis-seed-" + identity.NodeSigner.Public().String(),

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -934,7 +934,7 @@ func genesisToTendermint(d *genesisAPI.Document) (*tmtypes.GenesisDoc, error) {
 	}
 
 	doc := tmtypes.GenesisDoc{
-		ChainID:     d.ChainID,
+		ChainID:     d.ChainContext()[:tmtypes.MaxChainIDLen],
 		GenesisTime: d.Time,
 		ConsensusParams: &tmtypes.ConsensusParams{
 			Block: tmtypes.BlockParams{

--- a/go/genesis/api/api.go
+++ b/go/genesis/api/api.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	beacon "github.com/oasislabs/oasis-core/go/beacon/api"
+	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	consensus "github.com/oasislabs/oasis-core/go/consensus/genesis"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	keymanager "github.com/oasislabs/oasis-core/go/keymanager/api"
@@ -50,6 +52,31 @@ type Document struct {
 	// Extra data is arbitrary extra data that is part of the
 	// genesis block but is otherwise ignored by the protocol.
 	ExtraData map[string][]byte `json:"extra_data"`
+}
+
+// Hash returns the cryptographic hash of the encoded genesis document.
+func (d *Document) Hash() hash.Hash {
+	var h hash.Hash
+	h.From(d)
+	return h
+}
+
+// ChainContext returns a string that can be used as a chain domain separation
+// context. Changing this (or any data it is derived from) invalidates all
+// signatures that use chain domain separation.
+//
+// Currently this uses the hex-encoded cryptographic hash of the encoded
+// genesis document.
+func (d *Document) ChainContext() string {
+	return d.Hash().String()
+}
+
+// SetChainContext configures the global chain domain separation context.
+//
+// This method can only be called once during the application's lifetime and
+// will panic otherwise.
+func (d *Document) SetChainContext() {
+	signature.SetChainContext(d.ChainContext())
 }
 
 // WriteFileJSON writes the genesis document into a JSON file.

--- a/go/genesis/api/api_test.go
+++ b/go/genesis/api/api_test.go
@@ -29,7 +29,7 @@ import (
 
 var testDoc = &Document{
 	ChainID:   genesisTests.TestChainID,
-	Time:      time.Now(),
+	Time:      time.Unix(1574858284, 0),
 	HaltEpoch: epochtime.EpochTime(math.MaxUint64),
 	EpochTime: epochtime.Genesis{
 		Parameters: epochtime.ConsensusParameters{
@@ -92,6 +92,16 @@ func hex2pk(hex string) signature.PublicKey {
 		panic(err)
 	}
 	return pk
+}
+
+func TestGenesisChainContext(t *testing.T) {
+	// Ensure that the chain context is stable.
+	stableDoc := *testDoc
+	// NOTE: Staking part is not stable as it generates a new public key
+	//       on each run.
+	stableDoc.Staking = staking.Genesis{}
+
+	require.Equal(t, stableDoc.ChainContext(), "daba5eed9f82d37c76384f9f185dc0bfff60eb57a33b7d8955e265244e0a0a51")
 }
 
 func TestGenesisSanityCheck(t *testing.T) {

--- a/go/genesis/tests/tests.go
+++ b/go/genesis/tests/tests.go
@@ -1,12 +1,27 @@
 package tests
 
-import "github.com/oasislabs/oasis-core/go/common/crypto/signature"
+import (
+	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+)
 
 // TestChainID is the chain ID that should be used in tests.
 const TestChainID = "test: oasis-core tests"
 
+// TestChainContext is the chain domain separation context that should
+// be used in tests.
+var TestChainContext string
+
 // SetTestChainContext configures the TestChainID as the chain domain
 // separation context.
 func SetTestChainContext() {
-	signature.SetChainContext(TestChainID)
+	signature.SetChainContext(TestChainContext)
+}
+
+func init() {
+	var chainContext hash.Hash
+	// NOTE: This is not how the chain ID is actually derived, but we
+	//       just use something similar for unit tests.
+	chainContext.FromBytes([]byte(TestChainID))
+	TestChainContext = chainContext.String()
 }

--- a/go/oasis-node/cmd/common/consensus/consensus.go
+++ b/go/oasis-node/cmd/common/consensus/consensus.go
@@ -9,7 +9,6 @@ import (
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/consensus/api/transaction"
 	genesisFile "github.com/oasislabs/oasis-core/go/genesis/file"
@@ -66,7 +65,7 @@ func InitGenesis() {
 		)
 		os.Exit(1)
 	}
-	signature.SetChainContext(genesisDoc.ChainID)
+	genesisDoc.SetChainContext()
 }
 
 func GetTxNonceAndFee() (uint64, *transaction.Fee) {

--- a/go/oasis-node/cmd/debug/byzantine/tendermint.go
+++ b/go/oasis-node/cmd/debug/byzantine/tendermint.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/service"
@@ -36,7 +35,7 @@ func (ht *honestTendermint) start(id *identity.Identity, dataDir string) error {
 	if err != nil {
 		return err
 	}
-	signature.SetChainContext(genesisDoc.ChainID)
+	genesisDoc.SetChainContext()
 
 	ht.service, err = tendermint.New(context.Background(), dataDir, id, genesis)
 	if err != nil {

--- a/go/staking/gen_vectors/main.go
+++ b/go/staking/gen_vectors/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasislabs/oasis-core/go/common/quantity"
@@ -13,8 +14,6 @@ import (
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	staking "github.com/oasislabs/oasis-core/go/staking/api"
 )
-
-const chainID = "test-chain-id"
 
 func quantityInt64(v int64) quantity.Quantity {
 	var q quantity.Quantity
@@ -25,8 +24,10 @@ func quantityInt64(v int64) quantity.Quantity {
 }
 
 func main() {
-	// Configure chain context for all signatures using domain separation by ChainID.
-	signature.SetChainContext(chainID)
+	// Configure chain context for all signatures using chain domain separation.
+	var chainContext hash.Hash
+	chainContext.FromBytes([]byte("staking test vectors"))
+	signature.SetChainContext(chainContext.String())
 
 	var vectors []TestVector
 


### PR DESCRIPTION
Fixes #2410 

This is a BREAKING change as it invalidates all signatures that require chain domain separation (e.g., transactions) and also changes the consensus ChainID.