### PR TITLE
go/oasis-node: Reduce node test flakiness on certain systems

### DIFF
--- a/.changelog/2528.trivial.md
+++ b/.changelog/2528.trivial.md
@@ -1,0 +1,9 @@
+go/oasis-node: Reduce node test flakiness on certain systems
+
+There's been intermittent failures on certain systems (read: my laptop)
+in some tests for a while, that have recently gotten worse.
+
+This adds a helper `MustTransitionEpoch` that monitors the roothash
+backend for a block in the requested epoch, that can be called after
+the force advancing the epoch with the mock backend, to ensure that the
+roothash's view of the world is caught up enough where required.


### PR DESCRIPTION
There's been intermittent failures on certain systems (read: my laptop)
in some tests for a while, that have recently gotten worse.

This adds a helper `MustTransitionEpoch` that monitors the roothash
backend for a block in the requested epoch, that can be called after
the force advancing the epoch with the mock backend, to ensure that the
roothash's view of the world is caught up enough where required.