### PR TITLE
go/oasis-net-runner: Always set the feature-gate flag

### DIFF
--- a/go/oasis-net-runner/cmd/root.go
+++ b/go/oasis-net-runner/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/oasis-net-runner/fixtures"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	cmdFlags "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
 )
 
@@ -180,5 +181,7 @@ func init() {
 				common.EarlyLogAndExit(err)
 			}
 		}
+
+		viper.Set(cmdFlags.CfgDebugDontBlameOasis, true)
 	})
 }


### PR DESCRIPTION
This was missed when the debug feature-gating was added and it breaks
the test runner that internally loads the genesis file and does other
operations on test keys.