### PR TITLE
host/protocol: add RuntimeID to WorkerInfoRequest and use it

### DIFF
--- a/.changelog/2529.breaking.md
+++ b/.changelog/2529.breaking.md
@@ -1,0 +1,3 @@
+`RuntimeID` is not hardcoded anymore in the enclave, but is passed when
+dispatching the runtime. This enables the same runtime binary to be registered
+and executed multiple times with different `RuntimeID`.

--- a/.changelog/2529.feature.1.md
+++ b/.changelog/2529.feature.1.md
@@ -1,0 +1,2 @@
+Add `make force-test` to `go/Makefile` to run all go unit tests regardless
+of the previously cached test results.

--- a/.changelog/2529.feature.2.md
+++ b/.changelog/2529.feature.2.md
@@ -1,0 +1,1 @@
+Sort e2e names of the tests when invoking `oasis-test-runner list`.

--- a/go/Makefile
+++ b/go/Makefile
@@ -57,7 +57,12 @@ lint:
 # Test.
 test:
 	@$(ECHO) "$(CYAN)*** Running Go unit tests...$(OFF)"
-	@$(GO) test -timeout 5m -race -v ./...
+	@$(GO) test -timeout 5m -race -v $(GO_TEST_FLAGS) ./...
+
+# Test without caching.
+force-test:
+	@$(ECHO) "$(CYAN)*** Running Go unit tests in force mode...$(OFF)"
+	$(MAKE) test GO_TEST_FLAGS=-count=1
 
 # Test oasis-node with coverage.
 integrationrunner:

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -58,7 +58,7 @@ var (
 	// the runtime.
 	//
 	// NOTE: This version must be synced with runtime/src/common/version.rs.
-	RuntimeProtocol = Version{Major: 0, Minor: 10, Patch: 0}
+	RuntimeProtocol = Version{Major: 0, Minor: 11, Patch: 0}
 
 	// CommitteeProtocol versions the P2P protocol used by the
 	// committee members.

--- a/go/oasis-test-runner/cmd/root.go
+++ b/go/oasis-test-runner/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -289,6 +290,12 @@ func runList(cmd *cobra.Command, args []string) {
 		fmt.Printf("No supported test cases!\n")
 	default:
 		fmt.Printf("Supported test cases:\n")
+
+		// Sort scenarios alphabetically before printing.
+		sort.Slice(scenarios, func(i, j int) bool {
+			return scenarios[i].Name() < scenarios[j].Name()
+		})
+
 		for _, v := range scenarios {
 			fmt.Printf("  * %v\n", v.Name())
 		}

--- a/go/oasis-test-runner/scenario/e2e/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/multiple_runtimes.go
@@ -1,0 +1,133 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/oasislabs/oasis-core/go/common"
+	"github.com/oasislabs/oasis-core/go/common/logging"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/scenario"
+	registry "github.com/oasislabs/oasis-core/go/registry/api"
+)
+
+const (
+	// computeRuntimesCount is the number of runtimes with shared runtimeBinary registered.
+	computeRuntimesCount = 2
+
+	// computeRuntimeTxnCount is the number of insert transactions sent to each runtime.
+	computeRuntimeTxnCount = 3
+)
+
+var (
+	// MultipleRuntimes is a scenario which tests running multiple runtimes on one node.
+	MultipleRuntimes scenario.Scenario = &multipleRuntimesImpl{
+		basicImpl: *newBasicImpl("multiple-runtimes", "simple-keyvalue-client", nil),
+		logger:    logging.GetLogger("scenario/e2e/multiple_runtimes"),
+	}
+)
+
+type multipleRuntimesImpl struct {
+	basicImpl
+
+	logger *logging.Logger
+}
+
+func (mr *multipleRuntimesImpl) Name() string {
+	return "multiple-runtimes"
+}
+
+func (mr *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
+	fixtures, err := mr.basicImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	// Take the RuntimeID and binary from the existing compute runtime.
+	var id common.Namespace
+	var runtimeBinary string
+	for _, rt := range fixtures.Runtimes {
+		if rt.Kind == registry.KindCompute {
+			copy(id[:], rt.ID[:])
+			runtimeBinary = rt.Binary
+			break
+		}
+	}
+
+	// Add some more consecutive runtime IDs with the same binary.
+	for i := 1; i <= computeRuntimesCount-1; i++ {
+		// Increase LSB by 1.
+		id[len(id)-1]++
+
+		newRtFixture := oasis.RuntimeFixture{
+			ID:         id,
+			Kind:       registry.KindCompute,
+			Entity:     0,
+			Keymanager: 0,
+			Binary:     runtimeBinary,
+			Compute: registry.ComputeParameters{
+				GroupSize:       2,
+				GroupBackupSize: 1,
+				RoundTimeout:    10 * time.Second,
+			},
+			Merge: registry.MergeParameters{
+				GroupSize:       2,
+				GroupBackupSize: 1,
+				RoundTimeout:    10 * time.Second,
+			},
+			TxnScheduler: registry.TxnSchedulerParameters{
+				Algorithm:         registry.TxnSchedulerAlgorithmBatching,
+				GroupSize:         1,
+				MaxBatchSize:      1,
+				MaxBatchSizeBytes: 1000,
+				BatchFlushTimeout: 1 * time.Second,
+			},
+			Storage: registry.StorageParameters{GroupSize: 2},
+		}
+
+		fixtures.Runtimes = append(fixtures.Runtimes, newRtFixture)
+	}
+
+	return fixtures, nil
+}
+
+func (mr *multipleRuntimesImpl) Run(childEnv *env.Env) error {
+	if err := mr.net.Start(); err != nil {
+		return err
+	}
+
+	// Wait for all nodes to be synced before we proceed.
+	if err := mr.waitNodesSynced(); err != nil {
+		return err
+	}
+
+	mr.logger.Info("waiting for (some) nodes to register",
+		"num_nodes", mr.net.NumRegisterNodes(),
+	)
+	if err := mr.net.Controller().WaitNodesRegistered(context.Background(), mr.net.NumRegisterNodes()); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	// Submit transactions.
+	for _, r := range mr.net.Runtimes() {
+		rt := r.ToRuntimeDescriptor()
+		if rt.Kind == registry.KindCompute {
+			for i := 0; i < computeRuntimeTxnCount; i++ {
+				mr.logger.Info("submitting transaction to runtime",
+					"seq", i,
+					"runtime_id", rt.ID,
+				)
+
+				if err := mr.submitRuntimeTx(ctx, rt.ID, "hello", fmt.Sprintf("world %d from %s", i, rt.ID)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/go/oasis-test-runner/scenario/e2e/runtime_dynamic.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime_dynamic.go
@@ -143,7 +143,7 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error {
 		sc.logger.Info("submitting transaction to runtime",
 			"seq", i,
 		)
-		if err := sc.submitRuntimeTx(ctx, "hello", fmt.Sprintf("world %d", i)); err != nil {
+		if err := sc.submitRuntimeTx(ctx, runtimeID, "hello", fmt.Sprintf("world %d", i)); err != nil {
 			return err
 		}
 	}
@@ -216,7 +216,7 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error {
 
 	// Submit a runtime transaction to check whether the runtimes got resumed.
 	sc.logger.Info("submitting transaction to runtime")
-	if err := sc.submitRuntimeTx(ctx, "hello", "final world"); err != nil {
+	if err := sc.submitRuntimeTx(ctx, runtimeID, "hello", "final world"); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/runtime_prune.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime_prune.go
@@ -73,7 +73,7 @@ func (sc *runtimePruneImpl) Run(childEnv *env.Env) error {
 			"seq", i,
 		)
 
-		if err := sc.submitRuntimeTx(ctx, "hello", fmt.Sprintf("world %d", i)); err != nil {
+		if err := sc.submitRuntimeTx(ctx, runtimeID, "hello", fmt.Sprintf("world %d", i)); err != nil {
 			return err
 		}
 	}

--- a/go/oasis-test-runner/test-runner.go
+++ b/go/oasis-test-runner/test-runner.go
@@ -39,6 +39,8 @@ func main() {
 	_ = cmd.Register(e2e.DumpRestore)
 	// Halt test.
 	_ = cmd.Register(e2e.HaltRestore)
+	// Multiple runtimes test.
+	_ = cmd.Register(e2e.MultipleRuntimes)
 	// Registry CLI test.
 	_ = cmd.Register(e2e.RegistryCLI)
 	// Stake CLI test.

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -29,7 +29,7 @@ var (
 	_ prettyprint.PrettyPrinter = (*SignedRuntime)(nil)
 )
 
-// RuntimeKind represents the runtime funtionality.
+// RuntimeKind represents the runtime functionality.
 type RuntimeKind uint32
 
 const (

--- a/go/worker/common/host/protocol/types.go
+++ b/go/worker/common/host/protocol/types.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/sgx/ias"
@@ -53,7 +54,7 @@ type Body struct {
 	Error *Error `json:",omitempty"`
 
 	// Worker interface.
-	WorkerInfoRequest                    *Empty                                `json:",omitempty"`
+	WorkerInfoRequest                    *WorkerInfoRequest                    `json:",omitempty"`
 	WorkerInfoResponse                   *WorkerInfoResponse                   `json:",omitempty"`
 	WorkerPingRequest                    *Empty                                `json:",omitempty"`
 	WorkerShutdownRequest                *Empty                                `json:",omitempty"`
@@ -94,6 +95,12 @@ type Empty struct {
 // Error is a message body representing an error.
 type Error struct {
 	Message string `json:"message"`
+}
+
+// WorkerInfoRequest is a worker info request message body.
+type WorkerInfoRequest struct {
+	// RuntimeID is the assigned runtime ID of the loaded runtime.
+	RuntimeID common.Namespace `json:"runtime_id"`
 }
 
 // WorkerInfoResponse is a worker info response message body.

--- a/go/worker/common/host/sandboxed.go
+++ b/go/worker/common/host/sandboxed.go
@@ -540,7 +540,9 @@ func (h *sandboxedHost) checkInfo(worker *process) error {
 
 	// Request information about the running runtime and abort if the protocol
 	// version is incompatible.
-	rsp, err := worker.protocol.Call(ctx, &protocol.Body{WorkerInfoRequest: &protocol.Empty{}})
+	rsp, err := worker.protocol.Call(ctx, &protocol.Body{WorkerInfoRequest: &protocol.WorkerInfoRequest{
+		RuntimeID: h.cfg.ID,
+	}})
 	if err != nil || rsp.WorkerInfoResponse == nil {
 		return errors.Wrap(err, "error while requesting runtime info")
 	}

--- a/go/worker/common/host/sandboxed_test.go
+++ b/go/worker/common/host/sandboxed_test.go
@@ -208,7 +208,10 @@ func testCheckTxRequest(t *testing.T, host Host) {
 
 	select {
 	case rsp := <-rspCh:
+		require.Nil(t, rsp.Error, "worker should not return error", "err", rsp.Error)
+
 		require.NotNil(t, rsp, "worker channel should not be closed while waiting for response")
+		require.NotNil(t, rsp.WorkerCheckTxBatchResponse, "WorkerCheckTxBatchResponse instance should be returned")
 		require.NotNil(t, rsp.WorkerCheckTxBatchResponse.Results, "worker should respond to check tx call")
 		require.Len(t, rsp.WorkerCheckTxBatchResponse.Results, 3, "worker should return a check tx call result for each txn")
 

--- a/runtime/src/common/version.rs
+++ b/runtime/src/common/version.rs
@@ -66,6 +66,6 @@ impl From<u64> for Version {
 // the worker host.
 pub const PROTOCOL_VERSION: Version = Version {
     major: 0,
-    minor: 10,
+    minor: 11,
     patch: 0,
 };

--- a/runtime/src/init.rs
+++ b/runtime/src/init.rs
@@ -56,7 +56,7 @@ pub fn start_runtime(initializer: Option<Box<dyn Initializer>>, version: Version
         dispatcher.clone(),
         version,
     ));
-    dispatcher.start(protocol.clone());
+
     protocol.start();
 
     info!(logger, "Protocol handler terminated, shutting down");

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -13,6 +13,7 @@
 #![feature(test)]
 #![feature(box_into_pin)]
 #![feature(pin_into_inner)]
+#![feature(arbitrary_self_types)]
 
 #[macro_use]
 extern crate slog;

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -10,6 +10,7 @@ use crate::{
             signature::{PublicKey, Signature},
         },
         roothash::{Block, ComputeResultsHeader},
+        runtime::RuntimeId,
         sgx::avr::AVR,
     },
     storage::mkvs::{urkel::sync, WriteLog},
@@ -56,7 +57,9 @@ pub enum Body {
     },
 
     // Runtime worker interface.
-    WorkerInfoRequest {},
+    WorkerInfoRequest {
+        runtime_id: RuntimeId,
+    },
     WorkerInfoResponse {
         protocol_version: u64,
         runtime_version: u64,

--- a/tests/runtimes/simple-keyvalue/api/src/api.rs
+++ b/tests/runtimes/simple-keyvalue/api/src/api.rs
@@ -9,6 +9,9 @@ pub struct KeyValue {
 }
 
 runtime_api! {
+    //  Gets runtime ID of the runtime.
+    pub fn get_runtime_id(()) -> Option<String>;
+
     // Inserts key and corresponding value and returns old value, if any.
     // Both parameters are passed using a single serializable struct KeyValue.
     pub fn insert(KeyValue) -> Option<String>;


### PR DESCRIPTION
PR for https://github.com/oasislabs/oasis-core/issues/2519 and https://github.com/oasislabs/oasis-core/issues/1062:
- adds `RuntimeID` field to `WorkerInfoRequest`,
- adds `runtime_id` to runtime `Protocol`
- adds check to simple-keyvalue client that remote `runtime_id` equals the CLI passed one,
- adds new `multiple-runtimes` e2e test which spins up 2 runtimes on each compute node with shared runtime binary,
- adds `make force-test` rule to go/ for running *all* tests without taking caching into account,
- adds sorting scenarios alphabetically when calling `oasis-test-runner list`.