### PR TITLE
go/oasis-node: Add the `unsafe-reset` sub-command

### DIFF
--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -94,6 +94,10 @@ const (
 
 	// CfgConsensusMinGasPrice configures the minimum gas price for this validator.
 	CfgConsensusMinGasPrice = "consensus.tendermint.min_gas_price"
+
+	// StateDir is the name of the directory located inside the node's data
+	// directory which contains the tendermint state.
+	StateDir = "tendermint"
 )
 
 var (
@@ -822,7 +826,7 @@ func (t *tendermintService) lazyInit() error {
 	// Tendermint needs the on-disk directories to be present when
 	// launched like this, so create the relevant sub-directories
 	// under the node DataDir.
-	tendermintDataDir := filepath.Join(t.dataDir, "tendermint")
+	tendermintDataDir := filepath.Join(t.dataDir, StateDir)
 	if err = initDataDir(tendermintDataDir); err != nil {
 		return err
 	}

--- a/go/oasis-node/cmd/common/flags/flags.go
+++ b/go/oasis-node/cmd/common/flags/flags.go
@@ -32,6 +32,9 @@ const (
 	CfgSignerDir           = "signer.dir"
 	cfgSignerLedgerAddress = "signer.ledger.address"
 	cfgSignerLedgerIndex   = "signer.ledger.index"
+
+	// CfgDryRun is the flag used to specify a dry-run of an operation.
+	CfgDryRun = "dry_run"
 )
 
 var (
@@ -52,6 +55,9 @@ var (
 	ConsensusValidatorFlag = flag.NewFlagSet("", flag.ContinueOnError)
 	// DebugDontBlameOasisFlag has the "don't blame oasis" flag.
 	DebugDontBlameOasisFlag = flag.NewFlagSet("", flag.ContinueOnError)
+
+	// DryRunFlag has the dry-run flag.
+	DryRunFlag = flag.NewFlagSet("", flag.ContinueOnError)
 )
 
 // Verbose returns true iff the verbose flag is set.
@@ -117,6 +123,11 @@ func DebugDontBlameOasis() bool {
 	return viper.GetBool(CfgDebugDontBlameOasis)
 }
 
+// DryRun returns true iff the dry-run flag is set.
+func DryRun() bool {
+	return viper.GetBool(CfgDryRun)
+}
+
 func init() {
 	VerboseFlags.BoolP(cfgVerbose, "v", false, "verbose output")
 
@@ -139,6 +150,8 @@ func init() {
 	DebugDontBlameOasisFlag.Bool(CfgDebugDontBlameOasis, false, "Enable debug/unsafe/insecure options")
 	_ = DebugDontBlameOasisFlag.MarkHidden(CfgDebugDontBlameOasis)
 
+	DryRunFlag.BoolP(CfgDryRun, "n", false, "don't actually do anything, just show what will be done")
+
 	for _, v := range []*flag.FlagSet{
 		VerboseFlags,
 		ForceFlags,
@@ -148,6 +161,7 @@ func init() {
 		GenesisFileFlags,
 		ConsensusValidatorFlag,
 		DebugDontBlameOasisFlag,
+		DryRunFlag,
 	} {
 		_ = viper.BindPFlags(v)
 	}

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -774,6 +774,15 @@ func newNode(testNode bool) (*Node, error) {
 	return node, nil
 }
 
+// Register registers the node maintenance sub-commands and all of it's
+// children.
+func Register(parentCmd *cobra.Command) {
+	unsafeResetCmd.Flags().AddFlagSet(flags.DryRunFlag)
+	unsafeResetCmd.Flags().AddFlagSet(unsafeResetFlags)
+
+	parentCmd.AddCommand(unsafeResetCmd)
+}
+
 func init() {
 	Flags.AddFlagSet(flags.DebugTestEntityFlags)
 	Flags.AddFlagSet(flags.ConsensusValidatorFlag)

--- a/go/oasis-node/cmd/node/unsafe_reset.go
+++ b/go/oasis-node/cmd/node/unsafe_reset.go
@@ -1,0 +1,132 @@
+package node
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/oasislabs/oasis-core/go/common/logging"
+	"github.com/oasislabs/oasis-core/go/consensus/tendermint"
+	cmdCommon "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	cmdFlags "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
+	runtimeRegistry "github.com/oasislabs/oasis-core/go/runtime/registry"
+)
+
+const (
+	// CfgPreserveLocalStorage exempts the untrusted local storage from
+	// the unsafe-reset sub-command.
+	CfgPreserveLocalStorage = "preserve.local_storage"
+
+	// CfgPreserveMKVSDatabase exempts the MKVS database from the unsafe-reset
+	// sub-command.
+	CfgPreserveMKVSDatabase = "preserve.mkvs_database"
+)
+
+var (
+	unsafeResetFlags = flag.NewFlagSet("", flag.ContinueOnError)
+
+	unsafeResetCmd = &cobra.Command{
+		Use:   "unsafe-reset",
+		Short: "reset the node state (UNSAFE)",
+		Run:   doUnsafeReset,
+	}
+
+	nodeStateGlobs = []string{
+		"abci-mux-state.*.db",
+		"persistent-store.*.db",
+		tendermint.StateDir,
+		runtimeRegistry.RuntimesDir,
+	}
+
+	localStorageGlob = "worker-local-storage.*.db"
+	mkvsDatabaseGlob = "mkvs_storage.*.db"
+
+	logger = logging.GetLogger("cmd/unsafe-reset")
+)
+
+func doUnsafeReset(cmd *cobra.Command, args []string) {
+	var ok bool
+	defer func() {
+		if !ok {
+			os.Exit(1)
+		}
+	}()
+
+	if err := cmdCommon.Init(); err != nil {
+		cmdCommon.EarlyLogAndExit(err)
+	}
+
+	dataDir := cmdCommon.DataDir()
+	if dataDir == "" {
+		logger.Error("data directory must be set")
+		return
+	}
+
+	isDryRun := cmdFlags.DryRun()
+	if isDryRun {
+		logger.Info("dry run, no modifications will be made to files")
+	}
+
+	globs := append([]string{}, nodeStateGlobs...)
+	if viper.GetBool(CfgPreserveLocalStorage) {
+		logger.Info("preserving untrusted local storage")
+	} else {
+		globs = append(globs, localStorageGlob)
+	}
+	if viper.GetBool(CfgPreserveMKVSDatabase) {
+		logger.Info("preserving MKVS database")
+	} else {
+		globs = append(globs, mkvsDatabaseGlob)
+	}
+
+	// Enumerate the locations to purge.
+	var pathsToPurge []string
+	for _, v := range globs {
+		glob := filepath.Join(dataDir, v)
+		matches, err := filepath.Glob(glob)
+		if err != nil {
+			logger.Warn("failed to glob purge target",
+				"err", err,
+				"glob", glob,
+			)
+			return
+		}
+
+		if len(matches) == 0 {
+			logger.Debug("candidate state location does not exist",
+				"glob", glob,
+			)
+		} else {
+			pathsToPurge = append(pathsToPurge, matches...)
+		}
+	}
+
+	// Obliterate the state.
+	for _, v := range pathsToPurge {
+		logger.Info("removing on-disk node state",
+			"path", v,
+		)
+
+		if !isDryRun {
+			if err := os.RemoveAll(v); err != nil {
+				logger.Error("failed to remove on-disk node state",
+					"err", err,
+					"path", v,
+				)
+			}
+		}
+	}
+
+	logger.Info("state reset complete")
+
+	ok = true
+}
+
+func init() {
+	unsafeResetFlags.Bool(CfgPreserveLocalStorage, false, "preserve untrusted local storage")
+	unsafeResetFlags.Bool(CfgPreserveMKVSDatabase, false, "preserve MKVS database")
+	_ = viper.BindPFlags(unsafeResetFlags)
+}

--- a/go/oasis-node/cmd/root.go
+++ b/go/oasis-node/cmd/root.go
@@ -82,6 +82,7 @@ func init() {
 		stake.Register,
 		storage.Register,
 		consensus.Register,
+		node.Register,
 	} {
 		v(rootCmd)
 	}

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -81,6 +81,11 @@ func (n *Node) LogPath() string {
 	return nodeLogPath(n.dir)
 }
 
+// DataDir returns the path to the node's data directory.
+func (n *Node) DataDir() string {
+	return n.dir.String()
+}
+
 func (n *Node) stopNode() error {
 	if n.cmd == nil {
 		return nil

--- a/go/oasis-test-runner/scenario/e2e/dump_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/dump_restore.go
@@ -68,7 +68,7 @@ func (sc *dumpRestoreImpl) Run(childEnv *env.Env) error {
 	// Stop the network.
 	sc.logger.Info("stopping the network")
 	sc.basicImpl.net.Stop()
-	if err = sc.basicImpl.cleanTendermintStorage(); err != nil {
+	if err = sc.basicImpl.cleanTendermintStorage(childEnv); err != nil {
 		return fmt.Errorf("scenario/e2e/dump_restore: failed to clean tendemint storage: %w", err)
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/halt_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/halt_restore.go
@@ -164,7 +164,7 @@ func (sc *haltRestoreImpl) Run(childEnv *env.Env) error {
 	// Stop the network.
 	sc.logger.Info("stopping the network")
 	sc.basicImpl.net.Stop()
-	if err = sc.basicImpl.cleanTendermintStorage(); err != nil {
+	if err = sc.basicImpl.cleanTendermintStorage(childEnv); err != nil {
 		return fmt.Errorf("scenario/e2e/halt_restore: failed to clean tendemint storage: %w", err)
 	}
 


### PR DESCRIPTION
Fixes: #2435

As it probably can be deduced from the name, this sub-command will
reset the node back to a freshly provisioned state (preserving any
key material if it exists).

The `-n` (`--dry_run`) flag will go through the process without actually
removing state, so that it is possible to preview the results of
executing the command.

Usage: `oasis-node unsafe-reset --datadir=/path/to/datadir`