### PR TITLE
go/registry: Reject node registrations with duplicate keys

### DIFF
--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -162,7 +162,15 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 		)
 		return err
 	}
-	newNode, err := registry.VerifyRegisterNodeArgs(params, app.logger, sigNode, untrustedEntity, ctx.Now(), ctx.IsInitChain(), regRuntimes)
+	regNodes, err := state.Nodes()
+	if err != nil {
+		app.logger.Error("RegisterNode: failed to obtain registry nodes",
+			"err", err,
+			"signed_node", sigNode,
+		)
+		return err
+	}
+	newNode, err := registry.VerifyRegisterNodeArgs(params, app.logger, sigNode, untrustedEntity, ctx.Now(), ctx.IsInitChain(), regRuntimes, regNodes)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #2421.