### PR TITLE
go/consensus/tendermint/apps: Avoid loading all registered runtimes

### DIFF
--- a/.changelog/2538.feature.md
+++ b/.changelog/2538.feature.md
@@ -1,0 +1,4 @@
+Optimize registry runtime lookups during node registration.
+
+A performance optimization to avoid loading a list of all registered runtimes into memory in cases
+when only a specific runtime is actually needed.

--- a/go/consensus/tendermint/apps/keymanager/keymanager.go
+++ b/go/consensus/tendermint/apps/keymanager/keymanager.go
@@ -187,7 +187,7 @@ func (app *keymanagerApplication) generateStatus(kmrt *registry.Runtime, oldStat
 			continue
 		}
 
-		initResponse, err := api.VerifyExtraInfo(kmrt, nodeRt, ts)
+		initResponse, err := api.VerifyExtraInfo(app.logger, kmrt, nodeRt, ts)
 		if err != nil {
 			app.logger.Error("failed to validate ExtraInfo",
 				"err", err,

--- a/go/keymanager/api/api.go
+++ b/go/keymanager/api/api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/memory"
 	"github.com/oasislabs/oasis-core/go/common/errors"
+	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
@@ -107,7 +108,7 @@ func (r *SignedInitResponse) Verify(pk signature.PublicKey) error {
 
 // VerifyExtraInfo verifies and parses the per-node + per-runtime ExtraInfo
 // blob for a key manager.
-func VerifyExtraInfo(rt *registry.Runtime, nodeRt *node.Runtime, ts time.Time) (*InitResponse, error) {
+func VerifyExtraInfo(logger *logging.Logger, rt *registry.Runtime, nodeRt *node.Runtime, ts time.Time) (*InitResponse, error) {
 	var (
 		hw  node.TEEHardware
 		rak signature.PublicKey
@@ -121,7 +122,7 @@ func VerifyExtraInfo(rt *registry.Runtime, nodeRt *node.Runtime, ts time.Time) (
 	}
 	if hw != rt.TEEHardware {
 		return nil, fmt.Errorf("keymanger: TEEHardware mismatch")
-	} else if err := registry.VerifyNodeRuntimeEnclaveIDs(nil, nodeRt, []*registry.Runtime{rt}, ts); err != nil {
+	} else if err := registry.VerifyNodeRuntimeEnclaveIDs(logger, nodeRt, rt, ts); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Based on #2504 
Fixes #2538 

This is a performance optimization to avoid loading a list of all registered
runtimes into memory in cases when only a specific runtime is actually needed.