### PR TITLE
go: Use common.Namespace for runtime IDs

### DIFF
--- a/.changelog/1693.trivial.md
+++ b/.changelog/1693.trivial.md
@@ -1,0 +1,1 @@
+go: Use common.Namespace for runtime IDs

--- a/go/common/grpc/policy_test.go
+++ b/go/common/grpc/policy_test.go
@@ -160,14 +160,11 @@ func TestAccessPolicy(t *testing.T) {
 	grpcServer, err := NewServer(serverConfig)
 	require.NoErrorf(err, "Failed to create a new gRPC server: %v", err)
 
-	runtimeID, err := testNs.ToRuntimeID()
-	require.NoErrorf(err, "Failed to obtain runtime ID from namespace: %v", testNs)
-
 	// Create a new pingServer with a new RuntimePolicyChecker.
 	policyChecker := NewDynamicRuntimePolicyChecker()
 	server := &pingServer{policyChecker}
 	policy := accessctl.NewPolicy()
-	policyChecker.SetAccessPolicy(policy, runtimeID)
+	policyChecker.SetAccessPolicy(policy, testNs)
 
 	// Register the pingServer with the PingService.
 	grpcServer.Server().RegisterService(&serviceDesc, server)
@@ -218,7 +215,7 @@ func TestAccessPolicy(t *testing.T) {
 	policy = accessctl.NewPolicy()
 	subject := accessctl.SubjectFromX509Certificate(clientX509Cert)
 	policy.Allow(subject, "Ping")
-	policyChecker.SetAccessPolicy(policy, runtimeID)
+	policyChecker.SetAccessPolicy(policy, testNs)
 
 	res, err := client.Ping(ctx, &PingQuery{testNs})
 	require.NoError(err, "Calling Ping with proper access policy set should succeed")

--- a/go/common/namespace.go
+++ b/go/common/namespace.go
@@ -6,8 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
-
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 )
 
 const (
@@ -59,6 +57,16 @@ func (n *Namespace) UnmarshalText(text []byte) error {
 	return n.UnmarshalBinary(b)
 }
 
+// UnmarshalHex deserializes a hexadecimal text string into the given type.
+func (n *Namespace) UnmarshalHex(text string) error {
+	b, err := hex.DecodeString(text)
+	if err != nil {
+		return err
+	}
+
+	return n.UnmarshalBinary(b)
+}
+
 // Equal compares vs another namespace for equality.
 func (n *Namespace) Equal(cmp *Namespace) bool {
 	if cmp == nil {
@@ -70,11 +78,4 @@ func (n *Namespace) Equal(cmp *Namespace) bool {
 // String returns the string representation of a chain namespace identifier.
 func (n Namespace) String() string {
 	return hex.EncodeToString(n[:])
-}
-
-// ToRuntimeID derives a RuntimeID from the namespace.
-// XXX: In future we might be using namespaces directly for runtime IDs.
-func (n *Namespace) ToRuntimeID() (pk signature.PublicKey, err error) {
-	err = pk.UnmarshalBinary(n[:])
-	return
 }

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
@@ -138,7 +139,7 @@ func (n *Node) IsExpired(epoch uint64) bool {
 // Runtime represents the runtimes supported by a given Oasis node.
 type Runtime struct {
 	// ID is the public key identifying the runtime.
-	ID signature.PublicKey `json:"id"`
+	ID common.Namespace `json:"id"`
 
 	// Version is the version of the runtime.
 	Version version.Version `json:"version"`

--- a/go/consensus/tendermint/apps/keymanager/genesis.go
+++ b/go/consensus/tendermint/apps/keymanager/genesis.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/tendermint/tendermint/abci/types"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
 	tmapi "github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
 	keymanagerState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/keymanager/state"
@@ -29,7 +29,7 @@ func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.Req
 	// before the keymanager, and just query the registry for the runtime
 	// list.
 	regSt := doc.Registry
-	rtMap := make(map[signature.PublicKey]*registry.Runtime)
+	rtMap := make(map[common.Namespace]*registry.Runtime)
 	for _, v := range regSt.Runtimes {
 		rt, err := registry.VerifyRegisterRuntimeArgs(app.logger, v, true)
 		if err != nil {

--- a/go/consensus/tendermint/apps/keymanager/keymanager.go
+++ b/go/consensus/tendermint/apps/keymanager/keymanager.go
@@ -164,7 +164,7 @@ func (app *keymanagerApplication) generateStatus(kmrt *registry.Runtime, oldStat
 
 		var nodeRt *node.Runtime
 		for _, rt := range n.Runtimes {
-			if rt.ID.Equal(kmrt.ID) {
+			if rt.ID.Equal(&kmrt.ID) {
 				nodeRt = rt
 				break
 			}

--- a/go/consensus/tendermint/apps/keymanager/query.go
+++ b/go/consensus/tendermint/apps/keymanager/query.go
@@ -3,7 +3,7 @@ package keymanager
 import (
 	"context"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
 	keymanagerState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/keymanager/state"
 	keymanager "github.com/oasislabs/oasis-core/go/keymanager/api"
@@ -11,7 +11,7 @@ import (
 
 // Query is the key manager query interface.
 type Query interface {
-	Status(context.Context, signature.PublicKey) (*keymanager.Status, error)
+	Status(context.Context, common.Namespace) (*keymanager.Status, error)
 	Statuses(context.Context) ([]*keymanager.Status, error)
 	Genesis(context.Context) (*keymanager.Genesis, error)
 }
@@ -51,7 +51,7 @@ type keymanagerQuerier struct {
 	state *keymanagerState.ImmutableState
 }
 
-func (kq *keymanagerQuerier) Status(ctx context.Context, id signature.PublicKey) (*keymanager.Status, error) {
+func (kq *keymanagerQuerier) Status(ctx context.Context, id common.Namespace) (*keymanager.Status, error) {
 	return kq.state.Status(id)
 }
 

--- a/go/consensus/tendermint/apps/keymanager/state/state.go
+++ b/go/consensus/tendermint/apps/keymanager/state/state.go
@@ -3,8 +3,8 @@ package state
 import (
 	"github.com/tendermint/iavl"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/keyformat"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
 	"github.com/oasislabs/oasis-core/go/keymanager/api"
@@ -14,7 +14,7 @@ var (
 	// statusKeyFmt is the key manager status key format.
 	//
 	// Value is CBOR-serialized key manager status.
-	statusKeyFmt = keyformat.New(0x70, &signature.PublicKey{})
+	statusKeyFmt = keyformat.New(0x70, &common.Namespace{})
 )
 
 type ImmutableState struct {
@@ -57,7 +57,7 @@ func (st *ImmutableState) getStatusesRaw() ([][]byte, error) {
 	return rawVec, nil
 }
 
-func (st *ImmutableState) Status(id signature.PublicKey) (*api.Status, error) {
+func (st *ImmutableState) Status(id common.Namespace) (*api.Status, error) {
 	_, raw := st.Snapshot.Get(statusKeyFmt.Encode(&id))
 	if raw == nil {
 		return nil, nil

--- a/go/consensus/tendermint/apps/registry/query.go
+++ b/go/consensus/tendermint/apps/registry/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/entity"
 	"github.com/oasislabs/oasis-core/go/common/node"
@@ -19,7 +20,7 @@ type Query interface {
 	Node(context.Context, signature.PublicKey) (*node.Node, error)
 	NodeStatus(context.Context, signature.PublicKey) (*registry.NodeStatus, error)
 	Nodes(context.Context) ([]*node.Node, error)
-	Runtime(context.Context, signature.PublicKey) (*registry.Runtime, error)
+	Runtime(context.Context, common.Namespace) (*registry.Runtime, error)
 	Runtimes(context.Context) ([]*registry.Runtime, error)
 	Genesis(context.Context) (*registry.Genesis, error)
 }
@@ -113,7 +114,7 @@ func (rq *registryQuerier) Nodes(ctx context.Context) ([]*node.Node, error) {
 	return filteredNodes, nil
 }
 
-func (rq *registryQuerier) Runtime(ctx context.Context, id signature.PublicKey) (*registry.Runtime, error) {
+func (rq *registryQuerier) Runtime(ctx context.Context, id common.Namespace) (*registry.Runtime, error) {
 	return rq.state.Runtime(id)
 }
 

--- a/go/consensus/tendermint/apps/registry/state/state.go
+++ b/go/consensus/tendermint/apps/registry/state/state.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tendermint/iavl"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
@@ -35,7 +36,7 @@ var (
 	// signedRuntimeKeyFmt is the key format used for signed runtimes.
 	//
 	// Value is CBOR-serialized signed runtime.
-	signedRuntimeKeyFmt = keyformat.New(0x13, &signature.PublicKey{})
+	signedRuntimeKeyFmt = keyformat.New(0x13, &common.Namespace{})
 	// nodeByConsAddressKeyFmt is the key format used for the consensus address to
 	// node public key mapping.
 	//
@@ -237,13 +238,13 @@ func (s *ImmutableState) SignedNodes() ([]*node.SignedNode, error) {
 	return nodes, nil
 }
 
-func (s *ImmutableState) getSignedRuntimeRaw(id signature.PublicKey) ([]byte, error) {
+func (s *ImmutableState) getSignedRuntimeRaw(id common.Namespace) ([]byte, error) {
 	_, value := s.Snapshot.Get(signedRuntimeKeyFmt.Encode(&id))
 	return value, nil
 }
 
 // GetRuntime looks up a runtime by its identifier and returns it.
-func (s *ImmutableState) Runtime(id signature.PublicKey) (*registry.Runtime, error) {
+func (s *ImmutableState) Runtime(id common.Namespace) (*registry.Runtime, error) {
 	raw, err := s.getSignedRuntimeRaw(id)
 	if err != nil {
 		return nil, err

--- a/go/consensus/tendermint/apps/roothash/api.go
+++ b/go/consensus/tendermint/apps/roothash/api.go
@@ -1,7 +1,7 @@
 package roothash
 
 import (
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
 )
@@ -37,20 +37,20 @@ var (
 
 // ValueFinalized is the value component of a TagFinalized.
 type ValueFinalized struct {
-	ID    signature.PublicKey `json:"id"`
-	Round uint64              `json:"round"`
+	ID    common.Namespace `json:"id"`
+	Round uint64           `json:"round"`
 }
 
 // ValueMergeDiscrepancyDetected is the value component of a
 // TagMergeDiscrepancyDetected.
 type ValueMergeDiscrepancyDetected struct {
 	Event roothash.MergeDiscrepancyDetectedEvent `json:"event"`
-	ID    signature.PublicKey                    `json:"id"`
+	ID    common.Namespace                       `json:"id"`
 }
 
 // ValueComputeDiscrepancyDetected is the value component of a
 // TagMergeDiscrepancyDetected.
 type ValueComputeDiscrepancyDetected struct {
-	ID    signature.PublicKey                      `json:"id"`
+	ID    common.Namespace                         `json:"id"`
 	Event roothash.ComputeDiscrepancyDetectedEvent `json:"event"`
 }

--- a/go/consensus/tendermint/apps/roothash/genesis.go
+++ b/go/consensus/tendermint/apps/roothash/genesis.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tendermint/tendermint/abci/types"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
 	registryState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/registry/state"
@@ -40,7 +41,7 @@ func (rq *rootHashQuerier) Genesis(ctx context.Context) (*roothashAPI.Genesis, e
 	runtimes := rq.state.Runtimes()
 
 	// Get per-runtime states.
-	rtStates := make(map[signature.PublicKey]*api.RuntimeGenesis)
+	rtStates := make(map[common.Namespace]*api.RuntimeGenesis)
 	for _, rt := range runtimes {
 		rtState := api.RuntimeGenesis{
 			StateRoot: rt.CurrentBlock.Header.StateRoot,

--- a/go/consensus/tendermint/apps/roothash/query.go
+++ b/go/consensus/tendermint/apps/roothash/query.go
@@ -3,7 +3,7 @@ package roothash
 import (
 	"context"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
 	roothashState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/roothash/state"
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
@@ -12,8 +12,8 @@ import (
 
 // Query is the roothash query interface.
 type Query interface {
-	LatestBlock(context.Context, signature.PublicKey) (*block.Block, error)
-	GenesisBlock(context.Context, signature.PublicKey) (*block.Block, error)
+	LatestBlock(context.Context, common.Namespace) (*block.Block, error)
+	GenesisBlock(context.Context, common.Namespace) (*block.Block, error)
 	Genesis(context.Context) (*roothash.Genesis, error)
 }
 
@@ -52,7 +52,7 @@ type rootHashQuerier struct {
 	state *roothashState.ImmutableState
 }
 
-func (rq *rootHashQuerier) LatestBlock(ctx context.Context, id signature.PublicKey) (*block.Block, error) {
+func (rq *rootHashQuerier) LatestBlock(ctx context.Context, id common.Namespace) (*block.Block, error) {
 	runtime, err := rq.state.RuntimeState(id)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func (rq *rootHashQuerier) LatestBlock(ctx context.Context, id signature.PublicK
 	return runtime.CurrentBlock, nil
 }
 
-func (rq *rootHashQuerier) GenesisBlock(ctx context.Context, id signature.PublicKey) (*block.Block, error) {
+func (rq *rootHashQuerier) GenesisBlock(ctx context.Context, id common.Namespace) (*block.Block, error) {
 	runtime, err := rq.state.RuntimeState(id)
 	if err != nil {
 		return nil, err

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tendermint/tendermint/abci/types"
 
 	beacon "github.com/oasislabs/oasis-core/go/beacon/api"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
@@ -43,8 +44,8 @@ var (
 )
 
 type timerContext struct {
-	ID    signature.PublicKey `json:"id"`
-	Round uint64              `json:"round"`
+	ID    common.Namespace `json:"id"`
+	Round uint64           `json:"round"`
 }
 
 type rootHashApplication struct {
@@ -99,7 +100,7 @@ func (app *rootHashApplication) onCommitteeChanged(ctx *abci.Context, epoch epoc
 	// Query the updated runtime list.
 	regState := registryState.NewMutableState(ctx.State())
 	runtimes, _ := regState.Runtimes()
-	newDescriptors := make(map[signature.PublicKey]*registry.Runtime)
+	newDescriptors := make(map[common.Namespace]*registry.Runtime)
 	for _, v := range runtimes {
 		if v.Kind == registry.KindCompute {
 			newDescriptors[v.ID] = v
@@ -170,7 +171,7 @@ func (app *rootHashApplication) onCommitteeChanged(ctx *abci.Context, epoch epoc
 					return errors.Wrap(err1, "checkCommittees: failed to query node")
 				}
 				for _, r := range node.Runtimes {
-					if !r.ID.Equal(rtID) {
+					if !r.ID.Equal(&rtID) {
 						continue
 					}
 					nodeRuntime = r
@@ -483,7 +484,7 @@ func (app *rootHashApplication) FireTimer(ctx *abci.Context, timer *abci.Timer) 
 }
 
 type roothashSignatureVerifier struct {
-	runtimeID signature.PublicKey
+	runtimeID common.Namespace
 	scheduler *schedulerState.MutableState
 }
 
@@ -521,7 +522,7 @@ func (sv *roothashSignatureVerifier) VerifyCommitteeSignatures(kind scheduler.Co
 func (app *rootHashApplication) commit(
 	ctx *abci.Context,
 	state *roothashState.MutableState,
-	id signature.PublicKey,
+	id common.Namespace,
 	msg interface{},
 ) error {
 	logger := app.logger.With("is_check_only", ctx.IsCheckOnly())

--- a/go/consensus/tendermint/apps/roothash/state/state.go
+++ b/go/consensus/tendermint/apps/roothash/state/state.go
@@ -3,8 +3,8 @@ package state
 import (
 	"github.com/tendermint/iavl"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/keyformat"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
@@ -15,7 +15,7 @@ var (
 	// runtimeKeyFmt is the key format used for per-runtime roothash state.
 	//
 	// Value is CBOR-serialized runtime state.
-	runtimeKeyFmt = keyformat.New(0x20, &signature.PublicKey{})
+	runtimeKeyFmt = keyformat.New(0x20, &common.Namespace{})
 )
 
 type RuntimeState struct {
@@ -39,7 +39,7 @@ func NewImmutableState(state *abci.ApplicationState, version int64) (*ImmutableS
 	return &ImmutableState{inner}, nil
 }
 
-func (s *ImmutableState) RuntimeState(id signature.PublicKey) (*RuntimeState, error) {
+func (s *ImmutableState) RuntimeState(id common.Namespace) (*RuntimeState, error) {
 	_, raw := s.Snapshot.Get(runtimeKeyFmt.Encode(&id))
 	if raw == nil {
 		return nil, nil

--- a/go/consensus/tendermint/apps/scheduler/scheduler.go
+++ b/go/consensus/tendermint/apps/scheduler/scheduler.go
@@ -344,7 +344,7 @@ func (app *schedulerApplication) isSuitableComputeWorker(n *node.Node, rt *regis
 		return false
 	}
 	for _, nrt := range n.Runtimes {
-		if !nrt.ID.Equal(rt.ID) {
+		if !nrt.ID.Equal(&rt.ID) {
 			continue
 		}
 		switch rt.TEEHardware {
@@ -384,7 +384,7 @@ func (app *schedulerApplication) isSuitableTransactionScheduler(n *node.Node, rt
 		return false
 	}
 	for _, nrt := range n.Runtimes {
-		if !nrt.ID.Equal(rt.ID) {
+		if !nrt.ID.Equal(&rt.ID) {
 			continue
 		}
 		return true

--- a/go/consensus/tendermint/apps/scheduler/state/state.go
+++ b/go/consensus/tendermint/apps/scheduler/state/state.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tendermint/iavl"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/keyformat"
@@ -17,7 +18,7 @@ var (
 	// committeeKeyFmt is the key format used for committees.
 	//
 	// Value is CBOR-serialized committee.
-	committeeKeyFmt = keyformat.New(0x60, uint8(0), &signature.PublicKey{})
+	committeeKeyFmt = keyformat.New(0x60, uint8(0), &common.Namespace{})
 	// validatorsCurrentKeyFmt is the key format used for the current set of
 	// validators.
 	//
@@ -40,7 +41,7 @@ type ImmutableState struct {
 	*abci.ImmutableState
 }
 
-func (s *ImmutableState) Committee(kind api.CommitteeKind, runtimeID signature.PublicKey) (*api.Committee, error) {
+func (s *ImmutableState) Committee(kind api.CommitteeKind, runtimeID common.Namespace) (*api.Committee, error) {
 	_, raw := s.Snapshot.Get(committeeKeyFmt.Encode(uint8(kind), &runtimeID))
 	if raw == nil {
 		return nil, nil
@@ -163,7 +164,7 @@ func (s *MutableState) PutCommittee(c *api.Committee) {
 	s.tree.Set(committeeKeyFmt.Encode(uint8(c.Kind), &c.RuntimeID), cbor.Marshal(c))
 }
 
-func (s *MutableState) DropCommittee(kind api.CommitteeKind, runtimeID signature.PublicKey) {
+func (s *MutableState) DropCommittee(kind api.CommitteeKind, runtimeID common.Namespace) {
 	s.tree.Remove(committeeKeyFmt.Encode(uint8(kind), &runtimeID))
 }
 

--- a/go/consensus/tendermint/apps/supplementarysanity/checks.go
+++ b/go/consensus/tendermint/apps/supplementarysanity/checks.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/tendermint/iavl"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/quantity"
 	keymanagerState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/keymanager/state"
 	registryState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/registry/state"
@@ -70,7 +70,7 @@ func checkRootHash(state *iavl.MutableTree, now epochtime.EpochTime) error {
 	// Check blocks.
 	runtimes := st.Runtimes()
 
-	blocks := make(map[signature.PublicKey]*block.Block)
+	blocks := make(map[common.Namespace]*block.Block)
 	for _, rt := range runtimes {
 		blocks[rt.Runtime.ID] = rt.CurrentBlock
 	}

--- a/go/consensus/tendermint/keymanager/keymanager.go
+++ b/go/consensus/tendermint/keymanager/keymanager.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pkg/errors"
 	tmtypes "github.com/tendermint/tendermint/types"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
 	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
@@ -29,7 +29,7 @@ type tendermintBackend struct {
 	notifier *pubsub.Broker
 }
 
-func (tb *tendermintBackend) GetStatus(ctx context.Context, id signature.PublicKey, height int64) (*api.Status, error) {
+func (tb *tendermintBackend) GetStatus(ctx context.Context, id common.Namespace, height int64) (*api.Status, error) {
 	q, err := tb.querier.QueryAt(ctx, height)
 	if err != nil {
 		return nil, err

--- a/go/consensus/tendermint/registry/registry.go
+++ b/go/consensus/tendermint/registry/registry.go
@@ -108,7 +108,7 @@ func (tb *tendermintBackend) WatchNodeList(ctx context.Context) (<-chan *api.Nod
 	return typedCh, sub, nil
 }
 
-func (tb *tendermintBackend) GetRuntime(ctx context.Context, query *api.IDQuery) (*api.Runtime, error) {
+func (tb *tendermintBackend) GetRuntime(ctx context.Context, query *api.NamespaceQuery) (*api.Runtime, error) {
 	q, err := tb.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err

--- a/go/consensus/tendermint/scheduler/scheduler.go
+++ b/go/consensus/tendermint/scheduler/scheduler.go
@@ -62,7 +62,7 @@ func (tb *tendermintBackend) GetCommittees(ctx context.Context, request *api.Get
 
 	var runtimeCommittees []*api.Committee
 	for _, c := range committees {
-		if c.RuntimeID.Equal(request.RuntimeID) {
+		if c.RuntimeID.Equal(&request.RuntimeID) {
 			runtimeCommittees = append(runtimeCommittees, c)
 		}
 	}

--- a/go/ias/api/api.go
+++ b/go/ias/api/api.go
@@ -4,7 +4,7 @@ package api
 import (
 	"context"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/sgx/ias"
 )
 
@@ -33,8 +33,8 @@ type SPIDInfo struct {
 
 // Evidence is attestation evidence.
 type Evidence struct {
-	RuntimeID   signature.PublicKey `json:"runtime_id"`
-	Quote       []byte              `json:"quote"`
-	PSEManifest []byte              `json:"pse_manifest"`
-	Nonce       string              `json:"nonce"`
+	RuntimeID   common.Namespace `json:"runtime_id"`
+	Quote       []byte           `json:"quote"`
+	PSEManifest []byte           `json:"pse_manifest"`
+	Nonce       string           `json:"nonce"`
 }

--- a/go/keymanager/api/api.go
+++ b/go/keymanager/api/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/memory"
@@ -45,7 +46,7 @@ var (
 // Status is the current key manager status.
 type Status struct {
 	// ID is the runtime ID of the key manager.
-	ID signature.PublicKey `json:"id"`
+	ID common.Namespace `json:"id"`
 
 	// IsInitialized is true iff the key manager is done initializing.
 	IsInitialized bool `json:"is_initialized"`
@@ -66,7 +67,7 @@ type Status struct {
 // Backend is a key manager management implementation.
 type Backend interface {
 	// GetStatus returns a key manager status by key manager ID.
-	GetStatus(context.Context, signature.PublicKey, int64) (*Status, error)
+	GetStatus(context.Context, common.Namespace, int64) (*Status, error)
 
 	// GetStatuses returns all currently tracked key manager statuses.
 	GetStatuses(context.Context, int64) ([]*Status, error)
@@ -142,10 +143,7 @@ type Genesis struct {
 // SanityCheckStatuses examines the statuses table.
 func SanityCheckStatuses(statuses []*Status) error {
 	for _, status := range statuses {
-		// Verify key manager runtime ID.
-		if !status.ID.IsValid() {
-			return fmt.Errorf("keymanager: sanity check failed: key manager runtime ID %s is invalid", status.ID.String())
-		}
+		// TODO: Verify key manager runtime ID.
 
 		// Verify currently active key manager node IDs.
 		for _, node := range status.Nodes {

--- a/go/keymanager/client/client.go
+++ b/go/keymanager/client/client.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/status"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	cmnGrpc "github.com/oasislabs/oasis-core/go/common/grpc"
 	"github.com/oasislabs/oasis-core/go/common/grpc/resolver/manual"
@@ -48,8 +49,8 @@ type Client struct {
 	backend  api.Backend
 	registry registry.Backend
 
-	state map[signature.PublicKey]*clientState
-	kmMap map[signature.PublicKey]signature.PublicKey
+	state map[common.Namespace]*clientState
+	kmMap map[common.Namespace]common.Namespace
 
 	debugClient enclaverpc.Transport
 }
@@ -73,7 +74,7 @@ func (st *clientState) kill() {
 }
 
 // CallRemote calls a runtime-specific key manager via remote EnclaveRPC.
-func (c *Client) CallRemote(ctx context.Context, runtimeID signature.PublicKey, data []byte) ([]byte, error) {
+func (c *Client) CallRemote(ctx context.Context, runtimeID common.Namespace, data []byte) ([]byte, error) {
 	if c.debugClient != nil {
 		return c.debugClient.CallEnclave(ctx, &enclaverpc.CallEnclaveRequest{
 			RuntimeID: runtimeID,
@@ -316,8 +317,8 @@ func New(backend api.Backend, registryBackend registry.Backend, nodeIdentity *id
 	c := &Client{
 		logger:       logging.GetLogger("keymanager/client"),
 		nodeIdentity: nodeIdentity,
-		state:        make(map[signature.PublicKey]*clientState),
-		kmMap:        make(map[signature.PublicKey]signature.PublicKey),
+		state:        make(map[common.Namespace]*clientState),
+		kmMap:        make(map[common.Namespace]common.Namespace),
 	}
 
 	// Standard configuration watches the various backends.

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -8,7 +8,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/common/sgx"
 	"github.com/oasislabs/oasis-core/go/common/sgx/ias"
@@ -31,8 +31,8 @@ var (
 	// Flags is the command line flags for the fixtures.
 	Flags = flag.NewFlagSet("", flag.ContinueOnError)
 
-	runtimeID    signature.PublicKey
-	keymanagerID signature.PublicKey
+	runtimeID    common.Namespace
+	keymanagerID common.Namespace
 )
 
 // NewDefaultFixture returns a default network fixture.

--- a/go/oasis-node/cmd/debug/byzantine/compute.go
+++ b/go/oasis-node/cmd/debug/byzantine/compute.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
@@ -189,7 +190,7 @@ func (cbc *computeBatchContext) createCommitment(id *identity.Identity, rak sign
 	return nil
 }
 
-func (cbc *computeBatchContext) publishToCommittee(ht *honestTendermint, height int64, committee *scheduler.Committee, role scheduler.Role, ph *p2pHandle, runtimeID signature.PublicKey, groupVersion int64) error {
+func (cbc *computeBatchContext) publishToCommittee(ht *honestTendermint, height int64, committee *scheduler.Committee, role scheduler.Role, ph *p2pHandle, runtimeID common.Namespace, groupVersion int64) error {
 	if err := schedulerPublishToCommittee(ht, height, committee, role, ph, &p2p.Message{
 		RuntimeID:    runtimeID,
 		GroupVersion: groupVersion,

--- a/go/oasis-node/cmd/debug/byzantine/merge.go
+++ b/go/oasis-node/cmd/debug/byzantine/merge.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/identity"
@@ -27,7 +28,7 @@ func newMergeBatchContext() *mergeBatchContext {
 	return &mergeBatchContext{}
 }
 
-func (mbc *mergeBatchContext) loadCurrentBlock(ht *honestTendermint, runtimeID signature.PublicKey) error {
+func (mbc *mergeBatchContext) loadCurrentBlock(ht *honestTendermint, runtimeID common.Namespace) error {
 	var err error
 	mbc.currentBlock, err = roothashGetLatestBlock(ht, 0, runtimeID)
 	if err != nil {
@@ -134,7 +135,7 @@ func (mbc *mergeBatchContext) createCommitment(id *identity.Identity) error {
 	return nil
 }
 
-func (mbc *mergeBatchContext) publishToChain(svc service.TendermintService, id *identity.Identity, runtimeID signature.PublicKey) error {
+func (mbc *mergeBatchContext) publishToChain(svc service.TendermintService, id *identity.Identity, runtimeID common.Namespace) error {
 	if err := roothashMergeCommit(svc, id, runtimeID, []commitment.MergeCommitment{*mbc.commit}); err != nil {
 		return errors.Wrap(err, "roothash merge commentment")
 	}

--- a/go/oasis-node/cmd/debug/byzantine/p2p.go
+++ b/go/oasis-node/cmd/debug/byzantine/p2p.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/worker/common/p2p"
@@ -54,7 +55,7 @@ func (h *p2pRecvHandler) HandlePeerMessage(peerID signature.PublicKey, msg *p2p.
 	return <-responseCh
 }
 
-func (ph *p2pHandle) start(id *identity.Identity, runtimeID signature.PublicKey) error {
+func (ph *p2pHandle) start(id *identity.Identity, runtimeID common.Namespace) error {
 	if ph.service != nil {
 		return errors.New("P2P service already started")
 	}

--- a/go/oasis-node/cmd/debug/byzantine/registry.go
+++ b/go/oasis-node/cmd/debug/byzantine/registry.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/logging"
@@ -15,7 +16,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/worker/registration"
 )
 
-func registryRegisterNode(svc service.TendermintService, id *identity.Identity, dataDir string, committeeAddresses []node.Address, p2pAddresses []node.Address, runtimeID signature.PublicKey, capabilities *node.Capabilities, roles node.RolesMask) error {
+func registryRegisterNode(svc service.TendermintService, id *identity.Identity, dataDir string, committeeAddresses []node.Address, p2pAddresses []node.Address, runtimeID common.Namespace, capabilities *node.Capabilities, roles node.RolesMask) error {
 	entityID, registrationSigner, err := registration.GetRegistrationSigner(logging.GetLogger("cmd/byzantine/registration"), dataDir, id)
 	if err != nil {
 		return errors.Wrap(err, "registration GetRegistrationSigner")

--- a/go/oasis-node/cmd/debug/byzantine/roothash.go
+++ b/go/oasis-node/cmd/debug/byzantine/roothash.go
@@ -3,7 +3,7 @@ package byzantine
 import (
 	"context"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/service"
@@ -12,11 +12,11 @@ import (
 	"github.com/oasislabs/oasis-core/go/roothash/api/commitment"
 )
 
-func roothashGetLatestBlock(ht *honestTendermint, height int64, runtimeID signature.PublicKey) (*block.Block, error) {
+func roothashGetLatestBlock(ht *honestTendermint, height int64, runtimeID common.Namespace) (*block.Block, error) {
 	return ht.service.RootHash().GetLatestBlock(context.Background(), runtimeID, height)
 }
 
-func roothashMergeCommit(svc service.TendermintService, id *identity.Identity, runtimeID signature.PublicKey, commits []commitment.MergeCommitment) error {
+func roothashMergeCommit(svc service.TendermintService, id *identity.Identity, runtimeID common.Namespace, commits []commitment.MergeCommitment) error {
 	tx := roothash.NewMergeCommitTx(0, nil, runtimeID, commits)
 	return consensus.SignAndSubmitTx(context.Background(), svc, id.NodeSigner, tx)
 }

--- a/go/oasis-node/cmd/debug/byzantine/scheduler.go
+++ b/go/oasis-node/cmd/debug/byzantine/scheduler.go
@@ -7,6 +7,7 @@ import (
 
 	tmtypes "github.com/tendermint/tendermint/types"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/node"
@@ -48,7 +49,7 @@ func schedulerNextElectionHeight(svc service.TendermintService, kind scheduler.C
 	}
 }
 
-func schedulerGetCommittee(ht *honestTendermint, height int64, kind scheduler.CommitteeKind, runtimeID signature.PublicKey) (*scheduler.Committee, error) {
+func schedulerGetCommittee(ht *honestTendermint, height int64, kind scheduler.CommitteeKind, runtimeID common.Namespace) (*scheduler.Committee, error) {
 	committees, err := ht.service.Scheduler().GetCommittees(context.Background(), &scheduler.GetCommitteesRequest{
 		RuntimeID: runtimeID,
 		Height:    height,
@@ -62,7 +63,7 @@ func schedulerGetCommittee(ht *honestTendermint, height int64, kind scheduler.Co
 			continue
 		}
 
-		if !committee.RuntimeID.Equal(runtimeID) {
+		if !committee.RuntimeID.Equal(&runtimeID) {
 			continue
 		}
 

--- a/go/oasis-node/cmd/debug/byzantine/steps.go
+++ b/go/oasis-node/cmd/debug/byzantine/steps.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	fileSigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/file"
@@ -25,7 +26,7 @@ const (
 )
 
 var (
-	defaultRuntimeID signature.PublicKey
+	defaultRuntimeID common.Namespace
 	fakeAddresses    = []node.Address{
 		node.Address{
 			TCPAddr: net.TCPAddr{

--- a/go/oasis-node/cmd/debug/storage/export.go
+++ b/go/oasis-node/cmd/debug/storage/export.go
@@ -14,7 +14,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/oasislabs/oasis-core/go/common"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	cmdCommon "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
 	cmdConsensus "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/consensus"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
@@ -83,14 +82,11 @@ func doExport(cmd *cobra.Command, args []string) {
 	ok = true
 }
 
-func exportRuntime(dataDir, destDir string, id signature.PublicKey, rtg *registry.RuntimeGenesis) error {
+func exportRuntime(dataDir, destDir string, id common.Namespace, rtg *registry.RuntimeGenesis) error {
 	dataDir = filepath.Join(dataDir, runtimeRegistry.RuntimesDir, id.String())
 
 	// Initialize the storage backend.
-	var ns common.Namespace
-	_ = ns.UnmarshalBinary(id[:])
-
-	storageBackend, err := newDirectStorageBackend(dataDir, ns)
+	storageBackend, err := newDirectStorageBackend(dataDir, id)
 	if err != nil {
 		logger.Error("failed to construct storage backend",
 			"err", err,
@@ -104,7 +100,7 @@ func exportRuntime(dataDir, destDir string, id signature.PublicKey, rtg *registr
 
 	// Get the checkpoint iterator.
 	root := storageAPI.Root{
-		Namespace: ns,
+		Namespace: id,
 		Round:     rtg.Round,
 		Hash:      rtg.StateRoot,
 	}

--- a/go/oasis-node/cmd/debug/storage/storage.go
+++ b/go/oasis-node/cmd/debug/storage/storage.go
@@ -156,7 +156,7 @@ func doCheckRoots(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	var id signature.PublicKey
+	var id common.Namespace
 	if err = id.UnmarshalHex(args[0]); err != nil {
 		logger.Error("failed to decode runtime id",
 			"err", err,
@@ -256,7 +256,7 @@ func doForceFinalize(cmd *cobra.Command, args []string) {
 
 	failed := false
 	for _, arg := range args {
-		var id signature.PublicKey
+		var id common.Namespace
 		if err := id.UnmarshalHex(arg); err != nil {
 			logger.Error("failed to decode runtime id",
 				"err", err,

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/viper"
 
 	beacon "github.com/oasislabs/oasis-core/go/beacon/api"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/entity"
 	"github.com/oasislabs/oasis-core/go/common/logging"
@@ -405,7 +406,7 @@ func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []stri
 // of exported roothash blocks.
 func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Logger) error {
 	rootSt := roothash.Genesis{
-		RuntimeStates: make(map[signature.PublicKey]*registry.RuntimeGenesis),
+		RuntimeStates: make(map[common.Namespace]*registry.RuntimeGenesis),
 	}
 
 	for _, v := range exports {
@@ -418,7 +419,7 @@ func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Log
 			return err
 		}
 
-		var rtStates map[signature.PublicKey]*registry.RuntimeGenesis
+		var rtStates map[common.Namespace]*registry.RuntimeGenesis
 		if err = json.Unmarshal(b, &rtStates); err != nil {
 			l.Error("failed to parse genesis roothash runtime states",
 				"err", err,
@@ -427,15 +428,15 @@ func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Log
 			return err
 		}
 
-		for key, rtg := range rtStates {
-			if _, ok := rootSt.RuntimeStates[key]; ok {
+		for id, rtg := range rtStates {
+			if _, ok := rootSt.RuntimeStates[id]; ok {
 				l.Error("duplicate genesis roothash runtime state",
-					"runtime_id", key,
+					"runtime_id", id,
 					"block", rtg,
 				)
 				return errors.New("duplicate genesis roothash runtime states")
 			}
-			rootSt.RuntimeStates[key] = rtg
+			rootSt.RuntimeStates[id] = rtg
 		}
 	}
 

--- a/go/oasis-node/cmd/ias/auth.go
+++ b/go/oasis-node/cmd/ias/auth.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/common/sgx"
 	cmnIAS "github.com/oasislabs/oasis-core/go/common/sgx/ias"
@@ -17,7 +17,7 @@ import (
 type enclaveStore struct {
 	sync.RWMutex
 
-	enclaves map[signature.PublicKey][]sgx.EnclaveIdentity
+	enclaves map[common.Namespace][]sgx.EnclaveIdentity
 }
 
 func (st *enclaveStore) verifyEvidence(evidence *ias.Evidence) error {
@@ -68,6 +68,6 @@ func (st *enclaveStore) addRuntime(runtime *registry.Runtime) (int, error) {
 
 func newEnclaveStore() *enclaveStore {
 	return &enclaveStore{
-		enclaves: make(map[signature.PublicKey][]sgx.EnclaveIdentity),
+		enclaves: make(map[common.Namespace][]sgx.EnclaveIdentity),
 	}
 }

--- a/go/oasis-node/cmd/keymanager/keymanager.go
+++ b/go/oasis-node/cmd/keymanager/keymanager.go
@@ -15,6 +15,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	fileSigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/file"
@@ -374,7 +375,7 @@ func doInitStatus(cmd *cobra.Command, args []string) {
 }
 
 func statusFromFlags() (*kmApi.Status, error) {
-	var id signature.PublicKey
+	var id common.Namespace
 	if err := id.UnmarshalHex(viper.GetString(cfgStatusID)); err != nil {
 		logger.Error("failed to parse key manager status ID",
 			"err", err,

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -212,7 +212,7 @@ func doList(cmd *cobra.Command, args []string) {
 }
 
 func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) {
-	var id signature.PublicKey
+	var id common.Namespace
 	if err := id.UnmarshalHex(viper.GetString(CfgID)); err != nil {
 		logger.Error("failed to parse runtime ID",
 			"err", err,
@@ -238,7 +238,7 @@ func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) {
 	}
 
 	var (
-		kmID *signature.PublicKey
+		kmID *common.Namespace
 		kind registry.RuntimeKind
 	)
 	s = viper.GetString(CfgKind)
@@ -251,13 +251,14 @@ func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) {
 	switch kind {
 	case registry.KindCompute:
 		if viper.IsSet(CfgKeyManager) {
-			kmID = &signature.PublicKey{}
-			if err = kmID.UnmarshalHex(viper.GetString(CfgKeyManager)); err != nil {
+			var tmpKmID common.Namespace
+			if err = tmpKmID.UnmarshalHex(viper.GetString(CfgKeyManager)); err != nil {
 				logger.Error("failed to parse key manager ID",
 					"err", err,
 				)
 				return nil, nil, err
 			}
+			kmID = &tmpKmID
 		}
 	case registry.KindKeyManager:
 		// Key managers don't have their own key manager.

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -103,7 +103,7 @@ var (
 	}
 
 	testNamespace common.Namespace
-	testRuntimeID signature.PublicKey
+	testRuntimeID common.Namespace
 
 	initConfigOnce sync.Once
 )
@@ -111,7 +111,7 @@ var (
 type testNode struct {
 	*node.Node
 
-	runtimeID                 signature.PublicKey
+	runtimeID                 common.Namespace
 	computeCommitteeNode      *computeCommittee.Node
 	txnschedulerCommitteeNode *txnschedulerCommittee.Node
 
@@ -477,11 +477,7 @@ func init() {
 	ns.FromBytes([]byte("oasis node test namespace"))
 	copy(testNamespace[:], ns[:])
 
-	var err error
-	testRuntimeID, err = testNamespace.ToRuntimeID()
-	if err != nil {
-		panic("Unable to convert namespace to runtime ID")
-	}
+	testRuntimeID = testNamespace
 	testRuntime.ID = testRuntimeID
 
 	testRuntime.Genesis.StateRoot.Empty()

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	commonGrpc "github.com/oasislabs/oasis-core/go/common/grpc"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/common/sgx"
@@ -119,7 +119,7 @@ func (args *argBuilder) storageBackend(backend string) *argBuilder {
 	return args
 }
 
-func (args *argBuilder) runtimeSupported(id signature.PublicKey) *argBuilder {
+func (args *argBuilder) runtimeSupported(id common.Namespace) *argBuilder {
 	args.vec = append(args.vec, []string{
 		"--" + runtimeRegistry.CfgSupported, id.String(),
 	}...)
@@ -187,7 +187,7 @@ func (args *argBuilder) workerRuntimeLoader(fn string) *argBuilder {
 	return args
 }
 
-func (args *argBuilder) workerRuntimeBinary(id signature.PublicKey, fn string) *argBuilder {
+func (args *argBuilder) workerRuntimeBinary(id common.Namespace, fn string) *argBuilder {
 	args.vec = append(args.vec, []string{
 		"--" + workerCommon.CfgRuntimeBinary, id.String() + ":" + fn,
 	}...)
@@ -225,7 +225,7 @@ func (args *argBuilder) workerKeymanagerTEEHardware(hw node.TEEHardware) *argBui
 	return args
 }
 
-func (args *argBuilder) workerKeymanagerRuntimeID(id signature.PublicKey) *argBuilder {
+func (args *argBuilder) workerKeymanagerRuntimeID(id common.Namespace) *argBuilder {
 	args.vec = append(args.vec, []string{
 		"--" + keymanager.CfgRuntimeID, id.String(),
 	}...)

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -2,7 +2,8 @@ package oasis
 
 import (
 	"fmt"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/common/sgx"
 	"github.com/oasislabs/oasis-core/go/common/sgx/ias"
@@ -150,7 +151,7 @@ func (f *ValidatorFixture) Create(net *Network) (*Validator, error) {
 
 // RuntimeFixture is a runtime fixture.
 type RuntimeFixture struct {
-	ID         signature.PublicKey  `json:"id"`
+	ID         common.Namespace     `json:"id"`
 	Kind       registry.RuntimeKind `json:"kind"`
 	Entity     int                  `json:"entity"`
 	Keymanager int                  `json:"keymanager"`

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/common/sgx"
-	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	cmdCommon "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
 	cmdRegRt "github.com/oasislabs/oasis-core/go/oasis-node/cmd/registry/runtime"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
@@ -23,7 +23,7 @@ const rtDescriptorFile = "runtime_genesis.json"
 type Runtime struct { // nolint: maligned
 	dir *env.Dir
 
-	id   signature.PublicKey
+	id   common.Namespace
 	kind registry.RuntimeKind
 
 	binary      string
@@ -36,7 +36,7 @@ type Runtime struct { // nolint: maligned
 
 // RuntimeCfg is the Oasis runtime provisioning configuration.
 type RuntimeCfg struct { // nolint: maligned
-	ID          signature.PublicKey
+	ID          common.Namespace
 	Kind        registry.RuntimeKind
 	Entity      *Entity
 	Keymanager  *Runtime
@@ -64,7 +64,7 @@ type RuntimePrunerCfg struct {
 }
 
 // ID returns the runtime ID.
-func (rt *Runtime) ID() signature.PublicKey {
+func (rt *Runtime) ID() common.Namespace {
 	return rt.id
 }
 
@@ -86,7 +86,7 @@ func (net *Network) NewRuntime(cfg *RuntimeCfg) (*Runtime, error) {
 
 	args := []string{
 		"registry", "runtime", "init_genesis",
-		"--" + common.CfgDataDir, rtDir.String(),
+		"--" + cmdCommon.CfgDataDir, rtDir.String(),
 		"--" + cmdRegRt.CfgID, cfg.ID.String(),
 		"--" + cmdRegRt.CfgKind, cfg.Kind.String(),
 		"--" + cmdRegRt.CfgGenesisRound, strconv.FormatUint(cfg.GenesisRound, 10),

--- a/go/oasis-test-runner/scenario/e2e/common.go
+++ b/go/oasis-test-runner/scenario/e2e/common.go
@@ -14,7 +14,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
@@ -34,8 +34,8 @@ var (
 	// Flags is the command line flags for the e2e tests.
 	Flags = flag.NewFlagSet("", flag.ContinueOnError)
 
-	runtimeID    signature.PublicKey
-	keymanagerID signature.PublicKey
+	runtimeID    common.Namespace
+	keymanagerID common.Namespace
 
 	logger = logging.GetLogger("e2e/common")
 )

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -13,12 +13,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	fileSigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/file"
 	"github.com/oasislabs/oasis-core/go/common/entity"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
-	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	cmdCommon "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/consensus"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/grpc"
@@ -381,7 +382,7 @@ func (r *registryCLIImpl) newTestNode(entityID signature.PublicKey) (*node.Node,
 		},
 		Runtimes: []*node.Runtime{
 			{
-				ID: signature.PublicKey{}, // ID is set below.
+				ID: common.Namespace{}, // ID is set below.
 			},
 		},
 		Roles: node.RoleValidator,
@@ -415,7 +416,7 @@ func (r *registryCLIImpl) initNode(childEnv *env.Env, ent *entity.Entity, entDir
 			"--" + cmdRegNode.CfgNodeRuntimeID, testNode.Runtimes[0].ID.String(),
 			"--" + flags.CfgSigner, fileSigner.SignerName,
 			"--" + flags.CfgSignerDir, entDir,
-			"--" + common.CfgDataDir, dataDir,
+			"--" + cmdCommon.CfgDataDir, dataDir,
 		}
 		_, err = runSubCommandWithOutput(childEnv, "init-node", r.basicImpl.net.Config().NodeBinary, args)
 		if err != nil {
@@ -505,7 +506,7 @@ func (r *registryCLIImpl) genRegisterEntityTx(childEnv *env.Env, nonce int, txPa
 		"--" + consensus.CfgTxFeeAmount, strconv.Itoa(0),
 		"--" + consensus.CfgTxFeeGas, strconv.Itoa(feeGas),
 		"--" + flags.CfgDebugDontBlameOasis,
-		"--" + common.CfgDebugAllowTestKeys,
+		"--" + cmdCommon.CfgDebugAllowTestKeys,
 		"--" + flags.CfgSigner, fileSigner.SignerName,
 		"--" + flags.CfgSignerDir, entDir,
 		"--" + flags.CfgGenesisFile, r.basicImpl.net.GenesisPath(),
@@ -528,7 +529,7 @@ func (r *registryCLIImpl) genDeregisterEntityTx(childEnv *env.Env, nonce int, tx
 		"--" + consensus.CfgTxFeeAmount, strconv.Itoa(0),
 		"--" + consensus.CfgTxFeeGas, strconv.Itoa(feeGas),
 		"--" + flags.CfgDebugDontBlameOasis,
-		"--" + common.CfgDebugAllowTestKeys,
+		"--" + cmdCommon.CfgDebugAllowTestKeys,
 		"--" + flags.CfgSigner, fileSigner.SignerName,
 		"--" + flags.CfgSignerDir, entDir,
 		"--" + flags.CfgGenesisFile, r.basicImpl.net.GenesisPath(),
@@ -580,7 +581,7 @@ func (r *registryCLIImpl) testRuntime(childEnv *env.Env) error {
 	}
 	// Runtime ID 0x0 is for simple-keyvalue, 0xf... is for the keymanager. Let's use 0x1.
 	_ = testRuntime.ID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000001")
-	testRuntime.KeyManager = &signature.PublicKey{}
+	testRuntime.KeyManager = &common.Namespace{}
 	_ = testRuntime.KeyManager.UnmarshalHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 	// Empty genesis state root.
 	testRuntime.Genesis.StateRoot.Empty()
@@ -623,7 +624,7 @@ func (r *registryCLIImpl) testRuntime(childEnv *env.Env) error {
 }
 
 // listRuntimes lists currently registered runtimes.
-func (r *registryCLIImpl) listRuntimes(childEnv *env.Env) (map[signature.PublicKey]registry.Runtime, error) {
+func (r *registryCLIImpl) listRuntimes(childEnv *env.Env) (map[common.Namespace]registry.Runtime, error) {
 	r.logger.Info("listing all runtimes")
 	args := []string{
 		"registry", "runtime", "list",
@@ -636,7 +637,7 @@ func (r *registryCLIImpl) listRuntimes(childEnv *env.Env) (map[signature.PublicK
 	}
 	runtimesStr := strings.Split(b.String(), "\n")
 
-	runtimes := map[signature.PublicKey]registry.Runtime{}
+	runtimes := map[common.Namespace]registry.Runtime{}
 	for _, rtStr := range runtimesStr {
 		// Ignore last newline.
 		if rtStr == "" {
@@ -686,7 +687,7 @@ func (r *registryCLIImpl) genRegisterRuntimeTx(childEnv *env.Env, runtime regist
 		"--" + consensus.CfgTxFeeAmount, strconv.Itoa(0),
 		"--" + consensus.CfgTxFeeGas, strconv.Itoa(feeGas),
 		"--" + flags.CfgDebugDontBlameOasis,
-		"--" + common.CfgDebugAllowTestKeys,
+		"--" + cmdCommon.CfgDebugAllowTestKeys,
 		"--" + flags.CfgDebugTestEntity,
 		"--" + flags.CfgGenesisFile, r.basicImpl.net.GenesisPath(),
 	}

--- a/go/registry/api/grpc.go
+++ b/go/registry/api/grpc.go
@@ -231,7 +231,7 @@ func handlerGetRuntime( // nolint: golint
 	dec func(interface{}) error,
 	interceptor grpc.UnaryServerInterceptor,
 ) (interface{}, error) {
-	var query IDQuery
+	var query NamespaceQuery
 	if err := dec(&query); err != nil {
 		return nil, err
 	}
@@ -243,7 +243,7 @@ func handlerGetRuntime( // nolint: golint
 		FullMethod: methodGetRuntime.Full(),
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(Backend).GetRuntime(ctx, req.(*IDQuery))
+		return srv.(Backend).GetRuntime(ctx, req.(*NamespaceQuery))
 	}
 	return interceptor(ctx, &query, info, handler)
 }
@@ -583,7 +583,7 @@ func (c *registryClient) WatchNodeList(ctx context.Context) (<-chan *NodeList, p
 	return ch, sub, nil
 }
 
-func (c *registryClient) GetRuntime(ctx context.Context, query *IDQuery) (*Runtime, error) {
+func (c *registryClient) GetRuntime(ctx context.Context, query *NamespaceQuery) (*Runtime, error) {
 	var rsp Runtime
 	if err := c.conn.Invoke(ctx, methodGetRuntime.Full(), query, &rsp); err != nil {
 		return nil, err

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
@@ -131,7 +132,7 @@ type StorageParameters struct {
 // Runtime represents a runtime.
 type Runtime struct {
 	// ID is a globally unique long term identifier of the runtime.
-	ID signature.PublicKey `json:"id"`
+	ID common.Namespace `json:"id"`
 
 	// Genesis is the runtime genesis information.
 	Genesis RuntimeGenesis `json:"genesis"`
@@ -146,7 +147,7 @@ type Runtime struct {
 	Version VersionInfo `json:"versions"`
 
 	// KeyManager is the key manager runtime ID for this runtime.
-	KeyManager *signature.PublicKey `json:"key_manager,omitempty"`
+	KeyManager *common.Namespace `json:"key_manager,omitempty"`
 
 	// Compute stores parameters of the compute committee.
 	Compute ComputeParameters `json:"compute,omitempty"`

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/errors"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
 	"github.com/oasislabs/oasis-core/go/consensus/api/transaction"
@@ -56,13 +56,13 @@ var (
 // Backend is a root hash implementation.
 type Backend interface {
 	// GetGenesisBlock returns the genesis block.
-	GetGenesisBlock(ctx context.Context, runtimeID signature.PublicKey, height int64) (*block.Block, error)
+	GetGenesisBlock(ctx context.Context, runtimeID common.Namespace, height int64) (*block.Block, error)
 
 	// GetLatestBlock returns the latest block.
 	//
 	// The metadata contained in this block can be further used to get
 	// the latest state from the storage backend.
-	GetLatestBlock(ctx context.Context, runtimeID signature.PublicKey, height int64) (*block.Block, error)
+	GetLatestBlock(ctx context.Context, runtimeID common.Namespace, height int64) (*block.Block, error)
 
 	// WatchBlocks returns a channel that produces a stream of
 	// annotated blocks.
@@ -70,10 +70,10 @@ type Backend interface {
 	// The latest block if any will get pushed to the stream immediately.
 	// Subsequent blocks will be pushed into the stream as they are
 	// confirmed.
-	WatchBlocks(runtimeID signature.PublicKey) (<-chan *AnnotatedBlock, *pubsub.Subscription, error)
+	WatchBlocks(runtimeID common.Namespace) (<-chan *AnnotatedBlock, *pubsub.Subscription, error)
 
 	// WatchEvents returns a stream of protocol events.
-	WatchEvents(runtimeID signature.PublicKey) (<-chan *Event, *pubsub.Subscription, error)
+	WatchEvents(runtimeID common.Namespace) (<-chan *Event, *pubsub.Subscription, error)
 
 	// TrackRuntime adds a runtime the history of which should be tracked.
 	TrackRuntime(ctx context.Context, history BlockHistory) error
@@ -87,12 +87,12 @@ type Backend interface {
 
 // ComputeCommit is the argument set for the ComputeCommit method.
 type ComputeCommit struct {
-	ID      signature.PublicKey            `json:"id"`
+	ID      common.Namespace               `json:"id"`
 	Commits []commitment.ComputeCommitment `json:"commits"`
 }
 
 // NewComputeCommitTx creates a new compute commit transaction.
-func NewComputeCommitTx(nonce uint64, fee *transaction.Fee, runtimeID signature.PublicKey, commits []commitment.ComputeCommitment) *transaction.Transaction {
+func NewComputeCommitTx(nonce uint64, fee *transaction.Fee, runtimeID common.Namespace, commits []commitment.ComputeCommitment) *transaction.Transaction {
 	return transaction.NewTransaction(nonce, fee, MethodComputeCommit, &ComputeCommit{
 		ID:      runtimeID,
 		Commits: commits,
@@ -101,12 +101,12 @@ func NewComputeCommitTx(nonce uint64, fee *transaction.Fee, runtimeID signature.
 
 // MergeCommit is the argument set for the MergeCommit method.
 type MergeCommit struct {
-	ID      signature.PublicKey          `json:"id"`
+	ID      common.Namespace             `json:"id"`
 	Commits []commitment.MergeCommitment `json:"commits"`
 }
 
 // NewMergeCommitTx creates a new compute commit transaction.
-func NewMergeCommitTx(nonce uint64, fee *transaction.Fee, runtimeID signature.PublicKey, commits []commitment.MergeCommitment) *transaction.Transaction {
+func NewMergeCommitTx(nonce uint64, fee *transaction.Fee, runtimeID common.Namespace, commits []commitment.MergeCommitment) *transaction.Transaction {
 	return transaction.NewTransaction(nonce, fee, MethodMergeCommit, &MergeCommit{
 		ID:      runtimeID,
 		Commits: commits,
@@ -155,11 +155,11 @@ type MetricsMonitorable interface {
 // Genesis is the roothash genesis state.
 type Genesis struct {
 	// RuntimeStates is the per-runtime map of genesis blocks.
-	RuntimeStates map[signature.PublicKey]*api.RuntimeGenesis `json:"runtime_states,omitempty"`
+	RuntimeStates map[common.Namespace]*api.RuntimeGenesis `json:"runtime_states,omitempty"`
 }
 
 // SanityCheckBlocks examines the blocks table.
-func SanityCheckBlocks(blocks map[signature.PublicKey]*block.Block) error {
+func SanityCheckBlocks(blocks map[common.Namespace]*block.Block) error {
 	for _, blk := range blocks {
 		hdr := blk.Header
 

--- a/go/roothash/api/block/block.go
+++ b/go/roothash/api/block/block.go
@@ -1,7 +1,7 @@
 // Package block implements the roothash block and header.
 package block
 
-import "github.com/oasislabs/oasis-core/go/common/crypto/signature"
+import "github.com/oasislabs/oasis-core/go/common"
 
 // Block is an Oasis block.
 //
@@ -13,12 +13,12 @@ type Block struct {
 
 // NewGenesisBlock creates a new empty genesis block given a runtime
 // id and POSIX timestamp.
-func NewGenesisBlock(id signature.PublicKey, timestamp uint64) *Block {
+func NewGenesisBlock(id common.Namespace, timestamp uint64) *Block {
 	var blk Block
 
 	blk.Header.Version = 0
 	blk.Header.Timestamp = timestamp
-	_ = blk.Header.Namespace.UnmarshalBinary(id[:])
+	blk.Header.Namespace = id
 	blk.Header.PreviousHash.Empty()
 	blk.Header.IORoot.Empty()
 	blk.Header.StateRoot.Empty()

--- a/go/roothash/api/commitment/pool_test.go
+++ b/go/roothash/api/commitment/pool_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
@@ -60,7 +61,7 @@ func TestPoolDefault(t *testing.T) {
 	sk, err := memorySigner.NewSigner(rand.Reader)
 	require.NoError(t, err, "NewSigner")
 
-	var id signature.PublicKey
+	var id common.Namespace
 	blk := block.NewGenesisBlock(id, 0)
 
 	body := ComputeBody{
@@ -92,7 +93,7 @@ func TestPoolSingleCommitment(t *testing.T) {
 	genesisTestHelpers.SetTestChainContext()
 
 	// Generate a non-TEE runtime.
-	var rtID signature.PublicKey
+	var rtID common.Namespace
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt := &registry.Runtime{
@@ -198,7 +199,7 @@ func TestPoolSingleCommitmentTEE(t *testing.T) {
 	genesisTestHelpers.SetTestChainContext()
 
 	// Generate a TEE runtime.
-	var rtID signature.PublicKey
+	var rtID common.Namespace
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt := &registry.Runtime{
@@ -434,7 +435,7 @@ func TestPoolSerialization(t *testing.T) {
 	genesisTestHelpers.SetTestChainContext()
 
 	// Generate a non-TEE runtime.
-	var rtID signature.PublicKey
+	var rtID common.Namespace
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt := &registry.Runtime{
@@ -1096,7 +1097,7 @@ func generateMockCommittee(t *testing.T) (
 	nodeInfo map[signature.PublicKey]NodeInfo,
 ) {
 	// Generate a non-TEE runtime.
-	var rtID signature.PublicKey
+	var rtID common.Namespace
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt = &registry.Runtime{
@@ -1158,7 +1159,7 @@ func generateMockCommittee(t *testing.T) (
 }
 
 func generateComputeBody(t *testing.T, committee *scheduler.Committee) (*block.Block, *block.Block, ComputeBody) {
-	var id signature.PublicKey
+	var id common.Namespace
 	childBlk := block.NewGenesisBlock(id, 0)
 	parentBlk := block.NewEmptyBlock(childBlk, 1, block.Normal)
 

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -3,7 +3,7 @@ package api
 import (
 	"context"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
 )
 
@@ -12,7 +12,7 @@ import (
 // All methods operate on a specific runtime.
 type BlockHistory interface {
 	// RuntimeID returns the runtime ID of the runtime this block history is for.
-	RuntimeID() signature.PublicKey
+	RuntimeID() common.Namespace
 
 	// Commit commits an annotated block into history.
 	//

--- a/go/roothash/metrics.go
+++ b/go/roothash/metrics.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/oasislabs/oasis-core/go/common"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
 	"github.com/oasislabs/oasis-core/go/roothash/api"
 )
@@ -40,7 +39,7 @@ type metricsWrapper struct {
 	api.Backend
 }
 
-func (w *metricsWrapper) WatchBlocks(id signature.PublicKey) (<-chan *api.AnnotatedBlock, *pubsub.Subscription, error) {
+func (w *metricsWrapper) WatchBlocks(id common.Namespace) (<-chan *api.AnnotatedBlock, *pubsub.Subscription, error) {
 	return w.Backend.WatchBlocks(id)
 }
 

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -416,7 +416,7 @@ func mustGetCommittee(
 			if committee.ValidFor < epoch {
 				continue
 			}
-			if !rt.Runtime.ID.Equal(committee.RuntimeID) {
+			if !rt.Runtime.ID.Equal(&committee.RuntimeID) {
 				continue
 			}
 

--- a/go/runtime/client/api/api.go
+++ b/go/runtime/client/api/api.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"math"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/errors"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
@@ -56,7 +56,7 @@ type RuntimeClient interface {
 	QueryTxs(ctx context.Context, request *QueryTxsRequest) ([]*TxResult, error)
 
 	// WatchBlocks subscribes to blocks for a specific runtimes.
-	WatchBlocks(ctx context.Context, runtimeID signature.PublicKey) (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error)
+	WatchBlocks(ctx context.Context, runtimeID common.Namespace) (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error)
 
 	// WaitBlockIndexed waits for a runtime block to be indexed by the indexer.
 	WaitBlockIndexed(ctx context.Context, request *WaitBlockIndexedRequest) error
@@ -67,20 +67,20 @@ type RuntimeClient interface {
 
 // SubmitTxRequest is a SubmitTx request.
 type SubmitTxRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
-	Data      []byte              `json:"data"`
+	RuntimeID common.Namespace `json:"runtime_id"`
+	Data      []byte           `json:"data"`
 }
 
 // GetBlockRequest is a GetBlock request.
 type GetBlockRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
-	Round     uint64              `json:"round"`
+	RuntimeID common.Namespace `json:"runtime_id"`
+	Round     uint64           `json:"round"`
 }
 
 // GetBlockByHashRequest is a GetBlockByHash request.
 type GetBlockByHashRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
-	BlockHash hash.Hash           `json:"block_hash"`
+	RuntimeID common.Namespace `json:"runtime_id"`
+	BlockHash hash.Hash        `json:"block_hash"`
 }
 
 // TxResult is the transaction query result.
@@ -93,30 +93,30 @@ type TxResult struct {
 
 // GetTxRequest is a GetTx request.
 type GetTxRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
-	Round     uint64              `json:"round"`
-	Index     uint32              `json:"index"`
+	RuntimeID common.Namespace `json:"runtime_id"`
+	Round     uint64           `json:"round"`
+	Index     uint32           `json:"index"`
 }
 
 // GetTxByBlockHashRequest is a GetTxByBlockHash request.
 type GetTxByBlockHashRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
-	BlockHash hash.Hash           `json:"block_hash"`
-	Index     uint32              `json:"index"`
+	RuntimeID common.Namespace `json:"runtime_id"`
+	BlockHash hash.Hash        `json:"block_hash"`
+	Index     uint32           `json:"index"`
 }
 
 // GetTxsRequest is a GetTxs request.
 type GetTxsRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
-	Round     uint64              `json:"round"`
-	IORoot    hash.Hash           `json:"io_root"`
+	RuntimeID common.Namespace `json:"runtime_id"`
+	Round     uint64           `json:"round"`
+	IORoot    hash.Hash        `json:"io_root"`
 }
 
 // QueryTxRequest is a QueryTx request.
 type QueryTxRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
-	Key       []byte              `json:"key"`
-	Value     []byte              `json:"value"`
+	RuntimeID common.Namespace `json:"runtime_id"`
+	Key       []byte           `json:"key"`
+	Value     []byte           `json:"value"`
 }
 
 // QueryCondition is a query condition.
@@ -152,12 +152,12 @@ type Query struct {
 
 // QueryTxsRequest is a QueryTxs request.
 type QueryTxsRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
-	Query     Query               `json:"query"`
+	RuntimeID common.Namespace `json:"runtime_id"`
+	Query     Query            `json:"query"`
 }
 
 // WaitBlockIndexedRequest is a WaitBlockIndexed request.
 type WaitBlockIndexedRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
-	Round     uint64              `json:"round"`
+	RuntimeID common.Namespace `json:"runtime_id"`
+	Round     uint64           `json:"round"`
 }

--- a/go/runtime/client/api/grpc.go
+++ b/go/runtime/client/api/grpc.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/errors"
 	cmnGrpc "github.com/oasislabs/oasis-core/go/common/grpc"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
@@ -339,7 +339,7 @@ func handlerWaitBlockIndexed( // nolint: golint
 }
 
 func handlerWatchBlocks(srv interface{}, stream grpc.ServerStream) error {
-	var runtimeID signature.PublicKey
+	var runtimeID common.Namespace
 	if err := stream.RecvMsg(&runtimeID); err != nil {
 		return err
 	}
@@ -446,7 +446,7 @@ func (c *runtimeClient) WaitBlockIndexed(ctx context.Context, request *WaitBlock
 	return c.conn.Invoke(ctx, methodWaitBlockIndexed.Full(), request, nil)
 }
 
-func (c *runtimeClient) WatchBlocks(ctx context.Context, runtimeID signature.PublicKey) (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error) {
+func (c *runtimeClient) WatchBlocks(ctx context.Context, runtimeID common.Namespace) (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error) {
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 
 	stream, err := c.conn.NewStream(ctx, &serviceDesc.Streams[0], methodWatchBlocks.Full())

--- a/go/runtime/client/client.go
+++ b/go/runtime/client/client.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
 	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
@@ -70,12 +70,12 @@ type runtimeClient struct {
 
 	common *clientCommon
 
-	watchers map[signature.PublicKey]*blockWatcher
+	watchers map[common.Namespace]*blockWatcher
 
 	logger *logging.Logger
 }
 
-func (c *runtimeClient) tagIndexer(runtimeID signature.PublicKey) (tagindexer.QueryableBackend, error) {
+func (c *runtimeClient) tagIndexer(runtimeID common.Namespace) (tagindexer.QueryableBackend, error) {
 	rt, err := c.common.runtimeRegistry.GetRuntime(runtimeID)
 	if err != nil {
 		return nil, err
@@ -211,7 +211,7 @@ func (c *runtimeClient) SubmitTx(ctx context.Context, request *api.SubmitTxReque
 }
 
 // Implements api.RuntimeClient.
-func (c *runtimeClient) WatchBlocks(ctx context.Context, runtimeID signature.PublicKey) (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error) {
+func (c *runtimeClient) WatchBlocks(ctx context.Context, runtimeID common.Namespace) (<-chan *roothash.AnnotatedBlock, pubsub.ClosableSubscription, error) {
 	return c.common.roothash.WatchBlocks(runtimeID)
 }
 
@@ -479,7 +479,7 @@ func New(
 			runtimeRegistry: runtimeRegistry,
 			ctx:             ctx,
 		},
-		watchers: make(map[signature.PublicKey]*blockWatcher),
+		watchers: make(map[common.Namespace]*blockWatcher),
 		logger:   logging.GetLogger("runtime/client"),
 	}
 	return c, nil

--- a/go/runtime/client/tests/tester.go
+++ b/go/runtime/client/tests/tester.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/runtime/client/api"
 )
 
@@ -22,7 +22,7 @@ const timeout = 2 * time.Second
 func ClientImplementationTests(
 	t *testing.T,
 	client api.RuntimeClient,
-	runtimeID signature.PublicKey,
+	runtimeID common.Namespace,
 ) {
 	t.Run("SubmitTx", func(t *testing.T) {
 		ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
@@ -40,7 +40,7 @@ func ClientImplementationTests(
 func testSubmitTransaction(
 	ctx context.Context,
 	t *testing.T,
-	runtimeID signature.PublicKey,
+	runtimeID common.Namespace,
 	c api.RuntimeClient,
 ) {
 	// Submit a test transaction.
@@ -55,7 +55,7 @@ func testSubmitTransaction(
 func testQuery(
 	ctx context.Context,
 	t *testing.T,
-	runtimeID signature.PublicKey,
+	runtimeID common.Namespace,
 	c api.RuntimeClient,
 ) {
 	err := c.WaitBlockIndexed(ctx, &api.WaitBlockIndexedRequest{RuntimeID: runtimeID, Round: 4})

--- a/go/runtime/client/watcher.go
+++ b/go/runtime/client/watcher.go
@@ -10,8 +10,8 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/resolver"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	cmnGrpc "github.com/oasislabs/oasis-core/go/common/grpc"
 	"github.com/oasislabs/oasis-core/go/common/grpc/resolver/manual"
 	"github.com/oasislabs/oasis-core/go/common/identity"
@@ -96,7 +96,7 @@ type blockWatcher struct {
 	service.BaseBackgroundService
 
 	common *clientCommon
-	id     signature.PublicKey
+	id     common.Namespace
 
 	watched map[hash.Hash]*watchRequest
 	newCh   chan *watchRequest
@@ -281,7 +281,7 @@ func (w *blockWatcher) Stop() {
 	close(w.stopCh)
 }
 
-func newWatcher(common *clientCommon, id signature.PublicKey) (*blockWatcher, error) {
+func newWatcher(common *clientCommon, id common.Namespace) (*blockWatcher, error) {
 	svc := service.NewBaseBackgroundService("client/watcher")
 	watcher := &blockWatcher{
 		BaseBackgroundService:   *svc,

--- a/go/runtime/enclaverpc/api/api.go
+++ b/go/runtime/enclaverpc/api/api.go
@@ -4,7 +4,7 @@ package api
 import (
 	"context"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 )
 
 // Transport is the EnclaveRPC transport interface.
@@ -15,8 +15,8 @@ type Transport interface {
 
 // CallEnclaveRequest is a CallEnclave request.
 type CallEnclaveRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
-	Endpoint  string              `json:"endpoint"`
+	RuntimeID common.Namespace `json:"runtime_id"`
+	Endpoint  string           `json:"endpoint"`
 
 	Payload []byte `json:"payload"`
 }

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/eapache/channels"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
@@ -53,10 +53,10 @@ type History interface {
 }
 
 type nopHistory struct {
-	runtimeID signature.PublicKey
+	runtimeID common.Namespace
 }
 
-func (h *nopHistory) RuntimeID() signature.PublicKey {
+func (h *nopHistory) RuntimeID() common.Namespace {
 	return h.runtimeID
 }
 
@@ -85,12 +85,12 @@ func (h *nopHistory) Close() {
 }
 
 // NewNop creates a new no-op runtime history keeper.
-func NewNop(runtimeID signature.PublicKey) History {
+func NewNop(runtimeID common.Namespace) History {
 	return &nopHistory{runtimeID: runtimeID}
 }
 
 type runtimeHistory struct {
-	runtimeID signature.PublicKey
+	runtimeID common.Namespace
 
 	logger *logging.Logger
 
@@ -106,7 +106,7 @@ type runtimeHistory struct {
 	quitCh        chan struct{}
 }
 
-func (h *runtimeHistory) RuntimeID() signature.PublicKey {
+func (h *runtimeHistory) RuntimeID() common.Namespace {
 	return h.runtimeID
 }
 
@@ -191,7 +191,7 @@ func (h *runtimeHistory) pruneWorker() {
 }
 
 // New creates a new runtime history keeper.
-func New(dataDir string, runtimeID signature.PublicKey, cfg *Config) (History, error) {
+func New(dataDir string, runtimeID common.Namespace, cfg *Config) (History, error) {
 	db, err := newDB(filepath.Join(dataDir, DbFilename), runtimeID)
 	if err != nil {
 		return nil, err

--- a/go/runtime/history/history_test.go
+++ b/go/runtime/history/history_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
 )
@@ -25,9 +25,9 @@ func TestHistory(t *testing.T) {
 	require.NoError(err, "TempDir")
 	defer os.RemoveAll(dataDir)
 
-	var runtimeID signature.PublicKey
+	var runtimeID common.Namespace
 	_ = runtimeID.UnmarshalHex("1000000000000000000000000000000000000000000000000000000000000001")
-	var runtimeID2 signature.PublicKey
+	var runtimeID2 common.Namespace
 	_ = runtimeID2.UnmarshalHex("1000000000000000000000000000000000000000000000000000000000000002")
 
 	history, err := New(dataDir, runtimeID, NewDefaultConfig())
@@ -139,7 +139,7 @@ func TestHistoryPrune(t *testing.T) {
 	require.NoError(err, "TempDir")
 	defer os.RemoveAll(dataDir)
 
-	var runtimeID signature.PublicKey
+	var runtimeID common.Namespace
 	_ = runtimeID.UnmarshalHex("1000000000000000000000000000000000000000000000000000000000000001")
 
 	history, err := New(dataDir, runtimeID, &Config{
@@ -209,7 +209,7 @@ func TestHistoryPruneError(t *testing.T) {
 	require.NoError(err, "TempDir")
 	defer os.RemoveAll(dataDir)
 
-	var runtimeID signature.PublicKey
+	var runtimeID common.Namespace
 	_ = runtimeID.UnmarshalHex("1000000000000000000000000000000000000000000000000000000000000001")
 
 	history, err := New(dataDir, runtimeID, &Config{

--- a/go/runtime/localstorage/localstorage.go
+++ b/go/runtime/localstorage/localstorage.go
@@ -11,9 +11,9 @@ import (
 	"github.com/dgraph-io/badger/v2"
 	"github.com/dgraph-io/badger/v2/options"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	cmnBadger "github.com/oasislabs/oasis-core/go/common/badger"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 )
 
@@ -103,7 +103,7 @@ func (s *localStorage) Stop() {
 }
 
 // New creates new untrusted local storage.
-func New(dataDir, fn string, runtimeID signature.PublicKey) (LocalStorage, error) {
+func New(dataDir, fn string, runtimeID common.Namespace) (LocalStorage, error) {
 	s := &localStorage{
 		logger: logging.GetLogger("runtime/localstorage").With("runtime_id", runtimeID),
 	}

--- a/go/runtime/registry/helpers.go
+++ b/go/runtime/registry/helpers.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/oasislabs/oasis-core/go/common"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 )
 
 const (
@@ -17,7 +16,7 @@ const (
 
 // EnsureRuntimeStateDir ensures a specific per-runtime directory exists and
 // returns its full path.
-func EnsureRuntimeStateDir(dataDir string, runtimeID signature.PublicKey) (string, error) {
+func EnsureRuntimeStateDir(dataDir string, runtimeID common.Namespace) (string, error) {
 	path := filepath.Join(dataDir, RuntimesDir, runtimeID.String())
 	if err := common.Mkdir(path); err != nil {
 		return "", err
@@ -28,12 +27,12 @@ func EnsureRuntimeStateDir(dataDir string, runtimeID signature.PublicKey) (strin
 
 // ParseRuntimeMap parses strings in the format of <runtime-id>[:<value>] and
 // returns them as a map of runtime IDs to value.
-func ParseRuntimeMap(rawItems []string) (map[signature.PublicKey]string, error) {
-	result := make(map[signature.PublicKey]string, len(rawItems))
+func ParseRuntimeMap(rawItems []string) (map[common.Namespace]string, error) {
+	result := make(map[common.Namespace]string, len(rawItems))
 	for _, rawItem := range rawItems {
 		atoms := strings.SplitN(rawItem, ":", 2)
 
-		var id signature.PublicKey
+		var id common.Namespace
 		if err := id.UnmarshalHex(atoms[0]); err != nil {
 			return nil, fmt.Errorf("malformed runtime map item: %s", rawItem)
 		}

--- a/go/runtime/registry/storage_router.go
+++ b/go/runtime/registry/storage_router.go
@@ -14,11 +14,7 @@ type storageRouter struct {
 }
 
 func (sr *storageRouter) getRuntime(ns common.Namespace) (Runtime, error) {
-	id, err := ns.ToRuntimeID()
-	if err != nil {
-		return nil, err
-	}
-	return sr.registry.GetRuntime(id)
+	return sr.registry.GetRuntime(ns)
 }
 
 func (sr *storageRouter) SyncGet(ctx context.Context, request *api.GetRequest) (*api.ProofResponse, error) {

--- a/go/runtime/tagindexer/backend.go
+++ b/go/runtime/tagindexer/backend.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/runtime/client/api"
 	"github.com/oasislabs/oasis-core/go/runtime/transaction"
 )
@@ -39,7 +39,7 @@ type Result struct {
 type Results map[uint64][]Result
 
 // BackendFactory is the tag indexer backend factory interface.
-type BackendFactory func(dataDir string, runtimeID signature.PublicKey) (Backend, error)
+type BackendFactory func(dataDir string, runtimeID common.Namespace) (Backend, error)
 
 // QueryableBackend is the read-only tag indexer backend interface.
 type QueryableBackend interface {
@@ -132,7 +132,7 @@ func (n *nopBackend) Close() {
 
 // NewNopBackend creates a new no-op backend that doesn't perform any indexing.
 func NewNopBackend() BackendFactory {
-	return func(string, signature.PublicKey) (Backend, error) {
+	return func(string, common.Namespace) (Backend, error) {
 		return &nopBackend{}, nil
 	}
 }

--- a/go/runtime/tagindexer/backend_test.go
+++ b/go/runtime/tagindexer/backend_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/runtime/client/api"
 	"github.com/oasislabs/oasis-core/go/runtime/transaction"
 )
@@ -170,7 +170,7 @@ func testBackend(t *testing.T, factory BackendFactory) {
 	require.NoError(t, err, "TempDir")
 	defer os.RemoveAll(dataDir)
 
-	var id signature.PublicKey
+	var id common.Namespace
 
 	t.Run("Operations", func(t *testing.T) {
 		var backend Backend

--- a/go/runtime/tagindexer/bleve.go
+++ b/go/runtime/tagindexer/bleve.go
@@ -10,8 +10,8 @@ import (
 	"github.com/blevesearch/bleve/index/scorch"
 	bleveQuery "github.com/blevesearch/bleve/search/query"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/keyformat"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
@@ -388,7 +388,7 @@ func (b *bleveBackend) Close() {
 	b.index = nil
 }
 
-func newBleveBackend(dataDir string, runtimeID signature.PublicKey) (Backend, error) {
+func newBleveBackend(dataDir string, runtimeID common.Namespace) (Backend, error) {
 	b := &bleveBackend{
 		logger:               logging.GetLogger("runtime/history/tagindexer/bleve").With("runtime_id", runtimeID),
 		blockIndexedNotifier: pubsub.NewBroker(true),

--- a/go/runtime/tagindexer/tagindexer.go
+++ b/go/runtime/tagindexer/tagindexer.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cenkalti/backoff"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/service"
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
@@ -28,7 +28,7 @@ type Service struct {
 	service.BaseBackgroundService
 	QueryableBackend
 
-	runtimeID signature.PublicKey
+	runtimeID common.Namespace
 	backend   Backend
 	roothash  roothash.Backend
 	storage   storage.Backend

--- a/go/scheduler/api/api.go
+++ b/go/scheduler/api/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
@@ -121,7 +122,7 @@ type Committee struct {
 	Members []*CommitteeNode `json:"members"`
 
 	// RuntimeID is the runtime ID that this committee is for.
-	RuntimeID signature.PublicKey `json:"runtime_id"`
+	RuntimeID common.Namespace `json:"runtime_id"`
 
 	// ValidFor is the epoch for which the committee is valid.
 	ValidFor epochtime.EpochTime `json:"valid_for"`
@@ -183,8 +184,8 @@ type Backend interface {
 
 // GetCommitteesRequest is a GetCommittees request.
 type GetCommitteesRequest struct {
-	Height    int64               `json:"height"`
-	RuntimeID signature.PublicKey `json:"runtime_id"`
+	Height    int64            `json:"height"`
+	RuntimeID common.Namespace `json:"runtime_id"`
 }
 
 // Genesis is the committee scheduler genesis state.

--- a/go/scheduler/tests/tester.go
+++ b/go/scheduler/tests/tester.go
@@ -51,7 +51,7 @@ func SchedulerImplementationTests(t *testing.T, name string, backend api.Backend
 				if committee.ValidFor < epoch {
 					continue
 				}
-				if !rt.Runtime.ID.Equal(committee.RuntimeID) {
+				if !rt.Runtime.ID.Equal(&committee.RuntimeID) {
 					continue
 				}
 

--- a/go/staking/tests/tester.go
+++ b/go/staking/tests/tester.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/entity"
 	"github.com/oasislabs/oasis-core/go/common/identity"
@@ -45,7 +46,7 @@ func StakingImplementationTests(
 	identity *identity.Identity,
 	entity *entity.Entity,
 	entitySigner signature.Signer,
-	runtimeID signature.PublicKey,
+	runtimeID common.Namespace,
 ) {
 	for _, tc := range []struct {
 		n  string
@@ -488,7 +489,7 @@ func testSlashDoubleSigning(
 	ident *identity.Identity,
 	ent *entity.Entity,
 	entSigner signature.Signer,
-	runtimeID signature.PublicKey,
+	runtimeID common.Namespace,
 ) {
 	require := require.New(t)
 

--- a/go/storage/client/tests/tests.go
+++ b/go/storage/client/tests/tests.go
@@ -9,9 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	consensusAPI "github.com/oasislabs/oasis-core/go/consensus/api"
@@ -24,12 +22,6 @@ import (
 )
 
 const recvTimeout = 5 * time.Second
-
-func runtimeIDToNamespace(t *testing.T, runtimeID signature.PublicKey) (ns common.Namespace) {
-	err := ns.UnmarshalBinary(runtimeID[:])
-	require.NoError(t, err, "runtimeIDToNamespace")
-	return
-}
 
 // ClientWorkerTests implements tests for client worker.
 func ClientWorkerTests(
@@ -49,7 +41,7 @@ func ClientWorkerTests(
 	// Populate the registry with an entity and nodes.
 	nodes := rt.Populate(t, consensus.Registry(), consensus, seed)
 
-	ns := runtimeIDToNamespace(t, rt.Runtime.ID)
+	ns := rt.Runtime.ID
 
 	// Initialize storage client.
 	client, err := storageClient.New(ctx, ns, identity, consensus.Scheduler(), consensus.Registry())

--- a/go/storage/client/watcher.go
+++ b/go/storage/client/watcher.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/resolver"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	cmnGrpc "github.com/oasislabs/oasis-core/go/common/grpc"
 	"github.com/oasislabs/oasis-core/go/common/grpc/resolver/manual"
@@ -101,7 +102,7 @@ type watcherState struct {
 	scheduler scheduler.Backend
 	registry  registry.Backend
 
-	runtimeID signature.PublicKey
+	runtimeID common.Namespace
 
 	identity *identity.Identity
 
@@ -350,7 +351,7 @@ func (w *watcherState) watch(ctx context.Context) {
 
 func newWatcher(
 	ctx context.Context,
-	runtimeID signature.PublicKey,
+	runtimeID common.Namespace,
 	identity *identity.Identity,
 	schedulerBackend scheduler.Backend,
 	registryBackend registry.Backend,

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	opentracingExt "github.com/opentracing/opentracing-go/ext"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/identity"
@@ -211,7 +212,7 @@ type Group struct {
 	sync.RWMutex
 
 	identity  *identity.Identity
-	runtimeID signature.PublicKey
+	runtimeID common.Namespace
 
 	scheduler scheduler.Backend
 	registry  registry.Backend
@@ -350,7 +351,7 @@ func (g *Group) EpochTransition(ctx context.Context, height int64) error {
 	}
 
 	// Fetch current runtime descriptor.
-	runtime, err := g.registry.GetRuntime(ctx, &registry.IDQuery{ID: g.runtimeID, Height: height})
+	runtime, err := g.registry.GetRuntime(ctx, &registry.NamespaceQuery{ID: g.runtimeID, Height: height})
 	if err != nil {
 		return err
 	}
@@ -587,7 +588,7 @@ func (g *Group) PublishComputeFinished(spanCtx opentracing.SpanContext, c *commi
 // NewGroup creates a new group.
 func NewGroup(
 	identity *identity.Identity,
-	runtimeID signature.PublicKey,
+	runtimeID common.Namespace,
 	handler MessageHandler,
 	registry registry.Backend,
 	roothash roothash.Backend,

--- a/go/worker/common/config.go
+++ b/go/worker/common/config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/oasislabs/oasis-core/go/common"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/crypto/tls"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
@@ -63,7 +62,7 @@ type Config struct { // nolint: maligned
 
 // RuntimeHostRuntimeConfig is a single runtime's host configuration.
 type RuntimeHostRuntimeConfig struct {
-	ID     signature.PublicKey
+	ID     common.Namespace
 	Binary string
 }
 
@@ -71,7 +70,7 @@ type RuntimeHostRuntimeConfig struct {
 type RuntimeHostConfig struct {
 	Backend  string
 	Loader   string
-	Runtimes map[signature.PublicKey]RuntimeHostRuntimeConfig
+	Runtimes map[common.Namespace]RuntimeHostRuntimeConfig
 }
 
 // GetNodeAddresses returns worker node addresses.
@@ -157,7 +156,7 @@ func newConfig() (*Config, error) {
 		cfg.RuntimeHost = &RuntimeHostConfig{
 			Backend:  viper.GetString(CfgRuntimeBackend),
 			Loader:   runtimeLoader,
-			Runtimes: make(map[signature.PublicKey]RuntimeHostRuntimeConfig),
+			Runtimes: make(map[common.Namespace]RuntimeHostRuntimeConfig),
 		}
 
 		for id, path := range runtimeBinaries {

--- a/go/worker/common/configparser/configparser.go
+++ b/go/worker/common/configparser/configparser.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/node"
 )
 
@@ -40,10 +40,10 @@ func ParseAddressList(addresses []string) ([]node.Address, error) {
 }
 
 // GetRuntimes parses hex strings to PublicKeys
-func GetRuntimes(runtimeIDsHex []string) ([]signature.PublicKey, error) {
-	var runtimes []signature.PublicKey
+func GetRuntimes(runtimeIDsHex []string) ([]common.Namespace, error) {
+	var runtimes []common.Namespace
 	for _, runtimeHex := range runtimeIDsHex {
-		var runtime signature.PublicKey
+		var runtime common.Namespace
 		if err := runtime.UnmarshalHex(runtimeHex); err != nil {
 			return nil, err
 		}

--- a/go/worker/common/host/sandboxed.go
+++ b/go/worker/common/host/sandboxed.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/ctxsync"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
@@ -320,7 +320,7 @@ type teeStateIntelSGX struct {
 	ias  ias.Endpoint
 	aesm *aesm.Client
 
-	runtimeID signature.PublicKey
+	runtimeID common.Namespace
 
 	epidGID   uint32
 	spid      cmnIAS.SPID
@@ -436,7 +436,7 @@ type Config struct { //nolint: maligned
 	Role node.RolesMask
 
 	// ID is the runtime ID of this worker host.
-	ID signature.PublicKey
+	ID common.Namespace
 
 	// WorkerBinary is the path to the worker executable binary, typically
 	// the loader.

--- a/go/worker/common/host/sandboxed_test.go
+++ b/go/worker/common/host/sandboxed_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/logging"
@@ -65,7 +66,7 @@ func TestSandboxedHost(t *testing.T) {
 	ias, err := ias.New(nil)
 	require.NoError(t, err, "ias.New")
 
-	var testID signature.PublicKey
+	var testID common.Namespace
 	_ = testID.UnmarshalBinary(make([]byte, signature.PublicKeySize))
 
 	// Create host with sandbox disabled.

--- a/go/worker/common/p2p/p2p.go
+++ b/go/worker/common/p2p/p2p.go
@@ -20,6 +20,7 @@ import (
 	"github.com/multiformats/go-multiaddr-net"
 	"github.com/spf13/viper"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/logging"
@@ -58,7 +59,7 @@ type P2P struct {
 	registerAddresses []multiaddr.Multiaddr
 
 	host     core.Host
-	handlers map[signature.PublicKey]Handler
+	handlers map[common.Namespace]Handler
 
 	logger *logging.Logger
 }
@@ -224,7 +225,7 @@ func (p *P2P) Flush() {
 }
 
 // RegisterHandler registeres a message handler for the specified runtime.
-func (p *P2P) RegisterHandler(runtimeID signature.PublicKey, handler Handler) {
+func (p *P2P) RegisterHandler(runtimeID common.Namespace, handler Handler) {
 	p.Lock()
 	p.handlers[runtimeID] = handler
 	p.Unlock()
@@ -395,7 +396,7 @@ func New(ctx context.Context, identity *identity.Identity) (*P2P, error) {
 	p := &P2P{
 		registerAddresses: registerAddresses,
 		host:              host,
-		handlers:          make(map[signature.PublicKey]Handler),
+		handlers:          make(map[common.Namespace]Handler),
 		logger:            logging.GetLogger("worker/common/p2p"),
 	}
 

--- a/go/worker/common/p2p/types.go
+++ b/go/worker/common/p2p/types.go
@@ -1,7 +1,7 @@
 package p2p
 
 import (
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/roothash/api/commitment"
 )
 
@@ -12,7 +12,7 @@ import (
 type Message struct {
 	// RuntimeID is the identifier of the runtime this message
 	// belongs to. It is used as a namespace.
-	RuntimeID signature.PublicKey `json:"runtime_id,omitempty"`
+	RuntimeID common.Namespace `json:"runtime_id,omitempty"`
 
 	// GroupVersion is the version of all elected committees (the consensus
 	// block height of last processed committee election). Messages with

--- a/go/worker/common/runtime_host.go
+++ b/go/worker/common/runtime_host.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
 	keymanagerApi "github.com/oasislabs/oasis-core/go/keymanager/api"
@@ -153,7 +153,7 @@ func (f *runtimeWorkerHostSandboxedFactory) NewWorkerHost(cfg host.Config) (host
 }
 
 // NewRuntimeWorkerHostFactory creates a new worker host factory for the given runtime.
-func (rw *RuntimeHostWorker) NewRuntimeWorkerHostFactory(role node.RolesMask, id signature.PublicKey) (h host.Factory, err error) {
+func (rw *RuntimeHostWorker) NewRuntimeWorkerHostFactory(role node.RolesMask, id common.Namespace) (h host.Factory, err error) {
 	cfg := rw.commonWorker.GetConfig().RuntimeHost
 	rtCfg, ok := cfg.Runtimes[id]
 	if !ok {

--- a/go/worker/common/worker.go
+++ b/go/worker/common/worker.go
@@ -3,7 +3,7 @@ package common
 import (
 	"fmt"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/grpc"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/logging"
@@ -38,7 +38,7 @@ type Worker struct {
 	RuntimeRegistry  runtimeRegistry.Registry
 	GenesisDoc       *genesis.Document
 
-	runtimes map[signature.PublicKey]*committee.Node
+	runtimes map[common.Namespace]*committee.Node
 
 	quitCh chan struct{}
 	initCh chan struct{}
@@ -149,7 +149,7 @@ func (w *Worker) GetConfig() Config {
 }
 
 // GetRuntimes returns a map of registered runtimes.
-func (w *Worker) GetRuntimes() map[signature.PublicKey]*committee.Node {
+func (w *Worker) GetRuntimes() map[common.Namespace]*committee.Node {
 	return w.runtimes
 }
 
@@ -157,7 +157,7 @@ func (w *Worker) GetRuntimes() map[signature.PublicKey]*committee.Node {
 //
 // In case the runtime with the specified id was not registered it
 // returns nil.
-func (w *Worker) GetRuntime(id signature.PublicKey) *committee.Node {
+func (w *Worker) GetRuntime(id common.Namespace) *committee.Node {
 	return w.runtimes[id]
 }
 
@@ -245,7 +245,7 @@ func newWorker(
 		KeyManagerClient: keyManagerClient,
 		RuntimeRegistry:  runtimeRegistry,
 		GenesisDoc:       genesisDoc,
-		runtimes:         make(map[signature.PublicKey]*committee.Node),
+		runtimes:         make(map[common.Namespace]*committee.Node),
 		quitCh:           make(chan struct{}),
 		initCh:           make(chan struct{}),
 		logger:           logging.GetLogger("worker/common"),

--- a/go/worker/compute/tests/tester.go
+++ b/go/worker/compute/tests/tester.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	epochtimeTests "github.com/oasislabs/oasis-core/go/epochtime/tests"
 	"github.com/oasislabs/oasis-core/go/worker/compute"
@@ -22,7 +22,7 @@ const recvTimeout = 5 * time.Second
 func WorkerImplementationTests(
 	t *testing.T,
 	worker *compute.Worker,
-	runtimeID signature.PublicKey,
+	runtimeID common.Namespace,
 	rtNode *committee.Node,
 	epochtime epochtime.SetableBackend,
 ) {

--- a/go/worker/compute/worker.go
+++ b/go/worker/compute/worker.go
@@ -3,7 +3,7 @@ package compute
 import (
 	"context"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	workerCommon "github.com/oasislabs/oasis-core/go/worker/common"
@@ -23,7 +23,7 @@ type Worker struct {
 	merge        *merge.Worker
 	registration *registration.Worker
 
-	runtimes map[signature.PublicKey]*committee.Node
+	runtimes map[common.Namespace]*committee.Node
 
 	ctx       context.Context
 	cancelCtx context.CancelFunc
@@ -132,7 +132,7 @@ func (w *Worker) Initialized() <-chan struct{} {
 //
 // In case the runtime with the specified id was not registered it
 // returns nil.
-func (w *Worker) GetRuntime(id signature.PublicKey) *committee.Node {
+func (w *Worker) GetRuntime(id common.Namespace) *committee.Node {
 	return w.runtimes[id]
 }
 
@@ -181,7 +181,7 @@ func newWorker(
 		commonWorker: commonWorker,
 		merge:        merge,
 		registration: registration,
-		runtimes:     make(map[signature.PublicKey]*committee.Node),
+		runtimes:     make(map[common.Namespace]*committee.Node),
 		ctx:          ctx,
 		cancelCtx:    cancelCtx,
 		quitCh:       make(chan struct{}),

--- a/go/worker/merge/committee/node.go
+++ b/go/worker/merge/committee/node.go
@@ -209,7 +209,8 @@ func (n *Node) newStateWaitingForResultsLocked(epoch *committee.EpochSnapshot) S
 		for idx, nd := range ci.Nodes {
 			var nodeRuntime *node.Runtime
 			for _, r := range nd.Runtimes {
-				if !r.ID.Equal(n.commonNode.Runtime.ID()) {
+				nrtID := n.commonNode.Runtime.ID()
+				if !r.ID.Equal(&nrtID) {
 					continue
 				}
 				nodeRuntime = r

--- a/go/worker/merge/worker.go
+++ b/go/worker/merge/worker.go
@@ -3,7 +3,7 @@ package merge
 import (
 	"context"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	workerCommon "github.com/oasislabs/oasis-core/go/worker/common"
@@ -19,7 +19,7 @@ type Worker struct {
 	commonWorker       *workerCommon.Worker
 	registrationWorker *registration.Worker
 
-	runtimes map[signature.PublicKey]*committee.Node
+	runtimes map[common.Namespace]*committee.Node
 
 	ctx       context.Context
 	cancelCtx context.CancelFunc
@@ -127,7 +127,7 @@ func (w *Worker) Initialized() <-chan struct{} {
 //
 // In case the runtime with the specified id was not registered it
 // returns nil.
-func (w *Worker) GetRuntime(id signature.PublicKey) *committee.Node {
+func (w *Worker) GetRuntime(id common.Namespace) *committee.Node {
 	return w.runtimes[id]
 }
 
@@ -159,7 +159,7 @@ func newWorker(enabled bool, commonWorker *workerCommon.Worker, registrationWork
 		enabled:            enabled,
 		commonWorker:       commonWorker,
 		registrationWorker: registrationWorker,
-		runtimes:           make(map[signature.PublicKey]*committee.Node),
+		runtimes:           make(map[common.Namespace]*committee.Node),
 		ctx:                ctx,
 		cancelCtx:          cancelCtx,
 		quitCh:             make(chan struct{}),

--- a/go/worker/storage/api/api.go
+++ b/go/worker/storage/api/api.go
@@ -3,7 +3,7 @@ package api
 import (
 	"context"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/errors"
 	storage "github.com/oasislabs/oasis-core/go/storage/api"
 )
@@ -25,7 +25,7 @@ type StorageWorker interface {
 
 // GetLastSyncedRoundRequest is a GetLastSyncedRound request.
 type GetLastSyncedRoundRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
+	RuntimeID common.Namespace `json:"runtime_id"`
 }
 
 // GetLastSyncedRoundResponse is a GetLastSyncedRound response.
@@ -37,6 +37,6 @@ type GetLastSyncedRoundResponse struct {
 
 // ForceFinalizeRequest is a ForceFinalize request.
 type ForceFinalizeRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
-	Round     uint64              `json:"round"`
+	RuntimeID common.Namespace `json:"runtime_id"`
+	Round     uint64           `json:"round"`
 }

--- a/go/worker/storage/worker.go
+++ b/go/worker/storage/worker.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/grpc"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
@@ -59,7 +58,7 @@ type Worker struct {
 	initCh chan struct{}
 	quitCh chan struct{}
 
-	runtimes   map[signature.PublicKey]*committee.Node
+	runtimes   map[common.Namespace]*committee.Node
 	watchState *persistent.ServiceStore
 	fetchPool  *workerpool.Pool
 
@@ -82,7 +81,7 @@ func New(
 		logger:             logging.GetLogger("worker/storage"),
 		initCh:             make(chan struct{}),
 		quitCh:             make(chan struct{}),
-		runtimes:           make(map[signature.PublicKey]*committee.Node),
+		runtimes:           make(map[common.Namespace]*committee.Node),
 	}
 
 	if s.enabled {

--- a/go/worker/txnscheduler/api/api.go
+++ b/go/worker/txnscheduler/api/api.go
@@ -3,8 +3,8 @@ package api
 import (
 	"context"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/errors"
 )
 
@@ -38,8 +38,8 @@ type TransactionScheduler interface {
 
 // SubmitTxRequest is a SubmitTx request.
 type SubmitTxRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
-	Data      []byte              `json:"data"`
+	RuntimeID common.Namespace `json:"runtime_id"`
+	Data      []byte           `json:"data"`
 }
 
 // SubmitTxResponse is a SubmitTx response.
@@ -48,8 +48,8 @@ type SubmitTxResponse struct {
 
 // IsTransactionQueuedRequest is an IsTransactionQueued request.
 type IsTransactionQueuedRequest struct {
-	RuntimeID signature.PublicKey `json:"runtime_id"`
-	TxHash    hash.Hash           `json:"tx_hash"`
+	RuntimeID common.Namespace `json:"runtime_id"`
+	TxHash    hash.Hash        `json:"tx_hash"`
 }
 
 // IsTransactionQueuedResponse is an IsTransactionQueued response.

--- a/go/worker/txnscheduler/tests/tester.go
+++ b/go/worker/txnscheduler/tests/tester.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	epochtimeTests "github.com/oasislabs/oasis-core/go/epochtime/tests"
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
@@ -30,7 +30,7 @@ const recvTimeout = 5 * time.Second
 func WorkerImplementationTests(
 	t *testing.T,
 	worker *txnscheduler.Worker,
-	runtimeID signature.PublicKey,
+	runtimeID common.Namespace,
 	rtNode *committee.Node,
 	epochtime epochtime.SetableBackend,
 	roothash roothash.Backend,
@@ -65,7 +65,7 @@ func testInitialEpochTransition(t *testing.T, stateCh <-chan committee.NodeState
 
 func testQueueCall(
 	t *testing.T,
-	runtimeID signature.PublicKey,
+	runtimeID common.Namespace,
 	stateCh <-chan committee.NodeState,
 	rtNode *committee.Node,
 	roothash roothash.Backend,

--- a/go/worker/txnscheduler/worker.go
+++ b/go/worker/txnscheduler/worker.go
@@ -1,7 +1,7 @@
 package txnscheduler
 
 import (
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	workerCommon "github.com/oasislabs/oasis-core/go/worker/common"
@@ -20,7 +20,7 @@ type Worker struct {
 	registration *registration.Worker
 	compute      *compute.Worker
 
-	runtimes map[signature.PublicKey]*committee.Node
+	runtimes map[common.Namespace]*committee.Node
 
 	quitCh chan struct{}
 	initCh chan struct{}
@@ -126,7 +126,7 @@ func (w *Worker) Initialized() <-chan struct{} {
 //
 // In case the runtime with the specified id was not registered it
 // returns nil.
-func (w *Worker) GetRuntime(id signature.PublicKey) *committee.Node {
+func (w *Worker) GetRuntime(id common.Namespace) *committee.Node {
 	return w.runtimes[id]
 }
 
@@ -165,7 +165,7 @@ func newWorker(
 		commonWorker: commonWorker,
 		registration: registration,
 		compute:      compute,
-		runtimes:     make(map[signature.PublicKey]*committee.Node),
+		runtimes:     make(map[common.Namespace]*committee.Node),
 		quitCh:       make(chan struct{}),
 		initCh:       make(chan struct{}),
 		logger:       logging.GetLogger("worker/txnscheduler"),


### PR DESCRIPTION
Prerequisite for implementing the new runtime ID allocation scheme, I would like to merge this prior to doing the other changes just to save having to continually rebase this change set.