### PR TITLE
Makefile: Reduce noise

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -22,7 +22,7 @@ generate:
 
 $(go-binaries):
 	@$(ECHO) "$(MAGENTA)*** Building $@...$(OFF)"
-	$(GO) build $(GOFLAGS) $(GO_EXTRA_FLAGS) -o ./$@/$@ ./$@
+	@$(GO) build $(GOFLAGS) $(GO_EXTRA_FLAGS) -o ./$@/$@ ./$@
 
 oasis-node:
 


### PR DESCRIPTION
There's no need to print the entire `go build` line with all the
flags and everything.