### PR TITLE
ci: persist build artifacts in /var/tmp

### DIFF
--- a/.buildkite/deploy.pipeline.yml
+++ b/.buildkite/deploy.pipeline.yml
@@ -9,15 +9,15 @@ docker_plugin: &docker_plugin_configuration
     volumes:
       - .:/workdir
       # Shared Rust incremental compile caches.
-      - /tmp/cargo_ic/release:/workdir/target/release/incremental
-      - /tmp/cargo_ic/release_sgx:/workdir/target/x86_64-unknown-linux-sgx/release/incremental
+      - /var/tmp/cargo_ic/release:/workdir/target/release/incremental
+      - /var/tmp/cargo_ic/release_sgx:/workdir/target/x86_64-unknown-linux-sgx/release/incremental
       # Shared Rust package checkouts directory.
-      - /tmp/cargo_pkg/git:/root/.cargo/git
-      - /tmp/cargo_pkg/registry:/root/.cargo/registry
+      - /var/tmp/cargo_pkg/git:/root/.cargo/git
+      - /var/tmp/cargo_pkg/registry:/root/.cargo/registry
       # Shared Rust SGX standard library artifacts cache.
-      - /tmp/xargo_cache:/root/.xargo
+      - /var/tmp/xargo_cache:/root/.xargo
       # Shared Go package checkouts directory.
-      - /tmp/go_pkg:/root/go/pkg
+      - /var/tmp/go_pkg:/root/go/pkg
     environment:
       - "LC_ALL=C.UTF-8"
       - "LANG=C.UTF-8"

--- a/.buildkite/longtests.pipeline.yml
+++ b/.buildkite/longtests.pipeline.yml
@@ -7,15 +7,15 @@ docker_plugin_default_config: &docker_plugin_default_config
     - /var/lib/buildkite-agent/.coveralls:/root/.coveralls
     - /var/lib/buildkite-agent/.codecov:/root/.codecov
     # Shared Rust incremental compile caches.
-    - /tmp/cargo_ic/debug:/tmp/artifacts/debug/incremental
-    - /tmp/cargo_ic/debug_sgx:/tmp/artifacts/x86_64-unknown-linux-sgx/debug/incremental
+    - /var/tmp/cargo_ic/debug:/tmp/artifacts/debug/incremental
+    - /var/tmp/cargo_ic/debug_sgx:/tmp/artifacts/x86_64-unknown-linux-sgx/debug/incremental
     # Shared Rust package checkouts directory.
-    - /tmp/cargo_pkg/git:/root/.cargo/git
-    - /tmp/cargo_pkg/registry:/root/.cargo/registry
+    - /var/tmp/cargo_pkg/git:/root/.cargo/git
+    - /var/tmp/cargo_pkg/registry:/root/.cargo/registry
     # Shared Rust SGX standard library artifacts cache.
-    - /tmp/xargo_cache:/root/.xargo
+    - /var/tmp/xargo_cache:/root/.xargo
     # Shared Go package checkouts directory.
-    - /tmp/go_pkg:/root/go/pkg
+    - /var/tmp/go_pkg:/root/go/pkg
     # Intel SGX Application Enclave Services Manager (AESM) daemon running on
     # the Buildkite host.
     - /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,15 +9,15 @@ docker_plugin_default_config: &docker_plugin_default_config
     - /var/lib/buildkite-agent/.coveralls:/root/.coveralls
     - /var/lib/buildkite-agent/.codecov:/root/.codecov
     # Shared Rust incremental compile caches.
-    - /tmp/cargo_ic/debug:/tmp/artifacts/debug/incremental
-    - /tmp/cargo_ic/debug_sgx:/tmp/artifacts/x86_64-unknown-linux-sgx/debug/incremental
+    - /var/tmp/cargo_ic/debug:/tmp/artifacts/debug/incremental
+    - /var/tmp/cargo_ic/debug_sgx:/tmp/artifacts/x86_64-unknown-linux-sgx/debug/incremental
     # Shared Rust package checkouts directory.
-    - /tmp/cargo_pkg/git:/root/.cargo/git
-    - /tmp/cargo_pkg/registry:/root/.cargo/registry
+    - /var/tmp/cargo_pkg/git:/root/.cargo/git
+    - /var/tmp/cargo_pkg/registry:/root/.cargo/registry
     # Shared Rust SGX standard library artifacts cache.
-    - /tmp/xargo_cache:/root/.xargo
+    - /var/tmp/xargo_cache:/root/.xargo
     # Shared Go package checkouts directory.
-    - /tmp/go_pkg:/root/go/pkg
+    - /var/tmp/go_pkg:/root/go/pkg
     # Intel SGX Application Enclave Services Manager (AESM) daemon running on
     # the Buildkite host.
     - /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket

--- a/.changelog/2543.trivial.md
+++ b/.changelog/2543.trivial.md
@@ -1,0 +1,1 @@
+ci: persist artifacts through /var/tmp


### PR DESCRIPTION
since /tmp will be put on /tmpfs on ci hosts, artifacts should be persisted through /var/tmp