### PR TITLE
Temporarily disable p2p id checks (for public testnet upgrade)

### DIFF
--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -501,10 +501,12 @@ func VerifyRegisterNodeArgs( // nolint: gocyclo
 
 	// Validate P2PInfo.
 	if !n.P2P.ID.IsValid() {
-		logger.Error("RegisterNode: invalid P2P id",
+		// XXX: Validate P2P.ID after existing deployments have cleared up registry.
+		// https://github.com/oasislabs/oasis-core/issues/2428
+		logger.Warn("RegisterNode: invalid P2P id",
 			"node", n,
 		)
-		return nil, ErrInvalidArgument
+		//return nil, ErrInvalidArgument
 	}
 	p2pAddressRequired := n.HasRoles(P2PAddressRequiredRoles)
 	if err := verifyAddresses(params, p2pAddressRequired, n.P2P.Addresses); err != nil {
@@ -554,11 +556,13 @@ func VerifyRegisterNodeArgs( // nolint: gocyclo
 		return nil, ErrInvalidArgument
 	}
 	if existingNode != nil && existingNode.ID != n.ID {
-		logger.Error("RegisterNode: duplicate node p2p ID",
+		// XXX: Validate P2P.ID after existing deployments have cleared up registry.
+		// https://github.com/oasislabs/oasis-core/issues/2428
+		logger.Warn("RegisterNode: duplicate node p2p ID",
 			"node_id", n.ID,
 			"existing_node_id", existingNode.ID,
 		)
-		return nil, ErrInvalidArgument
+		//return nil, ErrInvalidArgument
 	}
 
 	existingNode, err = nodeLookup.NodeByCertificate(n.Committee.Certificate)

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -159,11 +159,13 @@ func testRegistryEntityNodes( // nolint: gocyclo
 				require.Error(err, "register node with reserved roles")
 				require.Equal(err, api.ErrInvalidArgument)
 
-				if v.Node.Roles&node.RoleComputeWorker != 0 {
-					err = v.Register(consensus, v.SignedInvalidRegistration6)
-					require.Error(err, "register node without a valid p2p id")
-					require.Equal(err, api.ErrInvalidArgument)
-				}
+				// XXX: Validate P2P.ID after existing deployments have cleared up registry.
+				// https://github.com/oasislabs/oasis-core/issues/2428
+				// if v.Node.Roles&node.RoleComputeWorker != 0 {
+				// 	err = v.Register(consensus, v.SignedInvalidRegistration6)
+				// 	require.Error(err, "register node without a valid p2p id")
+				// 	require.Equal(err, api.ErrInvalidArgument)
+				//}
 
 				err = v.Register(consensus, v.SignedInvalidRegistration7)
 				require.Error(err, "register node without runtimes")
@@ -197,9 +199,11 @@ func testRegistryEntityNodes( // nolint: gocyclo
 				require.NoError(err, "GetNode")
 				require.EqualValues(v.Node, nod, "retrieved node")
 
-				err = v.Register(consensus, v.SignedInvalidRegistration11)
-				require.Error(err, "register node with duplicate p2p id")
-				require.Equal(err, api.ErrInvalidArgument)
+				// XXX: Validate P2P.ID after existing deployments have cleared up registry.
+				// https://github.com/oasislabs/oasis-core/issues/2428
+				// err = v.Register(consensus, v.SignedInvalidRegistration11)
+				// require.Error(err, "register node with duplicate p2p id")
+				// require.Equal(err, api.ErrInvalidArgument)
 
 				err = v.Register(consensus, v.SignedInvalidRegistration12)
 				require.Error(err, "register node with duplicate consensus id")


### PR DESCRIPTION
Related to https://github.com/oasislabs/oasis-core/issues/2428. For compatibility with dumps from networks running pre-https://github.com/oasislabs/oasis-core/pull/2424 versions of oasis-node, we need to accept 0-valued p2p ids.