### PR TITLE
changelog: Update README for the new breaking type

### DIFF
--- a/.changelog/2511.trivial.md
+++ b/.changelog/2511.trivial.md
@@ -1,0 +1,3 @@
+changelog: Update README for the new breaking type.
+
+The breaking type was introduced in #2499.

--- a/.changelog/README.md
+++ b/.changelog/README.md
@@ -52,7 +52,7 @@ issue or pull request number, and `<TYPE>` is one of:
 
 - `process`: a change in Oasis Core's processes (e.g. development process,
   release process, ...),
-- `removal`: a deprecation or removal of functionality,
+- `breaking`: a removal of functionality or a breaking change,
 - `feature`: a new feature,
 - `bugfix`: a bug fix,
 - `doc`: a documentation-related change,


### PR DESCRIPTION
The `breaking` type was introduced in #2499.