### PR TITLE
roothash/api: rename Genesis.Blocks -> RuntimeStates

### DIFF
--- a/.changelog/2426.breaking.md
+++ b/.changelog/2426.breaking.md
@@ -1,0 +1,7 @@
+Refactoring of roothash genesis block for runtime.
+
+- `RuntimeGenesis.Round` field was added to the roothash block for the runtime
+which can be set by `--runtime.genesis.round` flag.
+- The `RuntimeGenesis.StorageReceipt` field was replaced by `StorageReceipts` list,
+one for each storage node.
+- Support for `base64` encoding/decoding of `Bytes` was added in rust.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,7 @@ dependencies = [
 name = "oasis-core-keymanager-api"
 version = "0.3.0-alpha"
 dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "oasis-core-runtime 0.3.0-alpha",

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -382,12 +382,18 @@ func (app *rootHashApplication) onNewRuntime(ctx *abci.Context, runtime *registr
 	}
 
 	// Create genesis block.
-	genesisBlock := genesis.Blocks[runtime.ID]
-	if genesisBlock == nil {
-		now := ctx.Now().Unix()
-		genesisBlock = block.NewGenesisBlock(runtime.ID, uint64(now))
-		if !runtime.Genesis.StateRoot.IsEmpty() {
-			genesisBlock.Header.StateRoot = runtime.Genesis.StateRoot
+	now := ctx.Now().Unix()
+	genesisBlock := block.NewGenesisBlock(runtime.ID, uint64(now))
+	// Fill the Header fields with Genesis runtime states, if this was called during InitChain().
+	genesisBlock.Header.Round = runtime.Genesis.Round
+	genesisBlock.Header.StateRoot = runtime.Genesis.StateRoot
+	genesisBlock.Header.StorageSignatures = runtime.Genesis.StorageReceipts
+	if ctx.IsInitChain() {
+		genesisRts := genesis.RuntimeStates[runtime.ID]
+		if genesisRts != nil {
+			genesisBlock.Header.Round = genesisRts.Round
+			genesisBlock.Header.StateRoot = genesisRts.StateRoot
+			genesisBlock.Header.StorageSignatures = runtime.Genesis.StorageReceipts
 		}
 	}
 

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -98,6 +98,7 @@ func NewDefaultFixture() (*oasis.NetworkFixture, error) {
 				},
 				Storage:      registry.StorageParameters{GroupSize: 1},
 				GenesisState: viper.GetString(cfgRuntimeGenesisState),
+				GenesisRound: 0,
 			},
 		},
 		Validators: []oasis.ValidatorFixture{

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -38,6 +38,7 @@ const (
 	CfgID             = "runtime.id"
 	CfgTEEHardware    = "runtime.tee_hardware"
 	CfgGenesisState   = "runtime.genesis.state"
+	CfgGenesisRound   = "runtime.genesis.round"
 	CfgKind           = "runtime.kind"
 	CfgKeyManager     = "runtime.keymanager"
 	cfgOutput         = "runtime.genesis.file"
@@ -264,6 +265,7 @@ func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) {
 
 	// TODO: Support root upload when registering.
 	gen := registry.RuntimeGenesis{}
+	gen.Round = viper.GetUint64(CfgGenesisRound)
 	switch state := viper.GetString(CfgGenesisState); state {
 	case "":
 		gen.StateRoot.Empty()
@@ -431,6 +433,7 @@ func init() {
 	runtimeFlags.String(CfgID, "", "Runtime ID")
 	runtimeFlags.String(CfgTEEHardware, "invalid", "Type of TEE hardware.  Supported values are \"invalid\" and \"intel-sgx\"")
 	runtimeFlags.String(CfgGenesisState, "", "Runtime state at genesis")
+	runtimeFlags.Uint64(CfgGenesisRound, 0, "Runtime round at genesis")
 	runtimeFlags.String(CfgKeyManager, "", "Key Manager Runtime ID")
 	runtimeFlags.String(CfgKind, "compute", "Kind of runtime.  Supported values are \"compute\" and \"keymanager\"")
 	runtimeFlags.String(CfgVersion, "", "Runtime version. Value is 64-bit hex e.g. 0x0000000100020003 for 1.2.3")

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -157,6 +157,7 @@ type RuntimeFixture struct {
 
 	Binary       string `json:"binary"`
 	GenesisState string `json:"genesis_state"`
+	GenesisRound uint64 `json:"genesis_round"`
 
 	Compute      registry.ComputeParameters      `json:"compute"`
 	Merge        registry.MergeParameters        `json:"merge"`
@@ -198,6 +199,7 @@ func (f *RuntimeFixture) Create(netFixture *NetworkFixture, net *Network) (*Runt
 		Storage:      f.Storage,
 		Binary:       f.Binary,
 		GenesisState: f.GenesisState,
+		GenesisRound: f.GenesisRound,
 		Pruner:       f.Pruner,
 	})
 }

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -45,6 +45,7 @@ type RuntimeCfg struct { // nolint: maligned
 
 	Binary       string
 	GenesisState string
+	GenesisRound uint64
 
 	Compute      registry.ComputeParameters
 	Merge        registry.MergeParameters
@@ -88,6 +89,7 @@ func (net *Network) NewRuntime(cfg *RuntimeCfg) (*Runtime, error) {
 		"--" + common.CfgDataDir, rtDir.String(),
 		"--" + cmdRegRt.CfgID, cfg.ID.String(),
 		"--" + cmdRegRt.CfgKind, cfg.Kind.String(),
+		"--" + cmdRegRt.CfgGenesisRound, strconv.FormatUint(cfg.GenesisRound, 10),
 	}
 	if cfg.Kind == registry.KindCompute {
 		args = append(args, []string{

--- a/go/oasis-test-runner/scenario/e2e/halt_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/halt_restore.go
@@ -183,6 +183,7 @@ func (sc *haltRestoreImpl) Run(childEnv *env.Env) error {
 	if err != nil {
 		sc.logger.Error("scenario/e2e/halt_restore: failed getting genesis file provider",
 			"err", err,
+			"genesis_file", files[0],
 		)
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -663,6 +663,7 @@ func (r *registryCLIImpl) genRegisterRuntimeTx(childEnv *env.Env, runtime regist
 		"--" + cmdRegRt.CfgID, runtime.ID.String(),
 		"--" + cmdRegRt.CfgTEEHardware, runtime.TEEHardware.String(),
 		"--" + cmdRegRt.CfgGenesisState, genesisStateFile,
+		"--" + cmdRegRt.CfgGenesisRound, strconv.FormatUint(runtime.Genesis.Round, 10),
 		"--" + cmdRegRt.CfgKind, runtime.Kind.String(),
 		"--" + cmdRegRt.CfgVersion, runtime.Version.Version.String(),
 		"--" + cmdRegRt.CfgVersionEnclave, string(runtime.Version.TEE),

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -889,8 +889,11 @@ func VerifyRegisterRuntimeArgs(logger *logging.Logger, sigRt *SignedRuntime, isG
 	}
 
 	if !isGenesis && !rt.Genesis.StateRoot.IsEmpty() {
-		// TODO: Verify storage receipt for the state root, reject such registrations for now.
+		// TODO: Verify storage receipt for the state root, reject such registrations for now. See oasis-core#1686.
 		return nil, ErrInvalidArgument
+	}
+	if err := rt.Genesis.SanityCheck(isGenesis); err != nil {
+		return nil, err
 	}
 
 	// Ensure there is at least one member of the compute group.

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -1066,10 +1066,10 @@ func NewTestRuntime(seed []byte, entity *TestEntity) (*TestRuntime, error) {
 		},
 		Storage: api.StorageParameters{GroupSize: 3},
 		Genesis: api.RuntimeGenesis{
-			StorageReceipt: signature.Signature{
+			StorageReceipts: []signature.Signature{{
 				// We don't want an invalid public key so we pass something.
 				PublicKey: rt.Signer.Public(),
-			},
+			}},
 		},
 	}
 	if entity != nil {

--- a/keymanager-runtime/api/Cargo.toml
+++ b/keymanager-runtime/api/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.0-alpha"
 authors = ["Oasis Labs Inc. <info@oasislabs.com>"]
 
 [dependencies]
+base64 = "0.10.1"
 oasis-core-runtime = { path = "../../runtime" }
 serde = "1.0.71"
 serde_derive = "1.0"

--- a/keymanager-runtime/api/src/api.rs
+++ b/keymanager-runtime/api/src/api.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use base64;
 use failure::Fail;
 use rand::{rngs::OsRng, Rng};
 use serde_derive::{Deserialize, Serialize};

--- a/keymanager-runtime/api/src/lib.rs
+++ b/keymanager-runtime/api/src/lib.rs
@@ -1,4 +1,5 @@
 //! Key manager API.
+extern crate base64;
 extern crate failure;
 extern crate lazy_static;
 extern crate oasis_core_runtime;

--- a/runtime/src/common/mod.rs
+++ b/runtime/src/common/mod.rs
@@ -6,6 +6,7 @@ pub mod cbor;
 pub mod crypto;
 pub mod key_format;
 pub mod logger;
+pub mod registry;
 pub mod roothash;
 pub mod runtime;
 pub mod sgx;

--- a/runtime/src/common/registry.rs
+++ b/runtime/src/common/registry.rs
@@ -1,0 +1,31 @@
+//! Registry structures.
+//!
+//! # Note
+//!
+//! This **MUST** be kept in sync with go/registry/api.
+//!
+use super::{
+    super::storage::mkvs::WriteLog,
+    crypto::{hash, signature::SignatureBundle},
+};
+use serde_derive::{Deserialize, Serialize};
+
+/// Runtime genesis information that is used to initialize runtime state in the first block.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RuntimeGenesis {
+    /// State root that should be used at genesis time. If the runtime should start with empty state,
+    /// this must be set to the empty hash.
+    pub state_root: hash::Hash,
+
+    /// State identified by the state_root. It may be empty iff all storage_receipts are valid or
+    /// state_root is an empty hash or if used in network genesis (e.g. during consensus chain init).
+    pub state: WriteLog,
+
+    /// Storage receipts for the state root. The list may be empty or a signature in the list
+    /// invalid iff the state is non-empty or state_root is an empty hash or if used in network
+    /// genesis (e.g. during consensus chain init).
+    pub storage_receipts: Vec<SignatureBundle>,
+
+    /// Runtime round in the genesis.
+    pub round: u64,
+}


### PR DESCRIPTION
PR for #2426:
- replaces `roothash.Genesis.Blocks` with map storing `api.RuntimeGenesis` objects,
- adds `RuntimeGenesis.Round` and `--runtime.genesis.round` flag,
- on `InitChain()` generates runtime genesis block using `RuntimeGenesis` instead of block,
- replaces `RuntimeGenesis.StorageReceipt` with `StorageReceipts` i.e. one receipt per storage node,
- adds sanity checks for `RuntimeGenesis` including `StorageSignatures` verification of `StateRoot` and tests for it,
- adds `RuntimeGenesis` struct to rust,
- adds base64 serialization/deserialization of `Bytes` in rust.