### PR TITLE
Makefile: Only set GOLDFLAGS if it doesn't exist yet

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -44,7 +44,7 @@ GOFLAGS ?= -trimpath -v
 
 # Add Oasis Core's version as a linker string value definition.
 ifneq ($(VERSION),)
-	export GOLDFLAGS += "-X github.com/oasislabs/oasis-core/go/common/version.SoftwareVersion=$(VERSION)"
+	export GOLDFLAGS ?= "-X github.com/oasislabs/oasis-core/go/common/version.SoftwareVersion=$(VERSION)"
 endif
 
 # Go build command to use by default.


### PR DESCRIPTION
If `make go` is called from project's root directory, then the `common.mk` file gets included twice, meaning `export GOLDFLAGS += foo` would recursively add `foo` to the `GOLDFLAGS` variable.