### PR TITLE
txsource: short runner

### DIFF
--- a/.buildkite/longtests.pipeline.yml
+++ b/.buildkite/longtests.pipeline.yml
@@ -37,12 +37,12 @@ docker_plugin: &docker_plugin
 steps:
   - label: Transaction source tests
     parallelism: 1
-    timeout_in_minutes: 480
+    timeout_in_minutes: 55
     command:
       - make
       - >-
         ./.buildkite/scripts/test_e2e.sh
-        -t txsource
+        -t txsource-transfer
     env:
       TEST_BASE_DIR: e2e
     agents:

--- a/.buildkite/longtests.pipeline.yml
+++ b/.buildkite/longtests.pipeline.yml
@@ -35,11 +35,14 @@ docker_plugin: &docker_plugin
     <<: *docker_plugin_default_config
 
 steps:
-  - label: Transaction source test
+  - label: Transaction source tests
+    parallelism: 1
     timeout_in_minutes: 480
     command:
       - make
-      - ./scripts/run-e2e-txsource.sh
+      - >-
+        ./.buildkite/scripts/test_e2e.sh
+        -t txsource
     env:
       TEST_BASE_DIR: e2e
     agents:

--- a/.changelog/2505.trivial.md
+++ b/.changelog/2505.trivial.md
@@ -1,0 +1,7 @@
+txsource: Short runner.
+
+This adds short versions of the txsource e2e tests for use in regular CI tests.
+Adding these to the regular CI tests is supposed to keep the system from rotting.
+
+The run-e2e-txsource.sh script is removed.
+Use .buildkite/scripts/test_e2e.sh with `-t txsource-transfer` instead.

--- a/go/oasis-test-runner/scenario/e2e/basic.go
+++ b/go/oasis-test-runner/scenario/e2e/basic.go
@@ -157,7 +157,7 @@ func (sc *basicImpl) start(childEnv *env.Env) (<-chan error, *exec.Cmd, error) {
 		return nil, nil, err
 	}
 
-	cmd, err := startClient(childEnv, sc.net, sc.clientBinary, sc.clientArgs)
+	cmd, err := startClient(childEnv, sc.net, resolveClientBinary(sc.clientBinary), sc.clientArgs)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/oasis-test-runner/scenario/e2e/common.go
+++ b/go/oasis-test-runner/scenario/e2e/common.go
@@ -66,7 +66,7 @@ func resolveDefaultKeyManagerBinary() (string, error) {
 	return resolveRuntimeBinary("oasis-core-keymanager-runtime")
 }
 
-func startClient(env *env.Env, net *oasis.Network, clientBinary string, clientArgs []string) (*exec.Cmd, error) {
+func startClient(env *env.Env, net *oasis.Network, binary string, clientArgs []string) (*exec.Cmd, error) {
 	clients := net.Clients()
 	if len(clients) == 0 {
 		return nil, fmt.Errorf("scenario/e2e: network has no client nodes")
@@ -82,7 +82,6 @@ func startClient(env *env.Env, net *oasis.Network, clientBinary string, clientAr
 		return nil, err
 	}
 
-	binary := resolveClientBinary(clientBinary)
 	args := []string{
 		"--node-address", "unix:" + clients[0].SocketPath(),
 		"--runtime-id", runtimeID.String(),

--- a/go/oasis-test-runner/scenario/e2e/keymanager_restart.go
+++ b/go/oasis-test-runner/scenario/e2e/keymanager_restart.go
@@ -83,7 +83,7 @@ func (sc *kmRestartImpl) Run(childEnv *env.Env) error {
 	// Run the second client on a different key so that it will require
 	// a second trip to the keymanager.
 	sc.logger.Info("starting a second client to check if key manager works")
-	cmd, err = startClient(childEnv, sc.basicImpl.net, sc.basicImpl.clientBinary, []string{"--key", "key2"})
+	cmd, err = startClient(childEnv, sc.basicImpl.net, resolveClientBinary(sc.basicImpl.clientBinary), []string{"--key", "key2"})
 	if err != nil {
 		return err
 	}

--- a/go/oasis-test-runner/scenario/e2e/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/txsource.go
@@ -14,13 +14,34 @@ import (
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/scenario"
 )
 
-// TxSource is a network with the txsource program as a client.
-var TxSource scenario.Scenario = &txSourceImpl{basicImpl{
-	name: "txsource",
-}}
+const (
+	timeLimitShort = time.Minute
+	timeLimitLong  = 43 * time.Minute
+)
+
+// TxSourceTransferShort uses the transfer workload for a short time.
+var TxSourceTransferShort scenario.Scenario = &txSourceImpl{
+	basicImpl: basicImpl{
+		name: "txsource-transfer-short",
+	},
+	workload:  workload.NameTransfer,
+	timeLimit: timeLimitShort,
+}
+
+// TxSourceTransfer uses the transfer workload.
+var TxSourceTransfer scenario.Scenario = &txSourceImpl{
+	basicImpl: basicImpl{
+		name: "txsource-transfer",
+	},
+	workload:  workload.NameTransfer,
+	timeLimit: timeLimitLong,
+}
 
 type txSourceImpl struct {
 	basicImpl
+
+	workload  string
+	timeLimit time.Duration
 }
 
 func (sc *txSourceImpl) Fixture() (*oasis.NetworkFixture, error) {
@@ -53,8 +74,8 @@ func (sc *txSourceImpl) Run(childEnv *env.Env) error {
 		"--log.format", logFmt.String(),
 		"--log.level", logLevel.String(),
 		"--" + flags.CfgGenesisFile, sc.net.GenesisPath(),
-		"--" + txsource.CfgWorkload, workload.NameTransfer,
-		"--" + txsource.CfgTimeLimit, (2 * time.Minute).String(), // %%% low value for validation (:
+		"--" + txsource.CfgWorkload, sc.workload,
+		"--" + txsource.CfgTimeLimit, sc.timeLimit.String(),
 	}, sc.clientArgs...))
 	if err != nil {
 		return fmt.Errorf("startClient: %w", err)

--- a/go/oasis-test-runner/scenario/e2e/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/txsource.go
@@ -16,8 +16,7 @@ import (
 
 // TxSource is a network with the txsource program as a client.
 var TxSource scenario.Scenario = &txSourceImpl{basicImpl{
-	name:         "txsource",
-	clientBinary: "txsource-wrapper.sh",
+	name: "txsource",
 }}
 
 type txSourceImpl struct {
@@ -46,7 +45,7 @@ func (sc *txSourceImpl) Run(childEnv *env.Env) error {
 
 	logFmt := logging.FmtJSON
 	logLevel := logging.LevelDebug
-	cmd, err := startClient(childEnv, sc.net, sc.clientBinary, append([]string{
+	cmd, err := startClient(childEnv, sc.net, "scripts/txsource-wrapper.sh", append([]string{
 		"--",
 		"--" + common.CfgDebugAllowTestKeys,
 		"--" + flags.CfgDebugDontBlameOasis,

--- a/go/oasis-test-runner/scenario/e2e/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/txsource.go
@@ -2,7 +2,13 @@ package e2e
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/oasislabs/oasis-core/go/common/logging"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/debug/txsource"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/debug/txsource/workload"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/oasis"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/scenario"
@@ -38,9 +44,18 @@ func (sc *txSourceImpl) Run(childEnv *env.Env) error {
 		return fmt.Errorf("scenario net Start: %w", err)
 	}
 
+	logFmt := logging.FmtJSON
+	logLevel := logging.LevelDebug
 	cmd, err := startClient(childEnv, sc.net, sc.clientBinary, append([]string{
-		"--genesis-path", sc.net.GenesisPath(),
-		"--time-limit", "2m", // %%% low value for validation (:
+		"--",
+		"--" + common.CfgDebugAllowTestKeys,
+		"--" + flags.CfgDebugDontBlameOasis,
+		"--" + flags.CfgDebugTestEntity,
+		"--log.format", logFmt.String(),
+		"--log.level", logLevel.String(),
+		"--" + flags.CfgGenesisFile, sc.net.GenesisPath(),
+		"--" + txsource.CfgWorkload, workload.NameTransfer,
+		"--" + txsource.CfgTimeLimit, (2 * time.Minute).String(), // %%% low value for validation (:
 	}, sc.clientArgs...))
 	if err != nil {
 		return fmt.Errorf("startClient: %w", err)

--- a/go/oasis-test-runner/test-runner.go
+++ b/go/oasis-test-runner/test-runner.go
@@ -52,7 +52,8 @@ func main() {
 	// Runtime prune test.
 	_ = cmd.Register(e2e.RuntimePrune)
 	// Transaction source test.
-	_ = cmd.RegisterNondefault(e2e.TxSource)
+	_ = cmd.Register(e2e.TxSourceTransferShort)
+	_ = cmd.RegisterNondefault(e2e.TxSourceTransfer)
 
 	// Execute the command, now that everything has been initialized.
 	cmd.Execute()

--- a/scripts/run-e2e-txsource.sh
+++ b/scripts/run-e2e-txsource.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-./go/oasis-test-runner/oasis-test-runner \
-    --basedir.no_cleanup \
-    --e2e.node.binary go/oasis-node/oasis-node \
-    --e2e.client.binary_dir scripts \
-    --e2e.runtime.binary_dir target/debug \
-    --e2e.runtime.loader target/debug/oasis-core-runtime-loader \
-    --log.level info \
-    -t txsource

--- a/scripts/txsource-wrapper.sh
+++ b/scripts/txsource-wrapper.sh
@@ -1,8 +1,8 @@
 #!/bin/sh -eu
 
 usage() {
-  echo >&2 "usage: $0 --node-address <node_address> --runtime-id <unused> --genesis-path <genesis_path> --time-limit <time_limit>"
-  #                0  1              2              3            4        5              6              7            8
+  echo >&2 "usage: $0 --node-address <node_address> --runtime-id <unused> -- <txsource args ...>"
+  #                0  1              2              3            4        5
   exit 1
 }
 
@@ -11,25 +11,12 @@ if [ "$1" = "--node-address" ]; then
 else
   usage
 fi
-if [ "$5" = "--genesis-path" ]; then
-  genesis_path=$6
-else
-  usage
-fi
-
-if [ "$7" = "--time-limit" ]; then
-  time_limit=$8
+if [ "$5" = "--" ]; then
+  shift 5
 else
   usage
 fi
 
 exec ./go/oasis-node/oasis-node debug txsource \
-  --workload transfer \
-  --time_limit "$time_limit" \
   --address "$node_address" \
-  --debug.allow_test_keys \
-  --debug.dont_blame_oasis \
-  --debug.test_entity \
-  --genesis.file "$genesis_path" \
-  --log.format JSON \
-  --log.level DEBUG
+  "$@"


### PR DESCRIPTION
This adds short versions of the txsource e2e tests for use in regular CI tests. Adding these to the regular CI tests is supposed to keep the system from rotting.

The run-e2e-txsource.sh script is removed. Use .buildkite/scripts/test_e2e.sh with `-t txsource-transfer` instead.
