### PR TITLE
 Hash should be base64 encoded in JSON

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -194,7 +194,7 @@ steps:
       - .buildkite/scripts/test_e2e.sh
     artifact_paths:
       - e2e/**/*.log
-      - coverage-e2e-*.txt
+      - coverage-e2e-*.tar.gz
     env:
       OASIS_E2E_COVERAGE: enable
       TEST_BASE_DIR: e2e
@@ -214,7 +214,7 @@ steps:
       - .buildkite/scripts/test_e2e.sh
     artifact_paths:
       - e2e/**/*.log
-      - coverage-e2e-*.txt
+      - coverage-e2e-sgx-*.tar.gz
     env:
       OASIS_E2E_COVERAGE: enable
       TEST_BASE_DIR: e2e
@@ -264,9 +264,7 @@ steps:
 
   - label: "Merge and upload coverage"
     command:
-      - mkdir -p /tmp/coverage-to-merge
-      - buildkite-agent artifact download "coverage-*.txt" /tmp/coverage-to-merge
-      - gocovmerge /tmp/coverage-to-merge/coverage-*.txt >merged-coverage.txt
+      - .buildkite/scripts/merge_coverage.sh
       - .buildkite/scripts/upload_coverage.sh
     artifact_paths:
       - merged-coverage.txt

--- a/.buildkite/scripts/merge_coverage.sh
+++ b/.buildkite/scripts/merge_coverage.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Helpful tips on writing build scripts:
+# https://buildkite.com/docs/pipelines/writing-build-scripts
+set -euxo pipefail
+
+# Working directory.
+WORKDIR=$PWD
+
+mkdir -p /tmp/coverage-to-merge
+
+buildkite-agent artifact download "coverage-*.txt" /tmp/coverage-to-merge
+buildkite-agent artifact download "coverage-e2e-*.tar.gz" /tmp/coverage-to-merge
+
+for f in /tmp/coverage-to-merge/*.tar.gz; do
+	tar xvzf $f -C /tmp/coverage-to-merge
+done
+gocovmerge /tmp/coverage-to-merge/coverage-*.txt >merged-coverage.txt

--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -48,3 +48,14 @@ ${WORKDIR}/go/oasis-test-runner/oasis-test-runner \
     ${BUILDKITE_PARALLEL_JOB_COUNT:+--parallel.job_count ${BUILDKITE_PARALLEL_JOB_COUNT}} \
     ${BUILDKITE_PARALLEL_JOB:+--parallel.job_index ${BUILDKITE_PARALLEL_JOB}} \
     "$@"
+
+# Gather the coverage output.
+if [[ "${BUILDKITE:-""}" != "" ]]; then
+    if [[ ${OASIS_E2E_COVERAGE:-""} != "" ]]; then
+        if [[ "${OASIS_TEE_HARDWARE:-""}" == "intel-sgx" ]]; then
+            tar -zvcf coverage-e2e-sgx-${BUILDKITE_PARALLEL_JOB}.tar.gz coverage-e2e-*.txt
+        else
+            tar -zvcf coverage-e2e-${BUILDKITE_PARALLEL_JOB}.tar.gz coverage-e2e-*.txt
+        fi
+    fi
+fi

--- a/go/common/crypto/hash/hash.go
+++ b/go/common/crypto/hash/hash.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha512"
 	"crypto/subtle"
 	"encoding"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 
@@ -42,6 +43,21 @@ func (h *Hash) UnmarshalBinary(data []byte) error {
 	copy(h[:], data)
 
 	return nil
+}
+
+// MarshalText encodes a Hash into text form.
+func (h Hash) MarshalText() (data []byte, err error) {
+	return []byte(base64.StdEncoding.EncodeToString(h[:])), nil
+}
+
+// UnmarshalText decodes a text marshaled Hash.
+func (h *Hash) UnmarshalText(text []byte) error {
+	b, err := base64.StdEncoding.DecodeString(string(text))
+	if err != nil {
+		return err
+	}
+
+	return h.UnmarshalBinary(b)
 }
 
 // UnmarshalHex deserializes a hexadecimal text string into the given type.

--- a/go/common/namespace.go
+++ b/go/common/namespace.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"encoding"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 
@@ -41,6 +42,21 @@ func (n *Namespace) UnmarshalBinary(data []byte) error {
 	copy(n[:], data)
 
 	return nil
+}
+
+// MarshalText encodes a namespace identifier into text form.
+func (n Namespace) MarshalText() (data []byte, err error) {
+	return []byte(base64.StdEncoding.EncodeToString(n[:])), nil
+}
+
+// UnmarshalText decodes a text marshaled namespace identifier.
+func (n *Namespace) UnmarshalText(text []byte) error {
+	b, err := base64.StdEncoding.DecodeString(string(text))
+	if err != nil {
+		return err
+	}
+
+	return n.UnmarshalBinary(b)
 }
 
 // Equal compares vs another namespace for equality.


### PR DESCRIPTION
Fixes #2476

 * [x] buildkite: Hide the e2e coverage output from integration test artifacts.
 * ~buildkite: Add more useful artifacts for certain tests.~ (Too spammy)
 * [x] Fix the encoding issues that show up in the genesis dump.