### PR TITLE
scripts: unhardcode node binary in txsource wrapper

### DIFF
--- a/.changelog/2507.trivial.md
+++ b/.changelog/2507.trivial.md
@@ -1,0 +1,3 @@
+scripts: Unhardcode node binary in txsource wrapper.
+
+We need this to support the test coverage hacks in integration tests.

--- a/go/oasis-test-runner/scenario/e2e/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/txsource.go
@@ -67,6 +67,7 @@ func (sc *txSourceImpl) Run(childEnv *env.Env) error {
 	logFmt := logging.FmtJSON
 	logLevel := logging.LevelDebug
 	cmd, err := startClient(childEnv, sc.net, "scripts/txsource-wrapper.sh", append([]string{
+		"--node-binary", sc.net.Config().NodeBinary,
 		"--",
 		"--" + common.CfgDebugAllowTestKeys,
 		"--" + flags.CfgDebugDontBlameOasis,

--- a/scripts/txsource-wrapper.sh
+++ b/scripts/txsource-wrapper.sh
@@ -1,8 +1,8 @@
 #!/bin/sh -eu
 
 usage() {
-  echo >&2 "usage: $0 --node-address <node_address> --runtime-id <unused> -- <txsource args ...>"
-  #                0  1              2              3            4        5
+  echo >&2 "usage: $0 --node-address <node_address> --runtime-id <unused> --node-binary <node_binary> -- <txsource args ...>"
+  #                0  1              2              3            4        5             6             7
   exit 1
 }
 
@@ -11,12 +11,17 @@ if [ "$1" = "--node-address" ]; then
 else
   usage
 fi
-if [ "$5" = "--" ]; then
-  shift 5
+if [ "$5" = "--node-binary" ]; then
+  node_binary=$6
+else
+  usage
+fi
+if [ "$7" = "--" ]; then
+  shift 7
 else
   usage
 fi
 
-exec ./go/oasis-node/oasis-node debug txsource \
+exec "$node_binary" debug txsource \
   --address "$node_address" \
   "$@"


### PR DESCRIPTION
We need this to support the test coverage hacks in integration tests.