### PR TITLE
More release automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target/
 *.so
 **/generated
 /dist/
+/__pycache__/
 
 # IDE.
 .idea/*

--- a/.punch_config.py
+++ b/.punch_config.py
@@ -1,0 +1,28 @@
+__config_version__ = 1
+
+GLOBALS = {
+    'serializer': '{{year}}.{{minor}}',
+}
+
+# NOTE: The FILES list is not allowed to be empty, so we need to pass it at
+# least a single valid file.
+FILES = ["README.md"]
+
+VERSION = [
+    {
+        'name': 'year',
+        'type': 'date',
+        'fmt': 'YY',
+    },
+    {
+        'name': 'minor',
+        'type': 'integer',
+    },
+]
+ACTIONS = {
+    'custom_bump': {
+        'type': 'conditional_reset',
+        'field': 'minor',
+        'update_fields': ['year']
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,17 @@ clean-go:
 
 clean: $(clean-targets)
 
+# Assemble Change log.
+changelog:
+	@if [[ -z "$(NEXT_VERSION)" ]]; then \
+		echo "Error: Could not compute project's new version."; \
+		exit 1; \
+	else \
+		echo "Generating changelog for version $(NEXT_VERSION)..."; \
+		towncrier build --version $(NEXT_VERSION); \
+		echo "Next, review the staged changes, commit them and make a pull request."; \
+    fi
+
 # Prepare release.
 release:
 	@goreleaser $(GORELEASER_ARGS)
@@ -117,5 +128,5 @@ docker-shell:
 	$(fmt-targets) fmt \
 	$(test-unit-targets) $(test-targets) test \
 	$(clean-targets) clean \
-	release docker-shell \
+	changelog release docker-shell \
 	all


### PR DESCRIPTION
Closes #2523. Closes #2512.

Note, documentation on installing the [Punch](https://punch.readthedocs.io/) utility for computing the next version will come as part of #2457.