### PR TITLE
go/worker/common/host: Emit events on (re)starts/failures

### DIFF
--- a/.changelog/2545.trivial.1.md
+++ b/.changelog/2545.trivial.1.md
@@ -1,0 +1,7 @@
+go/worker/common/host: Emit events on (re)starts/failures.
+
+This replaces the previous mechanism which was implemented twice, first to receive the CapabilityTEE
+and second to receive the runtime version.
+
+The new mechanism is based on events so that the caller is able to get notified when changes occur
+(e.g., on restarts).

--- a/.changelog/2545.trivial.2.md
+++ b/.changelog/2545.trivial.2.md
@@ -1,0 +1,21 @@
+go/worker: Make worker registration event-based.
+
+Previously, registration was based exclusively on epoch transitions which meant that in case the
+node was not yet ready to service requests when an epoch transition happened, it needed to block the
+registration goroutine until it was ready.
+
+This prevented updating the registration in reaction to some worker event that causes the node
+descriptor to become invalid (e.g., due to a runtime restart invalidating the RAK).
+
+Node registration API was changed as follows:
+
+- Each part of the code that wishes to contribute something to the node descriptor first asks the
+  registration worker to create a RoleProvider. This reserves a slot which is "not ready" by
+  default.
+
+- The registration worker is changed so that it reacts to both epoch transitions and role provider
+  changes. When a change is detected, the registration worker will check if all RoleProvider slots
+  indicate that the slot is "ready". In case any is not ready, registration will not proceed.
+
+- Anyone that has a reference to a RoleProvider can signal that the slot has become either "ready"
+  or "not ready".

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -126,6 +126,23 @@ func (n *Node) IsExpired(epoch uint64) bool {
 	return n.Expiration < epoch
 }
 
+// AddOrUpdateRuntime searches for an existing supported runtime descriptor in Runtimes and returns
+// it. In case a runtime descriptor for the given runtime doesn't exist yet, a new one is created
+// appended to the list of supported runtimes and returned.
+func (n *Node) AddOrUpdateRuntime(id common.Namespace) *Runtime {
+	for _, rt := range n.Runtimes {
+		if !rt.ID.Equal(&id) {
+			continue
+		}
+
+		return rt
+	}
+
+	rt := &Runtime{ID: id}
+	n.Runtimes = append(n.Runtimes, rt)
+	return rt
+}
+
 // Runtime represents the runtimes supported by a given Oasis node.
 type Runtime struct {
 	// ID is the public key identifying the runtime.

--- a/go/common/node/node_test.go
+++ b/go/common/node/node_test.go
@@ -1,0 +1,35 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasislabs/oasis-core/go/common"
+)
+
+func TestNodeDescriptor(t *testing.T) {
+	require := require.New(t)
+
+	n := Node{
+		Expiration: 42,
+	}
+
+	require.False(n.HasRoles(RoleComputeWorker))
+	require.False(n.HasRoles(RoleStorageWorker))
+	n.AddRoles(RoleComputeWorker)
+	require.True(n.HasRoles(RoleComputeWorker))
+	require.False(n.HasRoles(RoleStorageWorker))
+
+	require.False(n.IsExpired(0))
+	require.False(n.IsExpired(10))
+	require.False(n.IsExpired(42))
+	require.True(n.IsExpired(43))
+
+	ns1 := common.NewTestNamespaceFromSeed([]byte("node descriptor test"))
+	rt1 := n.AddOrUpdateRuntime(ns1)
+	require.Equal(rt1.ID, ns1, "created runtime id must be correct")
+	rt2 := n.AddOrUpdateRuntime(ns1)
+	require.Equal(&rt1, &rt2, "AddOrUpdateRuntime should return the same reference for same id")
+	require.Len(n.Runtimes, 1)
+}

--- a/go/oasis-test-runner/scenario/e2e/basic.go
+++ b/go/oasis-test-runner/scenario/e2e/basic.go
@@ -332,10 +332,9 @@ func (sc *basicImpl) waitNodesSynced() error {
 func (sc *basicImpl) initialEpochTransitions() error {
 	ctx := context.Background()
 	if sc.net.Keymanager() != nil {
-		// First wait for validator and key manager nodes to register. Then
-		// perform an epoch transition which will cause the compute nodes to
-		// register.
-		numNodes := len(sc.net.Validators()) + len(sc.net.StorageWorkers()) + 1
+		// First wait for validator and key manager nodes to register. Then perform an epoch
+		// transition which will cause the compute and storage nodes to register.
+		numNodes := len(sc.net.Validators()) + 1
 		sc.logger.Info("waiting for (some) nodes to register",
 			"num_nodes", numNodes,
 		)

--- a/go/oasis-test-runner/scenario/e2e/runtime_dynamic.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime_dynamic.go
@@ -91,9 +91,8 @@ func (sc *runtimeDynamicImpl) Run(childEnv *env.Env) error {
 		return err
 	}
 
-	// NOTE: Storage workers need to wait until the runtime is registered in the registry.
-	//       If this changes, node count needs update.
 	numNodes := len(sc.net.Validators())
+	// TODO: Once dynamic key manager registration is supported, this shouldn't be needed.
 	if sc.net.Keymanager() != nil {
 		numNodes++
 	}

--- a/go/worker/common/host/interface.go
+++ b/go/worker/common/host/interface.go
@@ -25,11 +25,6 @@ type Host interface {
 	// respawning it if necessary.
 	InterruptWorker(ctx context.Context) error
 
-	// WaitForStart waits for the worker to start.
-	//
-	// The returned event may be out of date by the time this function returns.
-	WaitForStart(ctx context.Context) (*StartedEvent, error)
-
 	// WatchEvents returns a channel which produces status change events.
 	WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error)
 }

--- a/go/worker/common/host/interface.go
+++ b/go/worker/common/host/interface.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/oasislabs/oasis-core/go/common/node"
+	"github.com/oasislabs/oasis-core/go/common/pubsub"
 	"github.com/oasislabs/oasis-core/go/common/service"
 	"github.com/oasislabs/oasis-core/go/common/version"
 	"github.com/oasislabs/oasis-core/go/worker/common/host/protocol"
@@ -20,19 +21,39 @@ type Host interface {
 	// Call sends a request to the worker process and returns the response or error.
 	Call(ctx context.Context, body *protocol.Body) (*protocol.Body, error)
 
-	// WaitForCapabilityTEE gets the active worker's CapabilityTEE,
-	// blocking if the active worker is not yet available. The returned
-	// CapabilityTEE may be out of date by the time this function returns.
-	WaitForCapabilityTEE(ctx context.Context) (*node.CapabilityTEE, error)
-
-	// WaitForRuntimeVersion gets the active worker's version of the Runtime,
-	// blocking if the active worker is not yet available. The returned
-	// Version may be out of date by the time this function returns.
-	WaitForRuntimeVersion(ctx context.Context) (*version.Version, error)
-
 	// InterruptWorker attempts to interrupt the worker, killing and
 	// respawning it if necessary.
 	InterruptWorker(ctx context.Context) error
+
+	// WaitForStart waits for the worker to start.
+	//
+	// The returned event may be out of date by the time this function returns.
+	WaitForStart(ctx context.Context) (*StartedEvent, error)
+
+	// WatchEvents returns a channel which produces status change events.
+	WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error)
+}
+
+// Event is a worker event.
+type Event struct {
+	Started       *StartedEvent
+	FailedToStart *FailedToStartEvent
+}
+
+// StartedEvent is a worker started event.
+type StartedEvent struct {
+	// Version is the runtime version.
+	Version version.Version
+
+	// CapabilityTEE is the newly started worker's CapabilityTEE. It may be nil in case the worker
+	// is not running inside a TEE.
+	CapabilityTEE *node.CapabilityTEE
+}
+
+// FailedToStartEvent is a worker failed to start event.
+type FailedToStartEvent struct {
+	// Error is the error that has occurred.
+	Error error
 }
 
 // Factory is a factory of worker hosts.

--- a/go/worker/common/host/mock.go
+++ b/go/worker/common/host/mock.go
@@ -5,8 +5,7 @@ import (
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/logging"
-	"github.com/oasislabs/oasis-core/go/common/node"
-	"github.com/oasislabs/oasis-core/go/common/version"
+	"github.com/oasislabs/oasis-core/go/common/pubsub"
 	"github.com/oasislabs/oasis-core/go/roothash/api/commitment"
 	"github.com/oasislabs/oasis-core/go/runtime/transaction"
 	urkelNode "github.com/oasislabs/oasis-core/go/storage/mkvs/urkel/node"
@@ -109,16 +108,22 @@ func (h *mockHost) MakeRequest(ctx context.Context, body *protocol.Body) (<-chan
 	return ch, nil
 }
 
-func (h *mockHost) WaitForCapabilityTEE(ctx context.Context) (*node.CapabilityTEE, error) {
-	return nil, nil
-}
-
-func (h *mockHost) WaitForRuntimeVersion(ctx context.Context) (*version.Version, error) {
-	return nil, nil
-}
-
 func (h *mockHost) InterruptWorker(ctx context.Context) error {
 	return nil
+}
+
+func (h *mockHost) WaitForStart(ctx context.Context) (*StartedEvent, error) {
+	return &StartedEvent{}, nil
+}
+
+func (h *mockHost) WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error) {
+	ch := make(chan *Event)
+	ctx, sub := pubsub.NewContextSubscription(ctx)
+	go func() {
+		defer close(ch)
+		<-ctx.Done()
+	}()
+	return ch, sub, nil
 }
 
 // NewMockHost creates a new mock worker host.

--- a/go/worker/common/host/mock.go
+++ b/go/worker/common/host/mock.go
@@ -112,15 +112,15 @@ func (h *mockHost) InterruptWorker(ctx context.Context) error {
 	return nil
 }
 
-func (h *mockHost) WaitForStart(ctx context.Context) (*StartedEvent, error) {
-	return &StartedEvent{}, nil
-}
-
 func (h *mockHost) WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error) {
 	ch := make(chan *Event)
 	ctx, sub := pubsub.NewContextSubscription(ctx)
 	go func() {
 		defer close(ch)
+		// Generate a mock worker host started event.
+		ch <- &Event{
+			Started: &StartedEvent{},
+		}
 		<-ctx.Done()
 	}()
 	return ch, sub, nil

--- a/go/worker/common/host/sandboxed.go
+++ b/go/worker/common/host/sandboxed.go
@@ -471,27 +471,6 @@ func (h *sandboxedHost) Name() string {
 	return "sandboxed worker host"
 }
 
-func (h *sandboxedHost) WaitForStart(ctx context.Context) (*StartedEvent, error) {
-	ch, sub, err := h.WatchEvents(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to watch events: %w", err)
-	}
-	defer sub.Close()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case ev := <-ch:
-			if ev.Started == nil {
-				continue
-			}
-
-			return ev.Started, nil
-		}
-	}
-}
-
 func (h *sandboxedHost) Start() error {
 	h.logger.Info("starting worker host")
 	go h.manager()
@@ -981,7 +960,7 @@ func NewHost(cfg *Config) (Host, error) {
 		stopCh:      make(chan struct{}),
 		requestCh:   make(chan *hostRequest, 10),
 		interruptCh: make(chan *interruptRequest, 10),
-		notifier:    pubsub.NewBroker(true),
+		notifier:    pubsub.NewBroker(false),
 		logger:      logger,
 	}
 	host.BaseHost = BaseHost{Host: host}

--- a/go/worker/common/host/sandboxed.go
+++ b/go/worker/common/host/sandboxed.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -18,9 +17,9 @@ import (
 
 	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
-	"github.com/oasislabs/oasis-core/go/common/ctxsync"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
+	"github.com/oasislabs/oasis-core/go/common/pubsub"
 	"github.com/oasislabs/oasis-core/go/common/sgx/aesm"
 	cmnIAS "github.com/oasislabs/oasis-core/go/common/sgx/ias"
 	"github.com/oasislabs/oasis-core/go/common/version"
@@ -70,8 +69,6 @@ var _ Host = (*sandboxedHost)(nil)
 type OnProcessStart func(*protocol.Protocol, *node.CapabilityTEE) error
 
 type process struct {
-	sync.Mutex
-
 	process  *os.Process
 	protocol *protocol.Protocol
 
@@ -169,25 +166,9 @@ func (p *process) attestationWorker(h *sandboxedHost) {
 				continue
 			}
 
-			p.Lock()
 			p.capabilityTEE = capabilityTEE
-			p.Unlock()
 		}
 	}
-}
-
-func (p *process) getCapabilityTEE() *node.CapabilityTEE {
-	p.Lock()
-	defer p.Unlock()
-
-	return p.capabilityTEE
-}
-
-func (p *process) getRuntimeVersion() *version.Version {
-	p.Lock()
-	defer p.Unlock()
-
-	return p.runtimeVersion
 }
 
 func prepareSandboxArgs(hostSocket, workerBinary, runtimeBinary string, hardware node.TEEHardware) ([]string, error) {
@@ -474,10 +455,11 @@ type sandboxedHost struct { //nolint: maligned
 	stopCh chan struct{}
 	quitCh chan struct{}
 
-	activeWorker          *process
-	activeWorkerAvailable *ctxsync.CancelableCond
-	requestCh             chan *hostRequest
-	interruptCh           chan *interruptRequest
+	activeWorker *process
+	requestCh    chan *hostRequest
+	interruptCh  chan *interruptRequest
+
+	notifier *pubsub.Broker
 
 	logger *logging.Logger
 }
@@ -489,30 +471,23 @@ func (h *sandboxedHost) Name() string {
 	return "sandboxed worker host"
 }
 
-func (h *sandboxedHost) WaitForCapabilityTEE(ctx context.Context) (*node.CapabilityTEE, error) {
-	h.activeWorkerAvailable.L.Lock()
-	defer h.activeWorkerAvailable.L.Unlock()
-	for {
-		activeWorker := h.activeWorker
-		if activeWorker != nil {
-			return activeWorker.getCapabilityTEE(), nil
-		}
-		if !h.activeWorkerAvailable.Wait(ctx) {
-			return nil, errors.New("aborted by context")
-		}
+func (h *sandboxedHost) WaitForStart(ctx context.Context) (*StartedEvent, error) {
+	ch, sub, err := h.WatchEvents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to watch events: %w", err)
 	}
-}
+	defer sub.Close()
 
-func (h *sandboxedHost) WaitForRuntimeVersion(ctx context.Context) (*version.Version, error) {
-	h.activeWorkerAvailable.L.Lock()
-	defer h.activeWorkerAvailable.L.Unlock()
 	for {
-		activeWorker := h.activeWorker
-		if activeWorker != nil {
-			return activeWorker.getRuntimeVersion(), nil
-		}
-		if !h.activeWorkerAvailable.Wait(ctx) {
-			return nil, errors.New("aborted by context")
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case ev := <-ch:
+			if ev.Started == nil {
+				continue
+			}
+
+			return ev.Started, nil
 		}
 	}
 }
@@ -600,6 +575,14 @@ func (h *sandboxedHost) InterruptWorker(ctx context.Context) error {
 	case <-ctx.Done():
 		return context.Canceled
 	}
+}
+
+func (h *sandboxedHost) WatchEvents(ctx context.Context) (<-chan *Event, pubsub.ClosableSubscription, error) {
+	typedCh := make(chan *Event)
+	sub := h.notifier.Subscribe()
+	sub.Unwrap(typedCh)
+
+	return typedCh, sub, nil
 }
 
 func (h *sandboxedHost) spawnWorker() (*process, error) { //nolint: gocyclo
@@ -838,13 +821,22 @@ func (h *sandboxedHost) spawnWorker() (*process, error) { //nolint: gocyclo
 func (h *sandboxedHost) spawnAndReplaceWorker() error {
 	worker, err := h.spawnWorker()
 	if err != nil {
+		h.notifier.Broadcast(&Event{
+			FailedToStart: &FailedToStartEvent{
+				Error: err,
+			},
+		})
 		return err
 	}
 
-	h.activeWorkerAvailable.L.Lock()
 	h.activeWorker = worker
-	h.activeWorkerAvailable.Broadcast()
-	h.activeWorkerAvailable.L.Unlock()
+
+	h.notifier.Broadcast(&Event{
+		Started: &StartedEvent{
+			Version:       *worker.runtimeVersion,
+			CapabilityTEE: worker.capabilityTEE,
+		},
+	})
 
 	return nil
 }
@@ -925,9 +917,7 @@ ManagerLoop:
 				<-h.activeWorker.quitCh
 			}
 
-			h.activeWorkerAvailable.L.Lock()
 			h.activeWorker = nil
-			h.activeWorkerAvailable.L.Unlock()
 		}
 
 		if !wantWorker {
@@ -985,14 +975,14 @@ func NewHost(cfg *Config) (Host, error) {
 	)
 
 	host := &sandboxedHost{
-		cfg:                   cfg,
-		teeState:              hostTeeState,
-		quitCh:                make(chan struct{}),
-		stopCh:                make(chan struct{}),
-		activeWorkerAvailable: ctxsync.NewCancelableCond(new(sync.Mutex)),
-		requestCh:             make(chan *hostRequest, 10),
-		interruptCh:           make(chan *interruptRequest, 10),
-		logger:                logger,
+		cfg:         cfg,
+		teeState:    hostTeeState,
+		quitCh:      make(chan struct{}),
+		stopCh:      make(chan struct{}),
+		requestCh:   make(chan *hostRequest, 10),
+		interruptCh: make(chan *interruptRequest, 10),
+		notifier:    pubsub.NewBroker(true),
+		logger:      logger,
 	}
 	host.BaseHost = BaseHost{Host: host}
 

--- a/go/worker/common/host/sandboxed_test.go
+++ b/go/worker/common/host/sandboxed_test.go
@@ -108,12 +108,8 @@ func testSandboxedHost(t *testing.T, host Host) {
 
 	// Run actual test cases.
 
-	t.Run("WaitForCapabilityTEE", func(t *testing.T) {
-		testWaitForCapabilityTEE(t, host)
-	})
-
-	t.Run("WaitForVersion", func(t *testing.T) {
-		testWaitForVersion(t, host)
+	t.Run("WaitForStart", func(t *testing.T) {
+		testWaitForStart(t, host)
 	})
 
 	t.Run("SimpleRequest", func(t *testing.T) {
@@ -129,28 +125,21 @@ func testSandboxedHost(t *testing.T, host Host) {
 	})
 }
 
-func testWaitForCapabilityTEE(t *testing.T, host Host) {
+func testWaitForStart(t *testing.T, host Host) {
 	ctx, cancel := context.WithTimeout(context.Background(), recvTimeout)
 	defer cancel()
 
-	cap, err := host.WaitForCapabilityTEE(ctx)
-	require.NoError(t, err, "WaitForCapabilityTEE")
+	ev, err := host.WaitForStart(ctx)
+	require.NoError(t, err, "WaitForStart")
+
+	// CapabilityTEE.
 	switch host.(*sandboxedHost).cfg.TEEHardware {
 	case node.TEEHardwareIntelSGX:
-		require.NotNil(t, cap, "capabilities should not be nil")
-		require.Equal(t, node.TEEHardwareIntelSGX, cap.Hardware, "TEE hardware should be Intel SGX")
+		require.NotNil(t, ev.CapabilityTEE, "capabilities should not be nil")
+		require.Equal(t, node.TEEHardwareIntelSGX, ev.CapabilityTEE.Hardware, "TEE hardware should be Intel SGX")
 	default:
-		require.Nil(t, cap, "capabilites should be nil")
+		require.Nil(t, ev.CapabilityTEE, "capabilites should be nil")
 	}
-}
-
-func testWaitForVersion(t *testing.T, host Host) {
-	ctx, cancel := context.WithTimeout(context.Background(), recvTimeout)
-	defer cancel()
-
-	v, err := host.WaitForRuntimeVersion(ctx)
-	require.NoError(t, err, "WaitForVersion")
-	require.NotNil(t, v, "version should not be nil")
 }
 
 func testSimpleRequest(t *testing.T, host Host) {

--- a/go/worker/common/runtime_host.go
+++ b/go/worker/common/runtime_host.go
@@ -206,15 +206,16 @@ type RuntimeHostNode struct {
 	workerHost        host.Host
 }
 
-// InitializeRuntimeWorkerHost initializes the runtime worker host for this
-// given runtime.
-func (n *RuntimeHostNode) InitializeRuntimeWorkerHost(ctx context.Context) error {
+// InitializeRuntimeWorkerHost initializes the runtime worker host for this runtime.
+//
+// NOTE: This does not start the worker host, call Start on the returned worker to do so.
+func (n *RuntimeHostNode) InitializeRuntimeWorkerHost(ctx context.Context) (host.Host, error) {
 	n.commonNode.CrossNode.Lock()
 	defer n.commonNode.CrossNode.Unlock()
 
 	rt, err := n.commonNode.Runtime.RegistryDescriptor(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	cfg := host.Config{
@@ -229,13 +230,10 @@ func (n *RuntimeHostNode) InitializeRuntimeWorkerHost(ctx context.Context) error
 	}
 	workerHost, err := n.workerHostFactory.NewWorkerHost(cfg)
 	if err != nil {
-		return err
-	}
-	if err := workerHost.Start(); err != nil {
-		return err
+		return nil, err
 	}
 	n.workerHost = workerHost
-	return nil
+	return workerHost, nil
 }
 
 // StopRuntimeWorkerHost signals the worker host to stop and waits for it

--- a/go/worker/executor/worker.go
+++ b/go/worker/executor/worker.go
@@ -234,25 +234,17 @@ func newWorker(
 					)
 					continue
 				}
-				if rt.Capabilities.TEE, err = workerHost.WaitForCapabilityTEE(w.ctx); err != nil {
-					w.logger.Error("failed to obtain CapabilityTEE",
+				ev, err := workerHost.WaitForStart(w.ctx)
+				if err != nil {
+					w.logger.Error("failed to wait for the worker to start",
 						"err", err,
 						"runtime", rt.ID,
 					)
 					continue
 				}
 
-				runtimeVersion, err := workerHost.WaitForRuntimeVersion(w.ctx)
-				if err == nil && runtimeVersion != nil {
-					rt.Version = *runtimeVersion
-				} else {
-					w.logger.Error("failed to obtain RuntimeVersion",
-						"err", err,
-						"runtime", rt.ID,
-						"runtime_version", runtimeVersion,
-					)
-					continue
-				}
+				rt.Version = ev.Version
+				rt.Capabilities.TEE = ev.CapabilityTEE
 			}
 
 			return nil

--- a/go/worker/keymanager/init.go
+++ b/go/worker/keymanager/init.go
@@ -73,7 +73,6 @@ func New(
 		quitCh:       make(chan struct{}),
 		initCh:       make(chan struct{}),
 		commonWorker: commonWorker,
-		registration: r,
 		backend:      backend,
 		grpcPolicy:   grpc.NewDynamicRuntimePolicyChecker(),
 		enabled:      Enabled(),
@@ -106,8 +105,9 @@ func New(
 			return nil, fmt.Errorf("worker/keymanager: cannot create local storage: %w", err)
 		}
 
-		if err := w.registration.RegisterRole(node.RoleKeyManager, w.onNodeRegistration); err != nil {
-			return nil, fmt.Errorf("worker/keymanager: failed to register role: %w", err)
+		w.roleProvider, err = r.NewRuntimeRoleProvider(node.RoleKeyManager, w.runtimeID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create role provider: %w", err)
 		}
 
 		w.workerHostCfg = host.Config{

--- a/go/worker/txnscheduler/worker.go
+++ b/go/worker/txnscheduler/worker.go
@@ -2,6 +2,7 @@ package txnscheduler
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/logging"
@@ -145,14 +146,19 @@ func (w *Worker) registerRuntime(commonNode *committeeCommon.Node) error {
 	// Get other nodes from this runtime.
 	executorNode := w.executor.GetRuntime(id)
 
+	rp, err := w.registration.NewRuntimeRoleProvider(node.RoleComputeWorker, id)
+	if err != nil {
+		return fmt.Errorf("failed to create role provider: %w", err)
+	}
+
 	// Create worker host for the given runtime.
 	workerHostFactory, err := w.NewRuntimeWorkerHostFactory(node.RoleComputeWorker, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create worker host: %w", err)
 	}
 
 	// Create committee node for the given runtime.
-	node, err := committee.NewNode(commonNode, executorNode, workerHostFactory, w.checkTxEnabled)
+	node, err := committee.NewNode(commonNode, executorNode, workerHostFactory, w.checkTxEnabled, rp)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
See #1794 

This replaces the previous mechanism which was implemented twice, first
to receive the CapabilityTEE and second to receive the runtime version.

The new mechanism is based on events so that the caller is able to get
notified when changes occur (e.g., on restarts).