### PR TITLE
runtime: Persist (sealed) RAK in untrusted local storage

### DIFF
--- a/.changelog/2534.feature.md
+++ b/.changelog/2534.feature.md
@@ -1,0 +1,9 @@
+runtime: Persist (sealed) RAK in untrusted local storage.
+
+Previously the RAK was totally ephemeral and got regenerated on each runtime
+enclave restart.
+
+This caused problems in case an enclave got restarted in the middle of an epoch
+as the RAK only got updated during a node's re-registration (which is once per
+epoch). Until the re-registration and an epoch transition happened, all
+RAK-signed messages were rejected.

--- a/runtime/src/common/sgx/egetkey.rs
+++ b/runtime/src/common/sgx/egetkey.rs
@@ -61,7 +61,7 @@ fn egetkey_impl(key_policy: Keypolicy, context: &[u8]) -> [u8; 16] {
 
 /// egetkey returns a 256 bit key suitable for sealing secrets to the
 /// enclave in cold storage, derived from the results of the `EGETKEY`
-/// instruction.  The `context` field a domain separation tag.
+/// instruction.  The `context` field is a domain separation tag.
 ///
 /// Note: The key can also be used for other things (eg: as an X25519
 /// private key).

--- a/runtime/src/common/sgx/mod.rs
+++ b/runtime/src/common/sgx/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod avr;
 pub mod egetkey;
+pub mod seal;

--- a/runtime/src/common/sgx/seal.rs
+++ b/runtime/src/common/sgx/seal.rs
@@ -1,0 +1,107 @@
+//! Wrappers for sealing secrets to the enclave in cold storage.
+use rand::{rngs::OsRng, Rng};
+use sgx_isa::Keypolicy;
+use zeroize::Zeroize;
+
+use crate::common::{
+    crypto::mrae::deoxysii::{DeoxysII, NONCE_SIZE, TAG_SIZE},
+    sgx::egetkey::egetkey,
+};
+
+/// Seal a secret to the enclave.
+///
+/// The `context` field is a domain separation tag.
+pub fn seal(key_policy: Keypolicy, context: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut rng = OsRng::new().unwrap();
+
+    // Encrypt the raw policy.
+    let mut nonce = [0u8; NONCE_SIZE];
+    rng.fill(&mut nonce);
+    let d2 = new_d2(key_policy, context);
+    let mut ciphertext = d2.seal(&nonce, data.to_vec(), vec![]);
+    ciphertext.extend_from_slice(&nonce);
+
+    ciphertext
+}
+
+/// Unseal a previously sealed secret to the enclave.
+///
+/// The `context` field is a domain separation tag.
+///
+/// # Panics
+///
+/// All parsing and authentication errors of the ciphertext are fatal and
+/// will result in a panic.
+pub fn unseal(key_policy: Keypolicy, context: &[u8], ciphertext: &[u8]) -> Option<Vec<u8>> {
+    let ct_len = ciphertext.len();
+    if ct_len == 0 {
+        return None;
+    } else if ct_len < TAG_SIZE + NONCE_SIZE {
+        panic!("ciphertext is corrupted, invalid size");
+    }
+    let ct_len = ct_len - NONCE_SIZE;
+
+    // Split the ciphertext || tag || nonce.
+    let mut nonce = [0u8; NONCE_SIZE];
+    nonce.copy_from_slice(&ciphertext[ct_len..]);
+    let ciphertext = &ciphertext[..ct_len];
+
+    let d2 = new_d2(key_policy, context);
+    let plaintext = d2
+        .open(&nonce, ciphertext.to_vec(), vec![])
+        .expect("ciphertext is corrupted");
+
+    Some(plaintext)
+}
+
+fn new_d2(key_policy: Keypolicy, context: &[u8]) -> DeoxysII {
+    let mut seal_key = egetkey(key_policy, context);
+    let d2 = DeoxysII::new(&seal_key);
+    seal_key.zeroize();
+
+    d2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_seal_unseal() {
+        // Test different policies.
+        let sealed_a = seal(Keypolicy::MRSIGNER, b"MRSIGNER", b"Mr. Signer");
+        let unsealed_a = unseal(Keypolicy::MRSIGNER, b"MRSIGNER", &sealed_a);
+        assert_eq!(unsealed_a, Some(b"Mr. Signer".to_vec()));
+
+        let sealed_b = seal(Keypolicy::MRENCLAVE, b"MRENCLAVE", b"Mr. Enclave");
+        let unsealed_b = unseal(Keypolicy::MRENCLAVE, b"MRENCLAVE", &sealed_b);
+        assert_eq!(unsealed_b, Some(b"Mr. Enclave".to_vec()));
+
+        // Test zero-length ciphertext.
+        let unsealed_c = unseal(Keypolicy::MRENCLAVE, b"MRENCLAVE", b"");
+        assert_eq!(unsealed_c, None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_incorrect_context() {
+        // Test incorrect context.
+        let sealed_b = seal(Keypolicy::MRENCLAVE, b"MRENCLAVE1", b"Mr. Enclave");
+        unseal(Keypolicy::MRENCLAVE, b"MRENCLAVE2", &sealed_b);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_incorrect_ciphertext_a() {
+        let sealed_b = seal(Keypolicy::MRENCLAVE, b"MRENCLAVE", b"Mr. Enclave");
+        unseal(Keypolicy::MRENCLAVE, b"MRENCLAVE", &sealed_b[..2]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_incorrect_ciphertext_b() {
+        let mut sealed_b = seal(Keypolicy::MRENCLAVE, b"MRENCLAVE", b"Mr. Enclave");
+        sealed_b[0] = 0x00;
+        unseal(Keypolicy::MRENCLAVE, b"MRENCLAVE", &sealed_b);
+    }
+}

--- a/runtime/src/init.rs
+++ b/runtime/src/init.rs
@@ -50,12 +50,7 @@ pub fn start_runtime(initializer: Option<Box<dyn Initializer>>, version: Version
 
     // Start handling protocol messages. This blocks the main thread forever
     // (or until we get a shutdown request).
-    let protocol = Arc::new(Protocol::new(
-        stream,
-        rak.clone(),
-        dispatcher.clone(),
-        version,
-    ));
+    let protocol = Protocol::new(stream, rak.clone(), dispatcher.clone(), version);
     dispatcher.start(protocol.clone());
     protocol.start();
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -13,6 +13,7 @@
 #![feature(test)]
 #![feature(box_into_pin)]
 #![feature(pin_into_inner)]
+#![feature(arbitrary_self_types)]
 
 #[macro_use]
 extern crate slog;


### PR DESCRIPTION
Previously the RAK was totally ephemeral and got regenerated on each runtime
enclave restart.

This caused problems in case an enclave got restarted in the middle of an epoch
as the RAK only got updated during a node's re-registration (which is once per
epoch). Until the re-registration and an epoch transition happened, all
RAK-signed messages were rejected.

Also changes some of the `Protocol` methods to take a `self: &Arc<Self>` which will be useful for work done in #2529 to defer dispatcher startup after the runtime ID has been received.