### PR TITLE
go/sentry/grpc: fix GetConsensusAddresses client method

### DIFF
--- a/go/sentry/api/grpc.go
+++ b/go/sentry/api/grpc.go
@@ -60,7 +60,7 @@ type sentryClient struct {
 
 func (c *sentryClient) GetConsensusAddresses(ctx context.Context) ([]node.ConsensusAddress, error) {
 	var rsp []node.ConsensusAddress
-	if err := c.conn.Invoke(ctx, methodGetConsensusAddresses.Full(), nil, rsp); err != nil {
+	if err := c.conn.Invoke(ctx, methodGetConsensusAddresses.Full(), nil, &rsp); err != nil {
 		return nil, err
 	}
 	return rsp, nil


### PR DESCRIPTION
Checked other clients as well, seems like all others are fine.

TODO:
- [x] open an issue to test node re-registration in the sentry e2e test (since it is a very distinct code path) - https://github.com/oasislabs/oasis-core/issues/2488