### PR TITLE
Matevz/feature/registry cli tests

### DIFF
--- a/go/common/mkdir.go
+++ b/go/common/mkdir.go
@@ -9,7 +9,7 @@ import (
 // Mkdir creates a directory iff it does not exist, and otherwise
 // ensures that the filesystem permissions are sufficiently restrictive.
 func Mkdir(d string) error {
-	const permDir = 0700
+	const permDir = os.FileMode(0700)
 
 	fi, err := os.Lstat(d)
 	if err != nil {

--- a/go/oasis-node/cmd/common/common.go
+++ b/go/oasis-node/cmd/common/common.go
@@ -26,7 +26,7 @@ const (
 	CfgDebugAllowTestKeys = "debug.allow_test_keys"
 
 	cfgConfigFile = "config"
-	cfgDataDir    = "datadir"
+	CfgDataDir    = "datadir"
 )
 
 var (
@@ -42,7 +42,7 @@ var (
 
 // DataDir retuns the data directory iff one is set.
 func DataDir() string {
-	return viper.GetString(cfgDataDir)
+	return viper.GetString(CfgDataDir)
 }
 
 // DataDirOrPwd returns the data directory iff one is set, pwd otherwise.
@@ -98,7 +98,7 @@ func init() {
 	_ = viper.BindPFlags(debugAllowTestKeysFlag)
 
 	RootFlags.StringVar(&cfgFile, cfgConfigFile, "", "config file")
-	RootFlags.String(cfgDataDir, "", "data directory")
+	RootFlags.String(CfgDataDir, "", "data directory")
 	_ = viper.BindPFlags(RootFlags)
 
 	RootFlags.AddFlagSet(loggingFlags)
@@ -121,7 +121,7 @@ func InitConfig() {
 		}
 	}
 
-	dataDir := viper.GetString(cfgDataDir)
+	dataDir := viper.GetString(CfgDataDir)
 
 	// Force the DataDir to be an absolute path.
 	if dataDir != "" {
@@ -139,11 +139,11 @@ func InitConfig() {
 	// Note: This is only for flags that are common across all
 	// sub-commands, so excludes things such as the gRPC/Metrics/etc
 	// configuration.
-	viper.Set(cfgDataDir, dataDir)
+	viper.Set(CfgDataDir, dataDir)
 }
 
 func initDataDir() error {
-	dataDir := viper.GetString(cfgDataDir)
+	dataDir := viper.GetString(CfgDataDir)
 	if dataDir == "" {
 		return nil
 	}
@@ -152,7 +152,7 @@ func initDataDir() error {
 
 func normalizePath(f string) string {
 	if !filepath.IsAbs(f) {
-		dataDir := viper.GetString(cfgDataDir)
+		dataDir := viper.GetString(CfgDataDir)
 		f = filepath.Join(dataDir, f)
 		return filepath.Clean(f)
 	}

--- a/go/oasis-node/cmd/common/flags/flags.go
+++ b/go/oasis-node/cmd/common/flags/flags.go
@@ -22,7 +22,7 @@ const (
 	cfgVerbose = "verbose"
 	cfgForce   = "force"
 	cfgRetries = "retries"
-	cfgEntity  = "entity"
+	CfgEntity  = "entity"
 )
 
 var (
@@ -73,7 +73,7 @@ func DebugTestEntity() bool {
 
 // Entity returns the set entity directory.
 func Entity() string {
-	return viper.GetString(cfgEntity)
+	return viper.GetString(CfgEntity)
 }
 
 // GenesisFile returns the set genesis file.
@@ -98,7 +98,7 @@ func init() {
 	DebugTestEntityFlags.Bool(CfgDebugTestEntity, false, "use the test entity (UNSAFE)")
 	_ = DebugTestEntityFlags.MarkHidden(CfgDebugTestEntity)
 
-	EntityFlags.StringP(cfgEntity, "e", "", "Path to directory containing entity private key and descriptor")
+	EntityFlags.StringP(CfgEntity, "e", "", "Path to directory containing entity private key and descriptor")
 
 	GenesisFileFlags.StringP(CfgGenesisFile, "g", "genesis.json", "path to genesis file")
 

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -53,7 +53,7 @@ const (
 
 	// Registry config flags.
 	cfgRegistryDebugAllowUnroutableAddresses = "registry.debug.allow_unroutable_addresses"
-	cfgRegistryDebugAllowRuntimeRegistration = "registry.debug.allow_runtime_registration"
+	CfgRegistryDebugAllowRuntimeRegistration = "registry.debug.allow_runtime_registration"
 	cfgRegistryDebugBypassStake              = "registry.debug.bypass_stake" // nolint: gosec
 
 	// Scheduler config flags.
@@ -243,7 +243,7 @@ func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []stri
 	regSt := registry.Genesis{
 		Parameters: registry.ConsensusParameters{
 			DebugAllowUnroutableAddresses: viper.GetBool(cfgRegistryDebugAllowUnroutableAddresses),
-			DebugAllowRuntimeRegistration: viper.GetBool(cfgRegistryDebugAllowRuntimeRegistration),
+			DebugAllowRuntimeRegistration: viper.GetBool(CfgRegistryDebugAllowRuntimeRegistration),
 			DebugBypassStake:              viper.GetBool(cfgRegistryDebugBypassStake),
 		},
 		Entities: make([]*entity.SignedEntity, 0, len(entities)),
@@ -678,10 +678,10 @@ func init() {
 
 	// Registry config flags.
 	initGenesisFlags.Bool(cfgRegistryDebugAllowUnroutableAddresses, false, "allow unroutable addreses (UNSAFE)")
-	initGenesisFlags.Bool(cfgRegistryDebugAllowRuntimeRegistration, false, "enable non-genesis runtime registration (UNSAFE)")
+	initGenesisFlags.Bool(CfgRegistryDebugAllowRuntimeRegistration, false, "enable non-genesis runtime registration (UNSAFE)")
 	initGenesisFlags.Bool(cfgRegistryDebugBypassStake, false, "bypass all stake checks and operations (UNSAFE)")
 	_ = initGenesisFlags.MarkHidden(cfgRegistryDebugAllowUnroutableAddresses)
-	_ = initGenesisFlags.MarkHidden(cfgRegistryDebugAllowRuntimeRegistration)
+	_ = initGenesisFlags.MarkHidden(CfgRegistryDebugAllowRuntimeRegistration)
 	_ = initGenesisFlags.MarkHidden(cfgRegistryDebugBypassStake)
 
 	// Scheduler config flags.

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -41,7 +41,7 @@ const (
 	CfgKind           = "runtime.kind"
 	CfgKeyManager     = "runtime.keymanager"
 	cfgOutput         = "runtime.genesis.file"
-	cfgVersion        = "runtime.version"
+	CfgVersion        = "runtime.version"
 	CfgVersionEnclave = "runtime.version.enclave"
 
 	// Compute commiteee flags.
@@ -330,7 +330,7 @@ func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) {
 		Kind:        kind,
 		TEEHardware: teeHardware,
 		Version: registry.VersionInfo{
-			Version: version.FromU64(viper.GetUint64(cfgVersion)),
+			Version: version.FromU64(viper.GetUint64(CfgVersion)),
 		},
 		KeyManager: kmID,
 		Compute: registry.ComputeParameters{
@@ -441,7 +441,7 @@ func init() {
 	runtimeFlags.String(CfgGenesisState, "", "Runtime state at genesis")
 	runtimeFlags.String(CfgKeyManager, "", "Key Manager Runtime ID")
 	runtimeFlags.String(CfgKind, "compute", "Kind of runtime.  Supported values are \"compute\" and \"keymanager\"")
-	runtimeFlags.String(cfgVersion, "", "Runtime version. Value is 64-bit hex e.g. 0x0000000100020003 for 1.2.3")
+	runtimeFlags.String(CfgVersion, "", "Runtime version. Value is 64-bit hex e.g. 0x0000000100020003 for 1.2.3")
 	runtimeFlags.StringSlice(CfgVersionEnclave, nil, "Runtime TEE enclave version(s)")
 
 	// Init Compute commitee flags.

--- a/go/oasis-test-runner/oasis/entity.go
+++ b/go/oasis-test-runner/oasis/entity.go
@@ -90,7 +90,7 @@ func (ent *Entity) update() error {
 
 	args := []string{
 		"registry", "entity", "update",
-		"--datadir", ent.dir.String(),
+		"--" + common.CfgDataDir, ent.dir.String(),
 	}
 	for _, n := range ent.nodes {
 		args = append(args, "--entity.node.id", n.String())
@@ -142,7 +142,7 @@ func (net *Network) NewEntity(cfg *EntityCfg) (*Entity, error) {
 		if !cfg.Restore {
 			args := []string{
 				"registry", "entity", "init",
-				"--datadir", entityDir.String(),
+				"--" + common.CfgDataDir, entityDir.String(),
 			}
 			if cfg.AllowEntitySignedNodes {
 				args = append(args, "--entity.debug.allow_entity_signed_nodes")

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -23,6 +23,8 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/node"
 	genesisFile "github.com/oasislabs/oasis-core/go/genesis/file"
 	genesisTests "github.com/oasislabs/oasis-core/go/genesis/tests"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/genesis"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/log"
 )
@@ -175,6 +177,9 @@ type NetworkCfg struct { // nolint: maligned
 
 	// StakingGenesis is the name of a file with a staking genesis document to use if GenesisFile isn't set.
 	StakingGenesis string `json:"staking_genesis"`
+
+	// RegistryDebugAllowRuntimeRegistration enables runtime registration.
+	RegistryDebugAllowRuntimeRegistration bool `json:"registry_debug_allow_runtime_registration"`
 
 	// A set of log watcher handler factories used by default on all nodes
 	// created in this test network.
@@ -513,7 +518,7 @@ func (net *Network) startOasisNode(
 	restartable bool,
 ) (*exec.Cmd, chan error, error) {
 	baseArgs := []string{
-		"--datadir", dir.String(),
+		"--" + common.CfgDataDir, dir.String(),
 		"--log.level", "debug",
 		"--log.format", "json",
 		"--log.file", nodeLogPath(dir),
@@ -606,6 +611,9 @@ func (net *Network) makeGenesis() error {
 	}
 	if net.cfg.StakingGenesis != "" {
 		args = append(args, "--staking", net.cfg.StakingGenesis)
+	}
+	if net.cfg.RegistryDebugAllowRuntimeRegistration {
+		args = append(args, "--"+genesis.CfgRegistryDebugAllowRuntimeRegistration)
 	}
 
 	w, err := net.baseDir.NewLogWriter("genesis_provision.log")

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -10,7 +10,8 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/common/sgx"
-	regRtCmd "github.com/oasislabs/oasis-core/go/oasis-node/cmd/registry/runtime"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	cmdRegRt "github.com/oasislabs/oasis-core/go/oasis-node/cmd/registry/runtime"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
 )
@@ -71,30 +72,30 @@ func (net *Network) NewRuntime(cfg *RuntimeCfg) (*Runtime, error) {
 
 	args := []string{
 		"registry", "runtime", "init_genesis",
-		"--datadir", rtDir.String(),
-		"--" + regRtCmd.CfgID, cfg.ID.String(),
-		"--" + regRtCmd.CfgKind, cfg.Kind.String(),
+		"--" + common.CfgDataDir, rtDir.String(),
+		"--" + cmdRegRt.CfgID, cfg.ID.String(),
+		"--" + cmdRegRt.CfgKind, cfg.Kind.String(),
 	}
 	if cfg.Kind == registry.KindCompute {
 		args = append(args, []string{
-			"--" + regRtCmd.CfgComputeGroupSize, strconv.FormatUint(cfg.Compute.GroupSize, 10),
-			"--" + regRtCmd.CfgComputeGroupBackupSize, strconv.FormatUint(cfg.Compute.GroupBackupSize, 10),
-			"--" + regRtCmd.CfgComputeAllowedStragglers, strconv.FormatUint(cfg.Compute.AllowedStragglers, 10),
-			"--" + regRtCmd.CfgComputeRoundTimeout, cfg.Compute.RoundTimeout.String(),
-			"--" + regRtCmd.CfgMergeGroupSize, strconv.FormatUint(cfg.Merge.GroupSize, 10),
-			"--" + regRtCmd.CfgMergeGroupBackupSize, strconv.FormatUint(cfg.Merge.GroupBackupSize, 10),
-			"--" + regRtCmd.CfgMergeAllowedStragglers, strconv.FormatUint(cfg.Merge.AllowedStragglers, 10),
-			"--" + regRtCmd.CfgMergeRoundTimeout, cfg.Merge.RoundTimeout.String(),
-			"--" + regRtCmd.CfgTxnSchedulerGroupSize, strconv.FormatUint(cfg.TxnScheduler.GroupSize, 10),
-			"--" + regRtCmd.CfgTxnSchedulerMaxBatchSize, strconv.FormatUint(cfg.TxnScheduler.MaxBatchSize, 10),
-			"--" + regRtCmd.CfgTxnSchedulerMaxBatchSizeBytes, strconv.FormatUint(cfg.TxnScheduler.MaxBatchSizeBytes, 10),
-			"--" + regRtCmd.CfgTxnSchedulerAlgorithm, cfg.TxnScheduler.Algorithm,
-			"--" + regRtCmd.CfgTxnSchedulerBatchFlushTimeout, cfg.TxnScheduler.BatchFlushTimeout.String(),
-			"--" + regRtCmd.CfgStorageGroupSize, strconv.FormatUint(cfg.Storage.GroupSize, 10),
+			"--" + cmdRegRt.CfgComputeGroupSize, strconv.FormatUint(cfg.Compute.GroupSize, 10),
+			"--" + cmdRegRt.CfgComputeGroupBackupSize, strconv.FormatUint(cfg.Compute.GroupBackupSize, 10),
+			"--" + cmdRegRt.CfgComputeAllowedStragglers, strconv.FormatUint(cfg.Compute.AllowedStragglers, 10),
+			"--" + cmdRegRt.CfgComputeRoundTimeout, cfg.Compute.RoundTimeout.String(),
+			"--" + cmdRegRt.CfgMergeGroupSize, strconv.FormatUint(cfg.Merge.GroupSize, 10),
+			"--" + cmdRegRt.CfgMergeGroupBackupSize, strconv.FormatUint(cfg.Merge.GroupBackupSize, 10),
+			"--" + cmdRegRt.CfgMergeAllowedStragglers, strconv.FormatUint(cfg.Merge.AllowedStragglers, 10),
+			"--" + cmdRegRt.CfgMergeRoundTimeout, cfg.Merge.RoundTimeout.String(),
+			"--" + cmdRegRt.CfgTxnSchedulerGroupSize, strconv.FormatUint(cfg.TxnScheduler.GroupSize, 10),
+			"--" + cmdRegRt.CfgTxnSchedulerMaxBatchSize, strconv.FormatUint(cfg.TxnScheduler.MaxBatchSize, 10),
+			"--" + cmdRegRt.CfgTxnSchedulerMaxBatchSizeBytes, strconv.FormatUint(cfg.TxnScheduler.MaxBatchSizeBytes, 10),
+			"--" + cmdRegRt.CfgTxnSchedulerAlgorithm, cfg.TxnScheduler.Algorithm,
+			"--" + cmdRegRt.CfgTxnSchedulerBatchFlushTimeout, cfg.TxnScheduler.BatchFlushTimeout.String(),
+			"--" + cmdRegRt.CfgStorageGroupSize, strconv.FormatUint(cfg.Storage.GroupSize, 10),
 		}...)
 
 		if cfg.GenesisState != "" {
-			args = append(args, "--"+regRtCmd.CfgGenesisState, cfg.GenesisState)
+			args = append(args, "--"+cmdRegRt.CfgGenesisState, cfg.GenesisState)
 		}
 	}
 	var mrEnclave *sgx.MrEnclave
@@ -104,13 +105,13 @@ func (net *Network) NewRuntime(cfg *RuntimeCfg) (*Runtime, error) {
 		}
 
 		args = append(args, []string{
-			"--" + regRtCmd.CfgTEEHardware, cfg.TEEHardware.String(),
-			"--" + regRtCmd.CfgVersionEnclave, mrEnclave.String() + cfg.MrSigner.String(),
+			"--" + cmdRegRt.CfgTEEHardware, cfg.TEEHardware.String(),
+			"--" + cmdRegRt.CfgVersionEnclave, mrEnclave.String() + cfg.MrSigner.String(),
 		}...)
 	}
 	if cfg.Keymanager != nil {
 		args = append(args, []string{
-			"--" + regRtCmd.CfgKeyManager, cfg.Keymanager.id.String(),
+			"--" + cmdRegRt.CfgKeyManager, cfg.Keymanager.id.String(),
 		}...)
 	}
 	args = append(args, cfg.Entity.toGenesisArgs()...)

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/crypto"
+	cmdCommon "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	cmdRegNode "github.com/oasislabs/oasis-core/go/oasis-node/cmd/registry/node"
 )
 
 // Validator is an Oasis validator.
@@ -148,12 +150,12 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 
 	args := []string{
 		"registry", "node", "init",
-		"--datadir", val.dir.String(),
-		"--node.expiration", "1",
-		"--node.role", "validator",
+		"--" + cmdCommon.CfgDataDir, val.dir.String(),
+		"--" + cmdRegNode.CfgExpiration, "1",
+		"--" + cmdRegNode.CfgRole, "validator",
 	}
 	for _, v := range consensusAddrs {
-		args = append(args, []string{"--node.consensus_address", v.String()}...)
+		args = append(args, []string{"--" + cmdRegNode.CfgConsensusAddress, v.String()}...)
 	}
 	args = append(args, cfg.Entity.toGenesisArgs()...)
 

--- a/go/oasis-test-runner/scenario/e2e/consensus_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/consensus_cli.go
@@ -1,0 +1,26 @@
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/oasislabs/oasis-core/go/common/logging"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/consensus"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/grpc"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
+)
+
+// submitTx is a wrapper for consensus submit_tx command.
+func submitTx(childEnv *env.Env, txPath string, logger *logging.Logger, socketPath string, nodeBinary string) error {
+	logger.Info("submitting tx", consensus.CfgTxFile, txPath)
+	args := []string{
+		"consensus", "submit_tx",
+		"--" + consensus.CfgTxFile, txPath,
+		"--" + grpc.CfgAddress, "unix:" + socketPath,
+		"--" + common.CfgDebugAllowTestKeys,
+	}
+	if err := runSubCommand(childEnv, "submit", nodeBinary, args); err != nil {
+		return fmt.Errorf("failed to submit tx: %w", err)
+	}
+	return nil
+}

--- a/go/oasis-test-runner/scenario/e2e/identity_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/identity_cli.go
@@ -9,6 +9,7 @@ import (
 	fileSigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/file"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/logging"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/oasis"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/scenario"
@@ -51,7 +52,7 @@ func (i *identityCLIImpl) Fixture() (*oasis.NetworkFixture, error) {
 func (i *identityCLIImpl) Run(childEnv *env.Env) error {
 	args := []string{
 		"identity", "init",
-		"--datadir", i.dataDir,
+		"--" + common.CfgDataDir, i.dataDir,
 	}
 	if err := runSubCommand(childEnv, "identity-init", i.nodeBinary, args); err != nil {
 		return fmt.Errorf("scenario/e2e/identity_cli: failed provision node identity: %w", err)

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -1,0 +1,690 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	fileSigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/file"
+	"github.com/oasislabs/oasis-core/go/common/entity"
+	"github.com/oasislabs/oasis-core/go/common/logging"
+	"github.com/oasislabs/oasis-core/go/common/node"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/consensus"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/grpc"
+	cmdRegEnt "github.com/oasislabs/oasis-core/go/oasis-node/cmd/registry/entity"
+	cmdRegNode "github.com/oasislabs/oasis-core/go/oasis-node/cmd/registry/node"
+	cmdRegRt "github.com/oasislabs/oasis-core/go/oasis-node/cmd/registry/runtime"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/scenario"
+	registry "github.com/oasislabs/oasis-core/go/registry/api"
+)
+
+const ()
+
+var (
+	// RegistryCLI is the staking scenario.
+	RegistryCLI scenario.Scenario = &registryCLIImpl{
+		basicImpl: basicImpl{},
+		logger:    logging.GetLogger("scenario/e2e/registry"),
+	}
+)
+
+type registryCLIImpl struct {
+	basicImpl
+
+	logger *logging.Logger
+}
+
+func (r *registryCLIImpl) Name() string {
+	return "registry-cli"
+}
+
+func (r *registryCLIImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := r.basicImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	// We will mock epochs for reclaiming the escrow.
+	f.Network.EpochtimeMock = true
+
+	// Allow runtime registration.
+	f.Network.RegistryDebugAllowRuntimeRegistration = true
+
+	return f, nil
+}
+
+func (r *registryCLIImpl) Run(childEnv *env.Env) error {
+	if err := r.net.Start(); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	logger.Info("waiting for nodes to register")
+	if err := r.net.Controller().WaitNodesRegistered(ctx, 3); err != nil {
+		return fmt.Errorf("waiting for nodes to register: %w", err)
+	}
+	logger.Info("nodes registered")
+
+	// Run the tests
+	// registry entity and registry node subcommands
+	if err := r.testEntityAndNode(childEnv); err != nil {
+		return fmt.Errorf("scenario/e2e/registry: error while running registry entity and node test: %w", err)
+	}
+
+	// registry runtime subcommands
+	if err := r.testRuntime(childEnv); err != nil {
+		return fmt.Errorf("scenario/e2e/registry: error while running registry runtime test: %w", err)
+	}
+
+	// Stop the network.
+	r.logger.Info("stopping the network")
+	r.net.Stop()
+
+	return nil
+}
+
+// testEntity tests registry entity subcommands.
+func (r *registryCLIImpl) testEntityAndNode(childEnv *env.Env) error {
+	// List entities.
+	entities, err := r.listEntities(childEnv)
+	if err != nil {
+		return err
+	}
+	// Two entities should be registered in our genesis block.
+	if len(entities) != 2 {
+		return fmt.Errorf("scenario/e2e/registry: initial entity list wrong number of entities: %d, expected at least: %d. Entities: %s", len(entities), 2, entities)
+	}
+
+	// List nodes.
+	nodes, err := r.listNodes(childEnv)
+	if err != nil {
+		return err
+	}
+	// Three nodes should be registered in our genesis block initially.
+	if len(nodes) != 3 {
+		return fmt.Errorf("scenario/e2e/registry: initial node list wrong number of nodes: %d, expected at least: %d. Nodes: %s", len(nodes), 3, nodes)
+	}
+
+	// Init new entity.
+	entDir, err := childEnv.NewSubDir("entity")
+	if err != nil {
+		return err
+	}
+
+	var ent *entity.Entity
+	ent, err = r.initEntity(childEnv, entDir.String())
+	if err != nil {
+		return err
+	}
+
+	// Init new node.
+	nDir, err := childEnv.NewSubDir("node")
+	if err != nil {
+		return err
+	}
+	var n *node.Node
+	n, err = r.initNode(childEnv, ent, entDir.String(), nDir.String())
+	if err != nil {
+		return err
+	}
+
+	// Update entity with a new node.
+	var entUp *entity.Entity
+	nodeGenesisFile := nDir.String() + "/node_genesis.json"
+	entUp, err = r.updateEntity(childEnv, []*node.Node{n}, []string{nodeGenesisFile}, entDir.String())
+	if err != nil {
+		return err
+	}
+	if entUp == nil {
+		return fmt.Errorf("scenario/e2e/registry/entity: got empty entity after updating")
+	}
+	// Check whether the entity was updated.
+	entBinary, _ := json.Marshal(ent)
+	entUpBinary, _ := json.Marshal(entUp)
+	if bytes.Equal(entBinary, entUpBinary) {
+		return fmt.Errorf("scenario/e2e/registry/entity: update entity failed. Entity not changed: %s", string(entBinary))
+	}
+	if len(entUp.Nodes) != 1 {
+		return fmt.Errorf("scenario/e2e/registry/entity: update entity failed. Wrong number of nodes: %d. Expected %d", len(entUp.Nodes), 1)
+	}
+	if !entUp.Nodes[0].Equal(n.ID) {
+		return fmt.Errorf("scenario/e2e/registry/entity: update entity failed. Wrong node ID: %s. Expected %s", entUp.Nodes[0].String(), n.ID.String())
+	}
+
+	// Generate register entity transaction.
+	registerTxPath := filepath.Join(childEnv.Dir(), "registry_entity_register.json")
+	if err = r.genRegisterEntityTx(childEnv, 0, registerTxPath, entDir.String()); err != nil {
+		return fmt.Errorf("scenario/e2e/registry/entity: failed to generate entity register tx: %w", err)
+	}
+
+	// Submit register entity transaction.
+	if err = r.submitTx(childEnv, registerTxPath); err != nil {
+		return fmt.Errorf("scenario/e2e/registry/entity: failed to submit entity register tx: %w", err)
+	}
+
+	// List entities.
+	entities, err = r.listEntities(childEnv)
+	if err != nil {
+		return err
+	}
+	// Three entities should now be registered after registration.
+	if len(entities) != 3 {
+		return fmt.Errorf("scenario/e2e/registry: initial entity list wrong number of entities: %d, expected at least: %d. Entities: %s", len(entities), 3, entities)
+	}
+
+	// Generate deregister entity transaction.
+	deregisterTxPath := filepath.Join(childEnv.Dir(), "registry_entity_deregister.json")
+	if err = r.genDeregisterEntityTx(childEnv, 1, deregisterTxPath, entDir.String()); err != nil {
+		return fmt.Errorf("scenario/e2e/registry/entity: failed to generate entity deregister tx: %w", err)
+	}
+
+	// Submit deregister entity transaction.
+	if err = r.submitTx(childEnv, deregisterTxPath); err != nil {
+		return fmt.Errorf("scenario/e2e/registry/entity: failed to submit entity deregister tx: %w", err)
+	}
+
+	// List entities.
+	entities, err = r.listEntities(childEnv)
+	if err != nil {
+		return err
+	}
+	// Only two entities should now be registered after deregistration.
+	if len(entities) != 2 {
+		return fmt.Errorf("scenario/e2e/registry: initial entity list wrong number of entities: %d, expected at least: %d. Entities: %s", len(entities), 2, entities)
+	}
+
+	return nil
+}
+
+// listEntities lists currently registered entities.
+func (r *registryCLIImpl) listEntities(childEnv *env.Env) ([]signature.PublicKey, error) {
+	r.logger.Info("listing all entities")
+	args := []string{
+		"registry", "entity", "list",
+		"--" + grpc.CfgAddress, "unix:" + r.basicImpl.net.Validators()[0].SocketPath(),
+	}
+	b, err := runSubCommandWithOutput(childEnv, "list", r.basicImpl.net.Config().NodeBinary, args)
+	if err != nil {
+		return nil, fmt.Errorf("scenario/e2e/registry/entity: failed to list entities: %s error: %w", b.String(), err)
+	}
+	entitiesStr := strings.Split(b.String(), "\n")
+
+	var entities []signature.PublicKey
+	for _, entStr := range entitiesStr {
+		// Ignore last newline.
+		if entStr == "" {
+			continue
+		}
+
+		var ent signature.PublicKey
+		if err = ent.UnmarshalHex(entStr); err != nil {
+			return nil, err
+		}
+		entities = append(entities, ent)
+	}
+
+	return entities, nil
+}
+
+// loadEntity loads entity and signer from given directory.
+func (r *registryCLIImpl) loadEntity(entDir string) (*entity.Entity, error) {
+	entitySignerFactory := fileSigner.NewFactory(entDir, signature.SignerEntity)
+	ent, _, err := entity.Load(entDir, entitySignerFactory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load entity: %s", err)
+	}
+
+	return ent, nil
+}
+
+// initEntity initializes new entity.
+func (r *registryCLIImpl) initEntity(childEnv *env.Env, entDir string) (*entity.Entity, error) {
+	r.logger.Info("initializing new entity")
+
+	args := []string{
+		"registry", "entity", "init",
+		"--" + common.CfgDataDir, entDir,
+	}
+	_, err := runSubCommandWithOutput(childEnv, "entity-init", r.basicImpl.net.Config().NodeBinary, args)
+	if err != nil {
+		return nil, fmt.Errorf("scenario/e2e/registry/entity: failed to init entity: %w", err)
+	}
+
+	return r.loadEntity(entDir)
+}
+
+// updateInit updates an entity.
+func (r *registryCLIImpl) updateEntity(childEnv *env.Env, nodes []*node.Node, nodeGenesisFiles []string, entDir string) (*entity.Entity, error) {
+	r.logger.Info("update entity")
+
+	var nodeIDs []string
+	for _, n := range nodes {
+		nodeIDs = append(nodeIDs, n.ID.String())
+	}
+
+	args := []string{
+		"registry", "entity", "update",
+		"--" + common.CfgDataDir, entDir,
+		"--" + cmdRegEnt.CfgNodeID, strings.Join(nodeIDs, ","),
+		"--" + cmdRegEnt.CfgNodeDescriptor, strings.Join(nodeGenesisFiles, ","),
+	}
+	_, err := runSubCommandWithOutput(childEnv, "entity-update", r.basicImpl.net.Config().NodeBinary, args)
+	if err != nil {
+		return nil, fmt.Errorf("scenario/e2e/registry/entity: failed to update entity: %w", err)
+	}
+
+	return r.loadEntity(entDir)
+}
+
+// listEntities lists currently registered entities.
+func (r *registryCLIImpl) listNodes(childEnv *env.Env) ([]signature.PublicKey, error) {
+	r.logger.Info("listing all nodes")
+	args := []string{
+		"registry", "node", "list",
+		"--" + grpc.CfgAddress, "unix:" + r.basicImpl.net.Validators()[0].SocketPath(),
+	}
+	b, err := runSubCommandWithOutput(childEnv, "node-list", r.basicImpl.net.Config().NodeBinary, args)
+	if err != nil {
+		return nil, fmt.Errorf("scenario/e2e/registry/entity: failed to list nodes: %s error: %w", b.String(), err)
+	}
+	nodesStr := strings.Split(b.String(), "\n")
+
+	var nodes []signature.PublicKey
+	for _, accStr := range nodesStr {
+		// Ignore last newline.
+		if accStr == "" {
+			continue
+		}
+
+		var acc signature.PublicKey
+		if err = acc.UnmarshalHex(accStr); err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, acc)
+	}
+
+	return nodes, nil
+}
+
+// newTestNode returns a test node instance given the entityID.
+func (r *registryCLIImpl) newTestNode(entityID signature.PublicKey) (*node.Node, []string, []string, error) {
+	testAddresses := []node.Address{
+		{TCPAddr: net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 12345,
+			Zone: "",
+		}},
+		{TCPAddr: net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 2),
+			Port: 54321,
+			Zone: "",
+		}},
+	}
+	testAddressesStr := []string{}
+	for _, a := range testAddresses {
+		testAddressesStr = append(testAddressesStr, a.String())
+	}
+	testCAddresses := []node.ConsensusAddress{
+		{
+			ID: signature.PublicKey{},
+			Address: node.Address{TCPAddr: net.TCPAddr{
+				IP:   net.IPv4(127, 0, 0, 1),
+				Port: 12345,
+				Zone: "",
+			}},
+		},
+		{
+			ID: signature.PublicKey{},
+			Address: node.Address{TCPAddr: net.TCPAddr{
+				IP:   net.IPv4(127, 0, 0, 2),
+				Port: 54321,
+				Zone: "",
+			}},
+		},
+	}
+	_ = testCAddresses[0].ID.UnmarshalHex("1100000000000000000000000000000000000000000000000000000000000000")
+	_ = testCAddresses[1].ID.UnmarshalHex("1200000000000000000000000000000000000000000000000000000000000000")
+	testCAddressesStr := []string{}
+	for _, a := range testCAddresses {
+		testCAddressesStr = append(testCAddressesStr, a.String())
+	}
+	testNode := node.Node{
+		ID:         signature.PublicKey{}, // ID is generated afterwards.
+		EntityID:   entityID,
+		Expiration: 42,
+		Committee: node.CommitteeInfo{
+			Certificate: []byte{}, // Certificate is generated afterwards.
+			Addresses:   testAddresses,
+		},
+		P2P: node.P2PInfo{
+			ID:        signature.PublicKey{}, // ID is generated afterwards.
+			Addresses: testAddresses,
+		},
+		Consensus: node.ConsensusInfo{
+			ID:        signature.PublicKey{}, // ID is generated afterwards.
+			Addresses: testCAddresses,
+		},
+		Runtimes: []*node.Runtime{
+			{
+				ID: signature.PublicKey{}, // ID is set below.
+			},
+		},
+		Roles: node.RoleValidator,
+	}
+	_ = testNode.Runtimes[0].ID.UnmarshalHex("4000000000000000000000000000000000000000000000000000000000000000")
+
+	return &testNode, testAddressesStr, testCAddressesStr, nil
+}
+
+// initNode very "thoroughly" initializes new node and returns its instance.
+func (r *registryCLIImpl) initNode(childEnv *env.Env, ent *entity.Entity, entDir string, dataDir string) (*node.Node, error) {
+	r.logger.Info("initializing new entity")
+
+	// testNode will be our fixture for testing the CLI.
+	testNode, testAddressesStr, testCAddressesStr, err := r.newTestNode(ent.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Helper for running the cmd and importing the generated node instance.
+	runInitNode := func() (*node.Node, error) {
+		args := []string{
+			"registry", "node", "init",
+			"--" + cmdRegNode.CfgCommitteeAddress, strings.Join(testAddressesStr, ","),
+			"--" + cmdRegNode.CfgConsensusAddress, strings.Join(testCAddressesStr, ","),
+			"--" + cmdRegNode.CfgEntityID, testNode.EntityID.String(),
+			"--" + cmdRegNode.CfgExpiration, strconv.FormatUint(testNode.Expiration, 10),
+			"--" + cmdRegNode.CfgSelfSigned, "1",
+			"--" + cmdRegNode.CfgP2PAddress, strings.Join(testAddressesStr, ","),
+			"--" + cmdRegNode.CfgRole, testNode.Roles.String(),
+			"--" + cmdRegNode.CfgNodeRuntimeID, testNode.Runtimes[0].ID.String(),
+			"--" + flags.CfgEntity, entDir,
+			"--" + common.CfgDataDir, dataDir,
+		}
+		_, err = runSubCommandWithOutput(childEnv, "init-node", r.basicImpl.net.Config().NodeBinary, args)
+		if err != nil {
+			return nil, fmt.Errorf("scenario/e2e/registry: failed to init node: %w", err)
+		}
+
+		// Check, if node genesis file was correctly written.
+		var b []byte
+		if b, err = ioutil.ReadFile(filepath.Join(dataDir, cmdRegNode.NodeGenesisFilename)); err != nil {
+			return nil, fmt.Errorf("scenario/e2e/registry: failed to open node genesis file: %w", err)
+		}
+
+		var signedNode node.SignedNode
+		if err = json.Unmarshal(b, &signedNode); err != nil {
+			return nil, fmt.Errorf("scenario/e2e/registry: failed to unmarshal signed node: %w", err)
+		}
+
+		var n node.Node
+		if err = signedNode.Open(registry.RegisterGenesisNodeSignatureContext, &n); err != nil {
+			return nil, fmt.Errorf("scenario/e2e/registry: failed to validate signed node descriptor: %w", err)
+		}
+
+		return &n, nil
+	}
+
+	n, err := runInitNode()
+	if err != nil {
+		return nil, err
+	}
+
+	// Check the generated fields from imported node.
+	if !n.ID.IsValid() {
+		return nil, fmt.Errorf("scenario/e2e/registry: new node ID is not valid")
+	}
+	if n.Committee.Certificate == nil || len(n.Committee.Certificate) == 0 {
+		return nil, fmt.Errorf("scenario/e2e/registry: new node committee certificate is not set")
+	}
+	if !n.P2P.ID.IsValid() {
+		return nil, fmt.Errorf("scenario/e2e/registry: new node P2P ID is not valid")
+	}
+	if !n.Consensus.ID.IsValid() {
+		return nil, fmt.Errorf("scenario/e2e/registry: new node Consensus ID is not valid")
+	}
+
+	// Replace our testNode fields with the generated one, so we can just marshal both nodes and compare the output afterwards.
+	testNode.ID = n.ID
+	testNode.Committee.Certificate = n.Committee.Certificate
+	testNode.P2P.ID = n.P2P.ID
+	testNode.Consensus.ID = n.Consensus.ID
+
+	// Export both original and imported node to JSON and compare them.
+	nStr, _ := json.Marshal(n)
+	testNodeStr, _ := json.Marshal(testNode)
+	if !bytes.Equal(nStr, testNodeStr) {
+		return nil, fmt.Errorf("scenario/e2e/registry: test node mismatch! Original node: %s, imported node: %s", testNodeStr, nStr)
+	}
+
+	// Now run node init again, this time by reading existing dataDir and expect the same node identity and JSON output.
+	if err = os.Remove(filepath.Join(dataDir, cmdRegNode.NodeGenesisFilename)); err != nil {
+		return nil, fmt.Errorf("scenario/e2e/registry: error while removing test node genesis file: %w", err)
+	}
+	n, err = runInitNode()
+	if err != nil {
+		return nil, err
+	}
+	nStr, _ = json.Marshal(n)
+	if !bytes.Equal(nStr, testNodeStr) {
+		return nil, fmt.Errorf("scenario/e2e/registry: second run test node mismatch! Original node: %s, imported node: %s", testNodeStr, nStr)
+	}
+
+	return n, nil
+}
+
+// submitTx is a wrapper for consensus submit_tx command.
+func (r *registryCLIImpl) submitTx(childEnv *env.Env, txPath string) error {
+	return submitTx(childEnv, txPath, r.logger, r.basicImpl.net.Validators()[0].SocketPath(), r.basicImpl.net.Config().NodeBinary)
+}
+
+// genRegisterEntityTx calls registry entity gen_register.
+func (r *registryCLIImpl) genRegisterEntityTx(childEnv *env.Env, nonce int, txPath string, entDir string) error {
+	r.logger.Info("generating register entity tx")
+
+	args := []string{
+		"registry", "entity", "gen_register",
+		"--" + consensus.CfgTxNonce, strconv.Itoa(nonce),
+		"--" + consensus.CfgTxFile, txPath,
+		"--" + consensus.CfgTxFeeAmount, strconv.Itoa(0),
+		"--" + consensus.CfgTxFeeGas, strconv.Itoa(feeGas),
+		"--" + flags.CfgDebugDontBlameOasis,
+		"--" + common.CfgDebugAllowTestKeys,
+		"--" + flags.CfgEntity, entDir,
+		"--" + flags.CfgGenesisFile, r.basicImpl.net.GenesisPath(),
+	}
+	if err := runSubCommand(childEnv, "gen_register", r.basicImpl.net.Config().NodeBinary, args); err != nil {
+		return fmt.Errorf("genRegisterEntityTx: failed to generate register entity tx: %w", err)
+	}
+
+	return nil
+}
+
+// genDeregisterEntityTx calls registry entity gen_deregister.
+func (r *registryCLIImpl) genDeregisterEntityTx(childEnv *env.Env, nonce int, txPath string, entDir string) error {
+	r.logger.Info("generating register entity tx")
+
+	args := []string{
+		"registry", "entity", "gen_deregister",
+		"--" + consensus.CfgTxNonce, strconv.Itoa(nonce),
+		"--" + consensus.CfgTxFile, txPath,
+		"--" + consensus.CfgTxFeeAmount, strconv.Itoa(0),
+		"--" + consensus.CfgTxFeeGas, strconv.Itoa(feeGas),
+		"--" + flags.CfgDebugDontBlameOasis,
+		"--" + common.CfgDebugAllowTestKeys,
+		"--" + flags.CfgEntity, entDir,
+		"--" + flags.CfgGenesisFile, r.basicImpl.net.GenesisPath(),
+	}
+	if err := runSubCommand(childEnv, "gen_deregister", r.basicImpl.net.Config().NodeBinary, args); err != nil {
+		return fmt.Errorf("genDeregisterEntityTx: failed to generate deregister entity tx: %w", err)
+	}
+
+	return nil
+}
+
+// testRuntime tests registry runtime subcommands.
+func (r *registryCLIImpl) testRuntime(childEnv *env.Env) error {
+	// List runtimes.
+	runtimes, err := r.listRuntimes(childEnv)
+	if err != nil {
+		return err
+	}
+	// simple-client and keymanager runtime should be registered in our genesis block.
+	if len(runtimes) != 2 {
+		return fmt.Errorf("scenario/e2e/registry: initial runtime list wrong number of runtimes: %d, expected at least: %d. Runtimes: %v", len(runtimes), 2, runtimes)
+	}
+
+	// Create runtime descriptor instance.
+	testRuntime := registry.Runtime{
+		Kind: registry.KindCompute,
+		Compute: registry.ComputeParameters{
+			GroupSize:         1,
+			GroupBackupSize:   2,
+			AllowedStragglers: 3,
+			RoundTimeout:      4 * time.Second,
+		},
+		Merge: registry.MergeParameters{
+			GroupSize:         5,
+			GroupBackupSize:   6,
+			AllowedStragglers: 7,
+			RoundTimeout:      8 * time.Second,
+		},
+		Storage: registry.StorageParameters{
+			GroupSize: 9,
+		},
+		TxnScheduler: registry.TxnSchedulerParameters{
+			GroupSize:         10,
+			Algorithm:         "batching",
+			BatchFlushTimeout: 11 * time.Second,
+			MaxBatchSize:      12,
+			MaxBatchSizeBytes: 13,
+		},
+	}
+	// Runtime ID 0x0 is for simple-keyvalue, 0xf... is for the keymanager. Let's use 0x1.
+	_ = testRuntime.ID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000001")
+	_ = testRuntime.KeyManager.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
+
+	// Generate register runtime transaction.
+	registerTxPath := filepath.Join(childEnv.Dir(), "registry_runtime_register.json")
+	genesisStatePath := filepath.Join(childEnv.Dir(), "registry_runtime_register_genesis_state.json")
+	genesisStateStr, _ := json.Marshal(testRuntime.Genesis.State)
+	if err = ioutil.WriteFile(genesisStatePath, genesisStateStr, 0600); err != nil {
+		return err
+	}
+	if err = r.genRegisterRuntimeTx(childEnv, testRuntime, registerTxPath, genesisStatePath); err != nil {
+		return fmt.Errorf("scenario/e2e/registry/runtime: failed to generate runtime register tx: %w", err)
+	}
+
+	// Submit register runtime transaction.
+	if err = r.submitTx(childEnv, registerTxPath); err != nil {
+		return fmt.Errorf("scenario/e2e/registry/runtime: failed to submit runtime register tx: %w", err)
+	}
+
+	// List runtimes.
+	runtimes, err = r.listRuntimes(childEnv)
+	if err != nil {
+		return err
+	}
+	// Our new runtime should also be registered now.
+	if len(runtimes) != 3 {
+		return fmt.Errorf("scenario/e2e/registry: initial runtime list wrong number of runtimes: %d, expected at least: %d. Runtimes: %v", len(runtimes), 3, runtimes)
+	}
+
+	// Compare runtime descriptors.
+	rt := runtimes[testRuntime.ID]
+	rtStr, _ := json.Marshal(rt)
+	testRuntimeStr, _ := json.Marshal(testRuntime)
+	if !bytes.Equal(rtStr, testRuntimeStr) {
+		return fmt.Errorf("scenario/e2e/registry: runtime %s does not match the test one. registry one: %s, test one: %s", testRuntime.ID.String(), rtStr, testRuntimeStr)
+	}
+
+	return nil
+}
+
+// listRuntimes lists currently registered runtimes.
+func (r *registryCLIImpl) listRuntimes(childEnv *env.Env) (map[signature.PublicKey]registry.Runtime, error) {
+	r.logger.Info("listing all runtimes")
+	args := []string{
+		"registry", "runtime", "list",
+		"-v",
+		"--" + grpc.CfgAddress, "unix:" + r.basicImpl.net.Validators()[0].SocketPath(),
+	}
+	b, err := runSubCommandWithOutput(childEnv, "list", r.basicImpl.net.Config().NodeBinary, args)
+	if err != nil {
+		return nil, fmt.Errorf("scenario/e2e/registry/runtime: failed to list runtimes: %s error: %w", b.String(), err)
+	}
+	runtimesStr := strings.Split(b.String(), "\n")
+
+	runtimes := map[signature.PublicKey]registry.Runtime{}
+	for _, rtStr := range runtimesStr {
+		// Ignore last newline.
+		if rtStr == "" {
+			continue
+		}
+
+		var rt registry.Runtime
+		if err = json.Unmarshal([]byte(rtStr), &rt); err != nil {
+			return nil, err
+		}
+		runtimes[rt.ID] = rt
+	}
+
+	return runtimes, nil
+}
+
+// genRegisterRuntimeTx calls registry entity gen_register.
+func (r *registryCLIImpl) genRegisterRuntimeTx(childEnv *env.Env, runtime registry.Runtime, txPath string, genesisStateFile string) error {
+	r.logger.Info("generating register entity tx")
+
+	// Generate a runtime register transaction file with debug test entity.
+	args := []string{
+		"registry", "runtime", "gen_register",
+		"--" + cmdRegRt.CfgID, runtime.ID.String(),
+		"--" + cmdRegRt.CfgTEEHardware, runtime.TEEHardware.String(),
+		"--" + cmdRegRt.CfgGenesisState, genesisStateFile,
+		"--" + cmdRegRt.CfgKind, runtime.Kind.String(),
+		"--" + cmdRegRt.CfgKeyManager, runtime.KeyManager.String(),
+		"--" + cmdRegRt.CfgVersion, runtime.Version.Version.String(),
+		"--" + cmdRegRt.CfgVersionEnclave, string(runtime.Version.TEE),
+		"--" + cmdRegRt.CfgComputeGroupSize, strconv.FormatUint(runtime.Compute.GroupSize, 10),
+		"--" + cmdRegRt.CfgComputeGroupBackupSize, strconv.FormatUint(runtime.Compute.GroupBackupSize, 10),
+		"--" + cmdRegRt.CfgComputeAllowedStragglers, strconv.FormatUint(runtime.Compute.AllowedStragglers, 10),
+		"--" + cmdRegRt.CfgComputeRoundTimeout, runtime.Compute.RoundTimeout.String(),
+		"--" + cmdRegRt.CfgMergeGroupSize, strconv.FormatUint(runtime.Merge.GroupSize, 10),
+		"--" + cmdRegRt.CfgMergeGroupBackupSize, strconv.FormatUint(runtime.Merge.GroupBackupSize, 10),
+		"--" + cmdRegRt.CfgMergeAllowedStragglers, strconv.FormatUint(runtime.Merge.AllowedStragglers, 10),
+		"--" + cmdRegRt.CfgMergeRoundTimeout, runtime.Merge.RoundTimeout.String(),
+		"--" + cmdRegRt.CfgStorageGroupSize, strconv.FormatUint(runtime.Storage.GroupSize, 10),
+		"--" + cmdRegRt.CfgTxnSchedulerGroupSize, strconv.FormatUint(runtime.TxnScheduler.GroupSize, 10),
+		"--" + cmdRegRt.CfgTxnSchedulerAlgorithm, runtime.TxnScheduler.Algorithm,
+		"--" + cmdRegRt.CfgTxnSchedulerBatchFlushTimeout, runtime.TxnScheduler.BatchFlushTimeout.String(),
+		"--" + cmdRegRt.CfgTxnSchedulerMaxBatchSize, strconv.FormatUint(runtime.TxnScheduler.MaxBatchSize, 10),
+		"--" + cmdRegRt.CfgTxnSchedulerMaxBatchSizeBytes, strconv.FormatUint(runtime.TxnScheduler.MaxBatchSizeBytes, 10),
+		"--" + consensus.CfgTxNonce, strconv.Itoa(0),
+		"--" + consensus.CfgTxFile, txPath,
+		"--" + consensus.CfgTxFeeAmount, strconv.Itoa(0),
+		"--" + consensus.CfgTxFeeGas, strconv.Itoa(feeGas),
+		"--" + flags.CfgDebugDontBlameOasis,
+		"--" + common.CfgDebugAllowTestKeys,
+		"--" + flags.CfgDebugTestEntity,
+		"--" + flags.CfgGenesisFile, r.basicImpl.net.GenesisPath(),
+	}
+	if err := runSubCommand(childEnv, "gen_register", r.basicImpl.net.Config().NodeBinary, args); err != nil {
+		return fmt.Errorf("genRegisterRuntimeTx: failed to generate register runtime tx: %w", err)
+	}
+
+	return nil
+}

--- a/go/oasis-test-runner/scenario/e2e/stake_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/stake_cli.go
@@ -183,7 +183,7 @@ func (s *stakeCLIImpl) testTransfer(childEnv *env.Env, src signature.PublicKey, 
 		return err
 	}
 
-	if err := s.submitTx(childEnv, src, transferTxPath); err != nil {
+	if err := s.submitTx(childEnv, transferTxPath); err != nil {
 		return err
 	}
 
@@ -214,7 +214,7 @@ func (s *stakeCLIImpl) testBurn(childEnv *env.Env, src signature.PublicKey) erro
 		return err
 	}
 
-	if err := s.submitTx(childEnv, src, burnTxPath); err != nil {
+	if err := s.submitTx(childEnv, burnTxPath); err != nil {
 		return err
 	}
 
@@ -242,7 +242,7 @@ func (s *stakeCLIImpl) testEscrow(childEnv *env.Env, src signature.PublicKey, es
 		return err
 	}
 
-	if err := s.submitTx(childEnv, src, escrowTxPath); err != nil {
+	if err := s.submitTx(childEnv, escrowTxPath); err != nil {
 		return err
 	}
 
@@ -273,7 +273,7 @@ func (s *stakeCLIImpl) testReclaimEscrow(childEnv *env.Env, src signature.Public
 		return err
 	}
 
-	if err := s.submitTx(childEnv, src, reclaimEscrowTxPath); err != nil {
+	if err := s.submitTx(childEnv, reclaimEscrowTxPath); err != nil {
 		return err
 
 	}
@@ -329,7 +329,7 @@ func (s *stakeCLIImpl) testAmendCommissionSchedule(childEnv *env.Env, src signat
 		return err
 	}
 
-	if err := s.submitTx(childEnv, src, amendCommissionScheduleTxPath); err != nil {
+	if err := s.submitTx(childEnv, amendCommissionScheduleTxPath); err != nil {
 		return err
 	}
 
@@ -367,18 +367,9 @@ func (s *stakeCLIImpl) listAccounts(childEnv *env.Env) ([]signature.PublicKey, e
 	return accounts, nil
 }
 
-func (s *stakeCLIImpl) submitTx(childEnv *env.Env, src signature.PublicKey, txPath string) error {
-	s.logger.Info("submitting tx", consensus.CfgTxFile, txPath)
-	args := []string{
-		"consensus", "submit_tx",
-		"--" + consensus.CfgTxFile, txPath,
-		"--" + grpc.CfgAddress, "unix:" + s.basicImpl.net.Validators()[0].SocketPath(),
-		"--" + common.CfgDebugAllowTestKeys,
-	}
-	if err := runSubCommand(childEnv, "submit", s.basicImpl.net.Config().NodeBinary, args); err != nil {
-		return fmt.Errorf("scenario/e2e/stake: failed to submit transfer tx: %w", err)
-	}
-	return nil
+// submitTx is a wrapper for consensus submit_tx command.
+func (s *stakeCLIImpl) submitTx(childEnv *env.Env, txPath string) error {
+	return submitTx(childEnv, txPath, s.logger, s.basicImpl.net.Validators()[0].SocketPath(), s.basicImpl.net.Config().NodeBinary)
 }
 
 func (s *stakeCLIImpl) getAccountInfo(childEnv *env.Env, src signature.PublicKey) (*stake.AccountInfo, error) {

--- a/go/oasis-test-runner/test-runner.go
+++ b/go/oasis-test-runner/test-runner.go
@@ -41,6 +41,8 @@ func main() {
 	_ = cmd.Register(e2e.HaltRestore)
 	// Roothash messages test.
 	_ = cmd.Register(e2e.RoothashMessages)
+	// Registry CLI test.
+	_ = cmd.Register(e2e.RegistryCLI)
 	// Stake CLI test.
 	_ = cmd.Register(e2e.StakeCLI)
 	// Node shutdown test.


### PR DESCRIPTION
PR for #2376:
* adds `registry-cli` e2e test,
* adds `debug.dont_blame_oasis` requirement for `debug.test_entity` flag,
* replaces bunch of `--someflag` -> `--`+CfgSomeFlag,
* improves error msg for wrong entity folder permission.