### PR TITLE
Fix simple-keyvalue-client crash

### DIFF
--- a/.changelog/2542.bugfix.md
+++ b/.changelog/2542.bugfix.md
@@ -1,0 +1,4 @@
+go/runtime/client: Return empty sequences instead of nil.
+
+The runtime client endpoint should return empty sequences instead of `nil` as serde doesn't know how
+to decode a `NULL` when the expected type is a sequence.

--- a/go/runtime/client/client.go
+++ b/go/runtime/client/client.go
@@ -326,7 +326,7 @@ func (c *runtimeClient) GetTxs(ctx context.Context, request *api.GetTxsRequest) 
 		return nil, err
 	}
 
-	var inputs [][]byte
+	inputs := [][]byte{}
 	for _, tx := range txs {
 		inputs = append(inputs, tx.Input)
 	}
@@ -391,7 +391,7 @@ func (c *runtimeClient) QueryTxs(ctx context.Context, request *api.QueryTxsReque
 		return nil, err
 	}
 
-	var output []*api.TxResult
+	output := []*api.TxResult{}
 	for round, txResults := range results {
 		// Fetch block for the given round.
 		var blk *block.Block

--- a/tests/clients/simple-keyvalue/src/main.rs
+++ b/tests/clients/simple-keyvalue/src/main.rs
@@ -150,12 +150,9 @@ fn main() {
 
     // Test wait_block_indexed call.
     println!("Waiting for block to be indexed...");
-    rt.block_on(
-        kv_client
-            .txn_client()
-            .wait_block_indexed(latest_snapshot.block.header.round),
-    )
-    .expect("wait block indexed");
+    let latest_round = latest_snapshot.block.header.round;
+    rt.block_on(kv_client.txn_client().wait_block_indexed(latest_round))
+        .expect("wait block indexed");
 
     // Test get_block_by_hash call.
     println!(
@@ -199,7 +196,7 @@ fn main() {
     println!("Querying transaction tags (kv_op=insert)...");
     let query = Query {
         round_min: 0,
-        round_max: 3,
+        round_max: latest_round,
         conditions: vec![QueryCondition {
             key: b"kv_op".to_vec(),
             values: vec![b"insert".to_vec().into()],


### PR DESCRIPTION
Fixes #2531 

The crash reported in the above issue is actually result of two separate problems, both of which should be fixed by this PR:
* The runtime client endpoint should return empty sequences instead of nil as serde doesn't know how to decode a `NULL` when the expected type is a sequence.
* The simple-keyvalue client used a hardcoded round number in the query (`3`) which can easily be incorrect due to the time at which the client is called.