### PR TITLE
go staking: reward for signing blocks

### DIFF
--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -69,7 +69,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	ConsensusProtocol = Version{Major: 0, Minor: 20, Patch: 0}
+	ConsensusProtocol = Version{Major: 0, Minor: 21, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)

--- a/go/consensus/tendermint/apps/staking/fees.go
+++ b/go/consensus/tendermint/apps/staking/fees.go
@@ -1,7 +1,6 @@
 package staking
 
 import (
-	"encoding/hex"
 	"fmt"
 
 	"github.com/tendermint/tendermint/abci/types"
@@ -9,7 +8,6 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/quantity"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
-	registryState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/registry/state"
 	stakingState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/staking/state"
 )
 
@@ -22,7 +20,6 @@ type disbursement struct {
 //
 // In case of errors the state may be inconsistent.
 func (app *stakingApplication) disburseFees(ctx *abci.Context, lastCommitInfo types.LastCommitInfo) error {
-	regState := registryState.NewMutableState(ctx.State())
 	stakeState := stakingState.NewMutableState(ctx.State())
 
 	totalFees, err := stakeState.LastBlockFees()
@@ -39,26 +36,13 @@ func (app *stakingApplication) disburseFees(ctx *abci.Context, lastCommitInfo ty
 	}
 
 	// Go through all signers of the previous block and resolve entities.
+	signingEntities := app.resolveEntityIDsFromVotes(ctx, lastCommitInfo)
+
 	var rewardAccounts []disbursement
 	var totalWeight int64
-	for _, a := range lastCommitInfo.Votes {
-		if !a.SignedLastBlock {
-			continue
-		}
-		valAddr := a.Validator.Address
-
-		// Map address to node/entity.
-		node, err := regState.NodeByConsensusAddress(valAddr)
-		if err != nil {
-			app.logger.Warn("failed to get validator node",
-				"err", err,
-				"address", hex.EncodeToString(valAddr),
-			)
-			continue
-		}
-
+	for _, entityID := range signingEntities {
 		d := disbursement{
-			id: node.EntityID,
+			id: entityID,
 			// For now we just disburse equally.
 			weight: 1,
 		}

--- a/go/consensus/tendermint/apps/staking/fees.go
+++ b/go/consensus/tendermint/apps/staking/fees.go
@@ -3,8 +3,6 @@ package staking
 import (
 	"fmt"
 
-	"github.com/tendermint/tendermint/abci/types"
-
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/quantity"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
@@ -19,7 +17,7 @@ type disbursement struct {
 // disburseFees disburses fees.
 //
 // In case of errors the state may be inconsistent.
-func (app *stakingApplication) disburseFees(ctx *abci.Context, lastCommitInfo types.LastCommitInfo) error {
+func (app *stakingApplication) disburseFees(ctx *abci.Context, signingEntities []signature.PublicKey) error {
 	stakeState := stakingState.NewMutableState(ctx.State())
 
 	totalFees, err := stakeState.LastBlockFees()
@@ -34,9 +32,6 @@ func (app *stakingApplication) disburseFees(ctx *abci.Context, lastCommitInfo ty
 		// Nothing to disburse.
 		return nil
 	}
-
-	// Go through all signers of the previous block and resolve entities.
-	signingEntities := app.resolveEntityIDsFromVotes(ctx, lastCommitInfo)
 
 	var rewardAccounts []disbursement
 	var totalWeight int64

--- a/go/consensus/tendermint/apps/staking/signing_rewards.go
+++ b/go/consensus/tendermint/apps/staking/signing_rewards.go
@@ -1,0 +1,84 @@
+package staking
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
+	stakingState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/staking/state"
+	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
+	staking "github.com/oasislabs/oasis-core/go/staking/api"
+)
+
+const (
+	SigningThresholdNumerator   = 3
+	SigningThresholdDenominator = 4
+)
+
+func (app *stakingApplication) updateEpochSigning(ctx *abci.Context, signingEntities []signature.PublicKey) error {
+	stakeState := stakingState.NewMutableState(ctx.State())
+
+	epochSigning, err := stakeState.EpochSigning()
+	if err != nil {
+		return fmt.Errorf("loading epoch signing info: %w", err)
+	}
+
+	oldTotal := epochSigning.Total
+	epochSigning.Total = oldTotal + 1
+	if epochSigning.Total <= oldTotal {
+		return fmt.Errorf("incrementing total blocks count: overflow, old_total=%d", oldTotal)
+	}
+
+	for _, entityID := range signingEntities {
+		oldCount := epochSigning.ByEntity[entityID]
+		epochSigning.ByEntity[entityID] = oldCount + 1
+		if epochSigning.ByEntity[entityID] <= oldCount {
+			return fmt.Errorf("incrementing count for entity %s: overflow, old_count=%d", entityID, oldCount)
+		}
+	}
+
+	stakeState.SetEpochSigning(epochSigning)
+
+	return nil
+}
+
+func (app *stakingApplication) rewardEpochSigning(ctx *abci.Context, time epochtime.EpochTime) error {
+	stakeState := stakingState.NewMutableState(ctx.State())
+
+	epochSigning, err := stakeState.EpochSigning()
+	if err != nil {
+		return fmt.Errorf("loading epoch signing info: %w", err)
+	}
+
+	stakeState.ClearEpochSigning()
+
+	if epochSigning.Total == 0 {
+		return nil
+	}
+
+	var eligibleEntities []signature.PublicKey
+	if epochSigning.Total > math.MaxUint64/SigningThresholdNumerator {
+		return fmt.Errorf("determining eligibility: overflow in total blocks, total=%d", epochSigning.Total)
+	}
+	for entityID, count := range epochSigning.ByEntity {
+		if count > math.MaxUint64/SigningThresholdDenominator {
+			return fmt.Errorf("determining eligibility for entity %s: overflow in threshold comparison, count=%d", entityID, count)
+		}
+		if count*SigningThresholdDenominator < epochSigning.Total*SigningThresholdNumerator {
+			continue
+		}
+		eligibleEntities = append(eligibleEntities, entityID)
+	}
+	sort.Slice(eligibleEntities, func(i, j int) bool {
+		return bytes.Compare(eligibleEntities[i][:], eligibleEntities[j][:]) < 0
+	})
+
+	if err := stakeState.AddRewards(time, staking.RewardFactorEpochSigned, eligibleEntities); err != nil {
+		return fmt.Errorf("adding rewards: %w", err)
+	}
+
+	return nil
+}

--- a/go/consensus/tendermint/apps/staking/signing_rewards.go
+++ b/go/consensus/tendermint/apps/staking/signing_rewards.go
@@ -1,11 +1,7 @@
 package staking
 
 import (
-	"bytes"
 	"fmt"
-	"math"
-	"sort"
-
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
 	stakingState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/staking/state"
@@ -21,18 +17,8 @@ func (app *stakingApplication) updateEpochSigning(ctx *abci.Context, signingEnti
 		return fmt.Errorf("loading epoch signing info: %w", err)
 	}
 
-	oldTotal := epochSigning.Total
-	epochSigning.Total = oldTotal + 1
-	if epochSigning.Total <= oldTotal {
-		return fmt.Errorf("incrementing total blocks count: overflow, old_total=%d", oldTotal)
-	}
-
-	for _, entityID := range signingEntities {
-		oldCount := epochSigning.ByEntity[entityID]
-		epochSigning.ByEntity[entityID] = oldCount + 1
-		if epochSigning.ByEntity[entityID] <= oldCount {
-			return fmt.Errorf("incrementing count for entity %s: overflow, old_count=%d", entityID, oldCount)
-		}
+	if err := epochSigning.Update(signingEntities); err != nil {
+		return err
 	}
 
 	stakeState.SetEpochSigning(epochSigning)
@@ -63,22 +49,10 @@ func (app *stakingApplication) rewardEpochSigning(ctx *abci.Context, time epocht
 		return nil
 	}
 
-	var eligibleEntities []signature.PublicKey
-	if epochSigning.Total > math.MaxUint64/params.SigningRewardThresholdNumerator {
-		return fmt.Errorf("determining eligibility: overflow in total blocks, total=%d", epochSigning.Total)
+	eligibleEntities, err := epochSigning.EligibleEntities(params.SigningRewardThresholdNumerator, params.SigningRewardThresholdDenominator)
+	if err != nil {
+		return fmt.Errorf("determining eligibility: %w", err)
 	}
-	for entityID, count := range epochSigning.ByEntity {
-		if count > math.MaxUint64/params.SigningRewardThresholdDenominator {
-			return fmt.Errorf("determining eligibility for entity %s: overflow in threshold comparison, count=%d", entityID, count)
-		}
-		if count*params.SigningRewardThresholdDenominator < epochSigning.Total*params.SigningRewardThresholdNumerator {
-			continue
-		}
-		eligibleEntities = append(eligibleEntities, entityID)
-	}
-	sort.Slice(eligibleEntities, func(i, j int) bool {
-		return bytes.Compare(eligibleEntities[i][:], eligibleEntities[j][:]) < 0
-	})
 
 	if err := stakeState.AddRewards(time, staking.RewardFactorEpochSigned, eligibleEntities); err != nil {
 		return fmt.Errorf("adding rewards: %w", err)

--- a/go/consensus/tendermint/apps/staking/state/state.go
+++ b/go/consensus/tendermint/apps/staking/state/state.go
@@ -387,21 +387,21 @@ type EpochSigning struct {
 	ByEntity map[signature.PublicKey]uint64
 }
 
-func (s *ImmutableState) EpochSigning() (EpochSigning, error) {
+func (s *ImmutableState) EpochSigning() (*EpochSigning, error) {
 	_, value := s.Snapshot.Get(epochSigningKeyFmt.Encode())
 	if value == nil {
 		// Not present means zero everything.
-		return EpochSigning{
+		return &EpochSigning{
 			ByEntity: make(map[signature.PublicKey]uint64),
 		}, nil
 	}
 
 	var es EpochSigning
 	if err := cbor.Unmarshal(value, &es); err != nil {
-		return EpochSigning{}, err
+		return nil, err
 	}
 
-	return es, nil
+	return &es, nil
 }
 
 func NewImmutableState(state *abci.ApplicationState, version int64) (*ImmutableState, error) {
@@ -469,7 +469,7 @@ func (s *MutableState) SetLastBlockFees(q *quantity.Quantity) {
 	s.tree.Set(lastBlockFeesKeyFmt.Encode(), cbor.Marshal(q))
 }
 
-func (s *MutableState) SetEpochSigning(es EpochSigning) {
+func (s *MutableState) SetEpochSigning(es *EpochSigning) {
 	s.tree.Set(epochSigningKeyFmt.Encode(), cbor.Marshal(es))
 }
 

--- a/go/consensus/tendermint/apps/staking/state/state.go
+++ b/go/consensus/tendermint/apps/staking/state/state.go
@@ -413,11 +413,12 @@ func (es *EpochSigning) EligibleEntities(thresholdNumerator, thresholdDenominato
 	if es.Total > math.MaxUint64/thresholdNumerator {
 		return nil, fmt.Errorf("overflow in total blocks, total=%d", es.Total)
 	}
+	thresholdPremultiplied := es.Total * thresholdNumerator
 	for entityID, count := range es.ByEntity {
 		if count > math.MaxUint64/thresholdDenominator {
 			return nil, fmt.Errorf("entity %s: overflow in threshold comparison, count=%d", entityID, count)
 		}
-		if count*thresholdDenominator < es.Total*thresholdNumerator {
+		if count*thresholdDenominator < thresholdPremultiplied {
 			continue
 		}
 		eligibleEntities = append(eligibleEntities, entityID)

--- a/go/consensus/tendermint/apps/staking/votes.go
+++ b/go/consensus/tendermint/apps/staking/votes.go
@@ -1,0 +1,37 @@
+package staking
+
+import (
+	"encoding/hex"
+
+	"github.com/tendermint/tendermint/abci/types"
+
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
+	registryState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/registry/state"
+)
+
+func (app *stakingApplication) resolveEntityIDsFromVotes(ctx *abci.Context, lastCommitInfo types.LastCommitInfo) []signature.PublicKey {
+	regState := registryState.NewMutableState(ctx.State())
+
+	var entityIDs []signature.PublicKey
+	for _, a := range lastCommitInfo.Votes {
+		if !a.SignedLastBlock {
+			continue
+		}
+		valAddr := a.Validator.Address
+
+		// Map address to node/entity.
+		node, err := regState.NodeByConsensusAddress(valAddr)
+		if err != nil {
+			app.logger.Warn("failed to get validator node",
+				"err", err,
+				"address", hex.EncodeToString(valAddr),
+			)
+			continue
+		}
+
+		entityIDs = append(entityIDs, node.EntityID)
+	}
+
+	return entityIDs
+}

--- a/go/genesis/api/api_test.go
+++ b/go/genesis/api/api_test.go
@@ -101,7 +101,7 @@ func TestGenesisChainContext(t *testing.T) {
 	//       on each run.
 	stableDoc.Staking = staking.Genesis{}
 
-	require.Equal(t, stableDoc.ChainContext(), "daba5eed9f82d37c76384f9f185dc0bfff60eb57a33b7d8955e265244e0a0a51")
+	require.Equal(t, "daba5eed9f82d37c76384f9f185dc0bfff60eb57a33b7d8955e265244e0a0a51", stableDoc.ChainContext())
 }
 
 func TestGenesisSanityCheck(t *testing.T) {

--- a/go/scheduler/api/api.go
+++ b/go/scheduler/api/api.go
@@ -4,7 +4,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"strings"
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
@@ -223,8 +222,4 @@ func (g *Genesis) SanityCheck() error {
 
 func init() {
 	RewardFactorEpochElectionAny = quantity.NewQuantity()
-	err := RewardFactorEpochElectionAny.FromBigInt(big.NewInt(1))
-	if err != nil {
-		panic(err)
-	}
 }

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -29,8 +29,8 @@ const (
 )
 
 var (
-	// RewardFactorEpochSigned is the factor for a reward
-	// distributed per epoch to entities that have signed 3/4 of the blocks.
+	// RewardFactorEpochSigned is the factor for a reward distributed per epoch to
+	// entities that have signed at least a threshold fraction of the blocks.
 	RewardFactorEpochSigned *quantity.Quantity
 
 	// ErrInvalidArgument is the error returned on malformed arguments.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -390,14 +390,16 @@ type Genesis struct {
 
 // ConsensusParameters are the staking consensus parameters.
 type ConsensusParameters struct {
-	Thresholds              map[ThresholdKind]quantity.Quantity `json:"thresholds,omitempty"`
-	DebondingInterval       epochtime.EpochTime                 `json:"debonding_interval,omitempty"`
-	RewardSchedule          []RewardStep                        `json:"reward_schedule,omitempty"`
-	CommissionScheduleRules CommissionScheduleRules             `json:"commission_schedule_rules,omitempty"`
-	AcceptableTransferPeers map[signature.PublicKey]bool        `json:"acceptable_transfer_peers,omitempty"`
-	Slashing                map[SlashReason]Slash               `json:"slashing,omitempty"`
-	GasCosts                transaction.Costs                   `json:"gas_costs,omitempty"`
-	MinDelegationAmount     quantity.Quantity                   `json:"min_delegation,omitempty"`
+	Thresholds                        map[ThresholdKind]quantity.Quantity `json:"thresholds,omitempty"`
+	DebondingInterval                 epochtime.EpochTime                 `json:"debonding_interval,omitempty"`
+	RewardSchedule                    []RewardStep                        `json:"reward_schedule,omitempty"`
+	SigningRewardThresholdNumerator   uint64                              `json:"signing_reward_threshold_numerator,omitempty"`
+	SigningRewardThresholdDenominator uint64                              `json:"signing_reward_threshold_denominator,omitempty"`
+	CommissionScheduleRules           CommissionScheduleRules             `json:"commission_schedule_rules,omitempty"`
+	AcceptableTransferPeers           map[signature.PublicKey]bool        `json:"acceptable_transfer_peers,omitempty"`
+	Slashing                          map[SlashReason]Slash               `json:"slashing,omitempty"`
+	GasCosts                          transaction.Costs                   `json:"gas_costs,omitempty"`
+	MinDelegationAmount               quantity.Quantity                   `json:"min_delegation,omitempty"`
 }
 
 const (

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -29,6 +29,10 @@ const (
 )
 
 var (
+	// RewardFactorEpochSigned is the factor for a reward
+	// distributed per epoch to entities that have signed 3/4 of the blocks.
+	RewardFactorEpochSigned *quantity.Quantity
+
 	// ErrInvalidArgument is the error returned on malformed arguments.
 	ErrInvalidArgument = errors.New(ModuleName, 1, "staking: invalid argument")
 
@@ -557,4 +561,11 @@ func (g *Genesis) SanityCheck(now epochtime.EpochTime) error { // nolint: gocycl
 	}
 
 	return nil
+}
+
+func init() {
+	RewardFactorEpochSigned = quantity.NewQuantity()
+	if err := RewardFactorEpochSigned.FromInt64(1); err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
blocks #2434

Give entities a reward on their staked amount when they sign 3/4 of the blocks of an epoch.

Relies on the property that an entity can have at most one node on the validator committee.

In this implementation, the staking mux app counts up how many blocks are created and how many each entity is seen signing. At the end of an epoch, we check which entities meet the 3/4 threshold and add rewards and reset the count.
