### PR TITLE
go staking: undisable transfers for some senders

### DIFF
--- a/.changelog/2498.feature.md
+++ b/.changelog/2498.feature.md
@@ -1,0 +1,7 @@
+Undisable transfers for some senders.
+
+Ostensibly for faucet purposes while we run the rest of the network with transfers disabled,
+this lets us identify a whitelist of accounts from which we allow transfers when otherwise transfers are disabled.
+
+Configure this with a map of allowed senders' public keys -> `true` in the new `undisable_transfers_from` field in the
+staking consensus parameters object along with `"disable_transfers": true`.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -410,8 +410,9 @@ type ConsensusParameters struct {
 	GasCosts                          transaction.Costs                   `json:"gas_costs,omitempty"`
 	MinDelegationAmount               quantity.Quantity                   `json:"min_delegation,omitempty"`
 
-	DisableTransfers  bool `json:"disable_transfers,omitempty"`
-	DisableDelegation bool `json:"disable_delegation,omitempty"`
+	DisableTransfers       bool                         `json:"disable_transfers,omitempty"`
+	DisableDelegation      bool                         `json:"disable_delegation,omitempty"`
+	UndisableTransfersFrom map[signature.PublicKey]bool `json:"undisable_transfers_from,omitempty"`
 }
 
 const (


### PR DESCRIPTION
ostensibly for faucet purposes while we run the rest of the network with transfers disabled, this lets us identify a whitelist of accounts from which we allow transfers when otherwise transfers are disabled.

cc #2481