### PR TITLE
add key manager ID check

### DIFF
--- a/.changelog/2459.breaking.md
+++ b/.changelog/2459.breaking.md
@@ -1,0 +1,2 @@
+When registering a new runtime, require that the given key manager ID points
+to a valid key manager in the registry.

--- a/go/consensus/tendermint/apps/keymanager/genesis.go
+++ b/go/consensus/tendermint/apps/keymanager/genesis.go
@@ -49,7 +49,7 @@ func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.Req
 	for _, v := range st.Statuses {
 		rt := rtMap[v.ID]
 		if rt == nil {
-			app.logger.Error("InitChain: State for unknown runtime",
+			app.logger.Error("InitChain: State for unknown key manager runtime",
 				"id", v.ID,
 			)
 			continue

--- a/go/consensus/tendermint/apps/registry/state/state.go
+++ b/go/consensus/tendermint/apps/registry/state/state.go
@@ -243,11 +243,13 @@ func (s *ImmutableState) getSignedRuntimeRaw(id common.Namespace) ([]byte, error
 	return value, nil
 }
 
-// GetRuntime looks up a runtime by its identifier and returns it.
 func (s *ImmutableState) Runtime(id common.Namespace) (*registry.Runtime, error) {
 	raw, err := s.getSignedRuntimeRaw(id)
 	if err != nil {
 		return nil, err
+	}
+	if raw == nil {
+		return nil, registry.ErrNoSuchRuntime
 	}
 
 	var signedRuntime registry.SignedRuntime

--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -402,6 +402,12 @@ func (app *registryApplication) registerRuntime(
 		return err
 	}
 
+	if rt.Kind == registry.KindCompute {
+		if err = registry.VerifyRegisterComputeRuntimeArgs(app.logger, rt, state); err != nil {
+			return err
+		}
+	}
+
 	if ctx.IsCheckOnly() {
 		return nil
 	}


### PR DESCRIPTION
PR for #2459:
- adds a check whether key manager ID of the newly registered runtime points to a valid key manager in the registry.