### PR TITLE
enum checks

### DIFF
--- a/.changelog/2546.breaking.md
+++ b/.changelog/2546.breaking.md
@@ -1,0 +1,4 @@
+All marshallable enumerations in the code were checked and the default `Invalid = 0`
+value was added, if it didn't exist before. This makes the code less error prone
+and more secure, because it requires the enum field to be explicitly set, if
+some meaningful behavior is expected from the corresponding object.

--- a/go/Makefile
+++ b/go/Makefile
@@ -62,7 +62,7 @@ test:
 # Test without caching.
 force-test:
 	@$(ECHO) "$(CYAN)*** Running Go unit tests in force mode...$(OFF)"
-	$(MAKE) test GO_TEST_FLAGS=-count=1
+	@$(MAKE) test GO_TEST_FLAGS=-count=1
 
 # Test oasis-node with coverage.
 integrationrunner:

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -70,7 +70,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	ConsensusProtocol = Version{Major: 0, Minor: 22, Patch: 0}
+	ConsensusProtocol = Version{Major: 0, Minor: 23, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)

--- a/go/consensus/tendermint/abci/context.go
+++ b/go/consensus/tendermint/abci/context.go
@@ -20,8 +20,10 @@ type contextKey struct{}
 type ContextMode uint
 
 const (
+	// ContextInvalid is invalid context and should never be used.
+	ContextInvalid ContextMode = iota
 	// ContextInitChain is InitChain context.
-	ContextInitChain ContextMode = iota
+	ContextInitChain
 	// ContextCheckTx is CheckTx context.
 	ContextCheckTx
 	// ContextDeliverTx is DeliverTx context.

--- a/go/consensus/tendermint/apps/registry/genesis.go
+++ b/go/consensus/tendermint/apps/registry/genesis.go
@@ -36,7 +36,7 @@ func (app *registryApplication) InitChain(ctx *abci.Context, request types.Reque
 	} else {
 		// This is informational for now since there are configurations
 		// that do not have a key manager.
-		ctx.Logger().Warn("InitChain: Invalid key manager operator, key maanger will not work",
+		ctx.Logger().Warn("InitChain: Invalid key manager operator, key manager will not work",
 			"id", st.Parameters.KeyManagerOperator,
 		)
 	}

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -224,7 +224,7 @@ func (app *rootHashApplication) prepareNewCommittees(
 
 	// NOTE: There will later be multiple executor committees.
 	var executorCommittees []*scheduler.Committee
-	xc1, err := schedState.Committee(scheduler.KindExecutor, rtID)
+	xc1, err := schedState.Committee(scheduler.KindComputeExecutor, rtID)
 	if err != nil {
 		ctx.Logger().Error("checkCommittees: failed to get executor committee from scheduler",
 			"err", err,
@@ -285,7 +285,7 @@ func (app *rootHashApplication) prepareNewCommittees(
 
 	mergePool = new(commitment.Pool)
 	committeeIDParts = append(committeeIDParts, []byte("merge committee follows"))
-	mergeCommittee, err := schedState.Committee(scheduler.KindMerge, rtID)
+	mergeCommittee, err := schedState.Committee(scheduler.KindComputeMerge, rtID)
 	if err != nil {
 		ctx.Logger().Error("checkCommittees: failed to get merge committee from scheduler",
 			"err", err,

--- a/go/oasis-node/cmd/debug/byzantine/byzantine.go
+++ b/go/oasis-node/cmd/debug/byzantine/byzantine.go
@@ -124,13 +124,13 @@ func doExecutorHonest(cmd *cobra.Command, args []string) {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
-	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindExecutor)
+	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindComputeExecutor)
 	if err != nil {
 		panic(fmt.Sprintf("scheduler next election height failed: %+v", err))
 	}
-	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindExecutor, defaultRuntimeID)
+	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeExecutor, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindExecutor, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeExecutor, err))
 	}
 	if err = schedulerCheckScheduled(executorCommittee, defaultIdentity.NodeSigner.Public(), scheduler.Worker); err != nil {
 		panic(fmt.Sprintf("scheduler check scheduled failed: %+v", err))
@@ -140,16 +140,16 @@ func doExecutorHonest(cmd *cobra.Command, args []string) {
 	if err != nil {
 		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindStorage, err))
 	}
-	transactionSchedulerCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindTransactionScheduler, defaultRuntimeID)
+	transactionSchedulerCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeTxnScheduler, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindTransactionScheduler, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeTxnScheduler, err))
 	}
 	if err = schedulerCheckNotScheduled(transactionSchedulerCommittee, defaultIdentity.NodeSigner.Public()); err != nil {
 		panic(fmt.Sprintf("scheduler check not scheduled txnscheduler failed: %+v", err))
 	}
-	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindMerge, defaultRuntimeID)
+	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeMerge, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindMerge, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeMerge, err))
 	}
 	if err = schedulerCheckNotScheduled(mergeCommittee, defaultIdentity.NodeSigner.Public()); err != nil {
 		panic(fmt.Sprintf("scheduler check not scheduled merge failed: %+v", err))
@@ -256,13 +256,13 @@ func doExecutorWrong(cmd *cobra.Command, args []string) {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
-	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindExecutor)
+	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindComputeExecutor)
 	if err != nil {
 		panic(fmt.Sprintf("scheduler next election height failed: %+v", err))
 	}
-	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindExecutor, defaultRuntimeID)
+	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeExecutor, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindExecutor, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeExecutor, err))
 	}
 	if err = schedulerCheckScheduled(executorCommittee, defaultIdentity.NodeSigner.Public(), scheduler.Worker); err != nil {
 		panic(fmt.Sprintf("scheduler check scheduled failed: %+v", err))
@@ -272,16 +272,16 @@ func doExecutorWrong(cmd *cobra.Command, args []string) {
 	if err != nil {
 		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindStorage, err))
 	}
-	transactionSchedulerCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindTransactionScheduler, defaultRuntimeID)
+	transactionSchedulerCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeTxnScheduler, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindTransactionScheduler, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeTxnScheduler, err))
 	}
 	if err = schedulerCheckNotScheduled(transactionSchedulerCommittee, defaultIdentity.NodeSigner.Public()); err != nil {
 		panic(fmt.Sprintf("scheduler check not scheduled txnscheduler failed: %+v", err))
 	}
-	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindMerge, defaultRuntimeID)
+	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeMerge, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindMerge, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeMerge, err))
 	}
 	if err = schedulerCheckNotScheduled(mergeCommittee, defaultIdentity.NodeSigner.Public()); err != nil {
 		panic(fmt.Sprintf("scheduler check not scheduled merge failed: %+v", err))
@@ -387,28 +387,28 @@ func doExecutorStraggler(cmd *cobra.Command, args []string) {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
-	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindExecutor)
+	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindComputeExecutor)
 	if err != nil {
 		panic(fmt.Sprintf("scheduler next election height failed: %+v", err))
 	}
-	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindExecutor, defaultRuntimeID)
+	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeExecutor, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindExecutor, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeExecutor, err))
 	}
 	if err = schedulerCheckScheduled(executorCommittee, defaultIdentity.NodeSigner.Public(), scheduler.Worker); err != nil {
 		panic(fmt.Sprintf("scheduler check scheduled failed: %+v", err))
 	}
 	logger.Debug("executor straggler: executor schedule ok")
-	transactionSchedulerCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindTransactionScheduler, defaultRuntimeID)
+	transactionSchedulerCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeTxnScheduler, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindTransactionScheduler, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeTxnScheduler, err))
 	}
 	if err = schedulerCheckNotScheduled(transactionSchedulerCommittee, defaultIdentity.NodeSigner.Public()); err != nil {
 		panic(fmt.Sprintf("scheduler check not scheduled txnscheduler failed: %+v", err))
 	}
-	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindMerge, defaultRuntimeID)
+	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeMerge, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindMerge, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeMerge, err))
 	}
 	if err = schedulerCheckNotScheduled(mergeCommittee, defaultIdentity.NodeSigner.Public()); err != nil {
 		panic(fmt.Sprintf("scheduler check not scheduled merge failed: %+v", err))
@@ -462,21 +462,21 @@ func doMergeHonest(cmd *cobra.Command, args []string) {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
-	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindExecutor)
+	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindComputeExecutor)
 	if err != nil {
 		panic(fmt.Sprintf("scheduler next election height failed: %+v", err))
 	}
-	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindMerge, defaultRuntimeID)
+	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeMerge, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindMerge, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeMerge, err))
 	}
 	if err = schedulerCheckScheduled(mergeCommittee, defaultIdentity.NodeSigner.Public(), scheduler.Worker); err != nil {
 		panic(fmt.Sprintf("scheduler check scheduled failed: %+v", err))
 	}
 	logger.Debug("merge honest: merge schedule ok")
-	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindExecutor, defaultRuntimeID)
+	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeExecutor, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindExecutor, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeExecutor, err))
 	}
 	if err = schedulerCheckNotScheduled(executorCommittee, defaultIdentity.NodeSigner.Public()); err != nil {
 		panic(fmt.Sprintf("scheduler check not scheduled executor failed: %+v", err))
@@ -485,9 +485,9 @@ func doMergeHonest(cmd *cobra.Command, args []string) {
 	if err != nil {
 		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindStorage, err))
 	}
-	transactionSchedulerCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindTransactionScheduler, defaultRuntimeID)
+	transactionSchedulerCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeTxnScheduler, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindTransactionScheduler, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeTxnScheduler, err))
 	}
 	if err = schedulerCheckNotScheduled(transactionSchedulerCommittee, defaultIdentity.NodeSigner.Public()); err != nil {
 		panic(fmt.Sprintf("scheduler check not scheduled txnscheduler failed: %+v", err))
@@ -570,21 +570,21 @@ func doMergeWrong(cmd *cobra.Command, args []string) {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
-	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindExecutor)
+	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindComputeExecutor)
 	if err != nil {
 		panic(fmt.Sprintf("scheduler next election height failed: %+v", err))
 	}
-	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindMerge, defaultRuntimeID)
+	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeMerge, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindMerge, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeMerge, err))
 	}
 	if err = schedulerCheckScheduled(mergeCommittee, defaultIdentity.NodeSigner.Public(), scheduler.Worker); err != nil {
 		panic(fmt.Sprintf("scheduler check scheduled failed: %+v", err))
 	}
 	logger.Debug("merge wrong: merge schedule ok")
-	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindExecutor, defaultRuntimeID)
+	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeExecutor, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindExecutor, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeExecutor, err))
 	}
 	if err = schedulerCheckNotScheduled(executorCommittee, defaultIdentity.NodeSigner.Public()); err != nil {
 		panic(fmt.Sprintf("scheduler check not scheduled executor failed: %+v", err))
@@ -593,9 +593,9 @@ func doMergeWrong(cmd *cobra.Command, args []string) {
 	if err != nil {
 		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindStorage, err))
 	}
-	transactionSchedulerCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindTransactionScheduler, defaultRuntimeID)
+	transactionSchedulerCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeTxnScheduler, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindTransactionScheduler, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeTxnScheduler, err))
 	}
 	if err = schedulerCheckNotScheduled(transactionSchedulerCommittee, defaultIdentity.NodeSigner.Public()); err != nil {
 		panic(fmt.Sprintf("scheduler check not scheduled txnscheduler failed: %+v", err))
@@ -702,28 +702,28 @@ func doMergeStraggler(cmd *cobra.Command, args []string) {
 		panic(fmt.Sprintf("registryRegisterNode: %+v", err))
 	}
 
-	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindExecutor)
+	electionHeight, err := schedulerNextElectionHeight(ht.service, scheduler.KindComputeExecutor)
 	if err != nil {
 		panic(fmt.Sprintf("scheduler next election height failed: %+v", err))
 	}
-	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindMerge, defaultRuntimeID)
+	mergeCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeMerge, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindMerge, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeMerge, err))
 	}
 	if err = schedulerCheckScheduled(mergeCommittee, defaultIdentity.NodeSigner.Public(), scheduler.Worker); err != nil {
 		panic(fmt.Sprintf("scheduler check scheduled failed: %+v", err))
 	}
 	logger.Debug("merge straggler: merge schedule ok")
-	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindExecutor, defaultRuntimeID)
+	executorCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeExecutor, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindExecutor, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeExecutor, err))
 	}
 	if err = schedulerCheckNotScheduled(executorCommittee, defaultIdentity.NodeSigner.Public()); err != nil {
 		panic(fmt.Sprintf("scheduler check not scheduled executor failed: %+v", err))
 	}
-	transactionSchedulerCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindTransactionScheduler, defaultRuntimeID)
+	transactionSchedulerCommittee, err := schedulerGetCommittee(ht, electionHeight, scheduler.KindComputeTxnScheduler, defaultRuntimeID)
 	if err != nil {
-		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindTransactionScheduler, err))
+		panic(fmt.Sprintf("scheduler get committee %s failed: %+v", scheduler.KindComputeTxnScheduler, err))
 	}
 	if err = schedulerCheckNotScheduled(transactionSchedulerCommittee, defaultIdentity.NodeSigner.Public()); err != nil {
 		panic(fmt.Sprintf("scheduler check not scheduled txnscheduler failed: %+v", err))

--- a/go/oasis-node/cmd/debug/byzantine/scheduler_test.go
+++ b/go/oasis-node/cmd/debug/byzantine/scheduler_test.go
@@ -23,23 +23,23 @@ func hasSuitablePermutations(t *testing.T, beacon []byte, runtimeID common.Names
 	mergeIdxs, err := schedulerapp.GetPerm(beacon, runtimeID, schedulerapp.RNGContextMerge, numComputeNodes)
 	require.NoError(t, err, "schedulerapp.GetPerm merge")
 
-	fmt.Printf("%20s schedule %v\n", scheduler.KindExecutor, computeIdxs)
-	fmt.Printf("%20s schedule %v\n", scheduler.KindTransactionScheduler, transactionSchedulerIdxs)
-	fmt.Printf("%20s schedule %v\n", scheduler.KindMerge, mergeIdxs)
+	fmt.Printf("%20s schedule %v\n", scheduler.KindComputeExecutor, computeIdxs)
+	fmt.Printf("%20s schedule %v\n", scheduler.KindComputeTxnScheduler, transactionSchedulerIdxs)
+	fmt.Printf("%20s schedule %v\n", scheduler.KindComputeMerge, mergeIdxs)
 
 	committees := map[scheduler.CommitteeKind]struct {
 		workers       int
 		backupWorkers int
 		perm          []int
 	}{
-		scheduler.KindExecutor:             {workers: 2, backupWorkers: 1, perm: computeIdxs},
-		scheduler.KindTransactionScheduler: {workers: 1, backupWorkers: 0, perm: transactionSchedulerIdxs},
-		scheduler.KindMerge:                {workers: 2, backupWorkers: 1, perm: mergeIdxs},
+		scheduler.KindComputeExecutor:     {workers: 2, backupWorkers: 1, perm: computeIdxs},
+		scheduler.KindComputeTxnScheduler: {workers: 1, backupWorkers: 0, perm: transactionSchedulerIdxs},
+		scheduler.KindComputeMerge:        {workers: 2, backupWorkers: 1, perm: mergeIdxs},
 	}
 
 	for _, c1Kind := range []scheduler.CommitteeKind{
-		scheduler.KindExecutor,
-		scheduler.KindMerge,
+		scheduler.KindComputeExecutor,
+		scheduler.KindComputeMerge,
 	} {
 		c1 := committees[c1Kind]
 		maxWorker := c1.workers

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -274,6 +274,8 @@ func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) {
 			)
 			return nil, nil, fmt.Errorf("invalid runtime flags")
 		}
+	case registry.KindInvalid:
+		return nil, nil, fmt.Errorf("cannot create runtime with invalid kind")
 	}
 
 	// TODO: Support root upload when registering.

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -79,6 +79,7 @@ var (
 
 	testRuntime = &registry.Runtime{
 		// ID: default value,
+		Kind: registry.KindCompute,
 		Executor: registry.ExecutorParameters{
 			GroupSize:       1,
 			GroupBackupSize: 0,

--- a/go/registry/api/runtime.go
+++ b/go/registry/api/runtime.go
@@ -19,9 +19,9 @@ import (
 )
 
 var (
-	// ErrInvalidRuntimeKind is the error returned when the parsed runtime
-	// kind is malformed.
-	ErrInvalidRuntimeKind = errors.New("runtime: invalid runtime kind")
+	// ErrUnsupportedRuntimeKind is the error returned when the parsed runtime
+	// kind is malformed or unknown.
+	ErrUnsupportedRuntimeKind = errors.New("runtime: unsupported runtime kind")
 	// ErrMalformedStoreID is the error returned when a storage service
 	// ID is malformed.
 	ErrMalformedStoreID = errors.New("runtime: Malformed store ID")
@@ -33,12 +33,16 @@ var (
 type RuntimeKind uint32
 
 const (
-	// KindCompute is a generic executor runtime.
-	KindCompute RuntimeKind = 0
+	// KindInvalid is an invalid runtime and should never be explicitly set.
+	KindInvalid RuntimeKind = 0
+
+	// KindCompute is a generic compute runtime.
+	KindCompute RuntimeKind = 1
 
 	// KindKeyManager is a key manager runtime.
-	KindKeyManager RuntimeKind = 1
+	KindKeyManager RuntimeKind = 2
 
+	kindInvalid    = "invalid"
 	kindCompute    = "compute"
 	kindKeyManager = "keymanager"
 
@@ -49,6 +53,8 @@ const (
 // String returns a string representation of a runtime kind.
 func (k RuntimeKind) String() string {
 	switch k {
+	case KindInvalid:
+		return kindInvalid
 	case KindCompute:
 		return kindCompute
 	case KindKeyManager:
@@ -66,7 +72,7 @@ func (k *RuntimeKind) FromString(str string) error {
 	case kindKeyManager:
 		*k = KindKeyManager
 	default:
-		return ErrInvalidRuntimeKind
+		return ErrUnsupportedRuntimeKind
 	}
 
 	return nil

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -1069,7 +1069,8 @@ func NewTestRuntime(seed []byte, entity *TestEntity, isKeyManager bool) (*TestRu
 	}
 
 	rt.Runtime = &api.Runtime{
-		ID: publicKeyToNamespace(rt.Signer.Public(), isKeyManager),
+		ID:   publicKeyToNamespace(rt.Signer.Public(), isKeyManager),
+		Kind: api.KindCompute,
 		Executor: api.ExecutorParameters{
 			GroupSize:         3,
 			GroupBackupSize:   5,

--- a/go/roothash/api/block/block.go
+++ b/go/roothash/api/block/block.go
@@ -18,6 +18,7 @@ func NewGenesisBlock(id common.Namespace, timestamp uint64) *Block {
 
 	blk.Header.Version = 0
 	blk.Header.Timestamp = timestamp
+	blk.Header.HeaderType = Normal
 	blk.Header.Namespace = id
 	blk.Header.PreviousHash.Empty()
 	blk.Header.IORoot.Empty()

--- a/go/roothash/api/block/header.go
+++ b/go/roothash/api/block/header.go
@@ -18,26 +18,29 @@ var ErrInvalidVersion = errors.New("roothash: invalid version")
 type HeaderType uint8
 
 const (
+	// Invalid is an invalid header type and should never be stored.
+	Invalid HeaderType = 0
+
 	// Normal is a normal header.
-	Normal HeaderType = 0
+	Normal HeaderType = 1
 
 	// RoundFailed is a header resulting from a failed round. Such a
 	// header contains no transactions but advances the round as normal
 	// to prevent replays of old commitments.
-	RoundFailed HeaderType = 1
+	RoundFailed HeaderType = 2
 
 	// EpochTransition is a header resulting from an epoch transition.
 	//
 	// Such a header contains no transactions but advances the round as
 	// normal.
 	// TODO: Consider renaming this to CommitteeTransition.
-	EpochTransition HeaderType = 2
+	EpochTransition HeaderType = 3
 
 	// Suspended is a header resulting from the runtime being suspended.
 	//
 	// Such a header contains no transactions but advances the round as
 	// normal.
-	Suspended HeaderType = 3
+	Suspended HeaderType = 4
 )
 
 // Header is a block header.

--- a/go/roothash/api/block/header_test.go
+++ b/go/roothash/api/block/header_test.go
@@ -21,7 +21,7 @@ func TestConsistentHash(t *testing.T) {
 	require.EqualValues(t, emptyHeaderHash, empty.EncodedHash())
 
 	var populatedHeaderHash hash.Hash
-	_ = populatedHeaderHash.UnmarshalHex("e42c423b85e6ac261712f65b50ddbdef4758ed214c316c1f61ee76db28d1d8a5")
+	_ = populatedHeaderHash.UnmarshalHex("c39e8aefea5a1f794fb57f294a4ea8599381cd8739e67a8a9acb7763b54a630a")
 
 	var emptyRoot hash.Hash
 	emptyRoot.Empty()
@@ -46,5 +46,5 @@ func TestConsistentHash(t *testing.T) {
 		StateRoot:    emptyRoot,
 		Messages:     nil,
 	}
-	require.EqualValues(t, populatedHeaderHash, populated.EncodedHash())
+	require.EqualValues(t, populatedHeaderHash.String(), populated.EncodedHash().String())
 }

--- a/go/roothash/api/commitment/pool_test.go
+++ b/go/roothash/api/commitment/pool_test.go
@@ -40,7 +40,7 @@ func (n *staticSignatureVerifier) VerifyCommitteeSignatures(kind scheduler.Commi
 	switch kind {
 	case scheduler.KindStorage:
 		pk = n.storagePublicKey
-	case scheduler.KindTransactionScheduler:
+	case scheduler.KindComputeTxnScheduler:
 		pk = n.txnSchedulerPublicKey
 	default:
 		return errors.New("unsupported committee kind")
@@ -98,6 +98,7 @@ func TestPoolSingleCommitment(t *testing.T) {
 
 	rt := &registry.Runtime{
 		ID:          rtID,
+		Kind:        registry.KindCompute,
 		TEEHardware: node.TEEHardwareInvalid,
 	}
 
@@ -108,7 +109,7 @@ func TestPoolSingleCommitment(t *testing.T) {
 	// Generate a committee.
 	cID := sk.Public()
 	committee := &scheduler.Committee{
-		Kind: scheduler.KindExecutor,
+		Kind: scheduler.KindComputeExecutor,
 		Members: []*scheduler.CommitteeNode{
 			&scheduler.CommitteeNode{
 				Role:      scheduler.Worker,
@@ -204,6 +205,7 @@ func TestPoolSingleCommitmentTEE(t *testing.T) {
 
 	rt := &registry.Runtime{
 		ID:          rtID,
+		Kind:        registry.KindCompute,
 		TEEHardware: node.TEEHardwareIntelSGX,
 	}
 
@@ -218,7 +220,7 @@ func TestPoolSingleCommitmentTEE(t *testing.T) {
 	// Generate a committee.
 	cID := sk.Public()
 	committee := &scheduler.Committee{
-		Kind: scheduler.KindExecutor,
+		Kind: scheduler.KindComputeExecutor,
 		Members: []*scheduler.CommitteeNode{
 			&scheduler.CommitteeNode{
 				Role:      scheduler.Worker,
@@ -440,6 +442,7 @@ func TestPoolSerialization(t *testing.T) {
 
 	rt := &registry.Runtime{
 		ID:          rtID,
+		Kind:        registry.KindCompute,
 		TEEHardware: node.TEEHardwareInvalid,
 	}
 
@@ -450,7 +453,7 @@ func TestPoolSerialization(t *testing.T) {
 	// Generate a committee.
 	cID := sk.Public()
 	committee := &scheduler.Committee{
-		Kind: scheduler.KindExecutor,
+		Kind: scheduler.KindComputeExecutor,
 		Members: []*scheduler.CommitteeNode{
 			&scheduler.CommitteeNode{
 				Role:      scheduler.Worker,
@@ -578,7 +581,7 @@ func TestPoolMergeCommitment(t *testing.T) {
 
 	rt, executorSks, executorCommittee, executorNodeInfo := generateMockCommittee(t)
 	_, mergeSks, mergeCommittee, mergeNodeInfo := generateMockCommittee(t)
-	mergeCommittee.Kind = scheduler.KindMerge
+	mergeCommittee.Kind = scheduler.KindComputeMerge
 	executorCommitteeID := executorCommittee.EncodedMembersHash()
 
 	t.Run("NoDiscrepancy", func(t *testing.T) {
@@ -1102,6 +1105,7 @@ func generateMockCommittee(t *testing.T) (
 
 	rt = &registry.Runtime{
 		ID:          rtID,
+		Kind:        registry.KindCompute,
 		TEEHardware: node.TEEHardwareInvalid,
 	}
 
@@ -1119,7 +1123,7 @@ func generateMockCommittee(t *testing.T) (
 	c2ID := sk2.Public()
 	c3ID := sk3.Public()
 	committee = &scheduler.Committee{
-		Kind: scheduler.KindExecutor,
+		Kind: scheduler.KindComputeExecutor,
 		Members: []*scheduler.CommitteeNode{
 			&scheduler.CommitteeNode{
 				Role:      scheduler.Worker,

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -437,19 +437,22 @@ func mustGetCommittee(
 
 			var groupSize, groupBackupSize int
 			switch committee.Kind {
-			case scheduler.KindTransactionScheduler:
+			case scheduler.KindComputeTxnScheduler:
 				groupSize = int(rt.Runtime.TxnScheduler.GroupSize)
 				groupBackupSize = 0
-			case scheduler.KindExecutor:
+			case scheduler.KindComputeExecutor:
 				fallthrough
-			case scheduler.KindMerge:
+			case scheduler.KindComputeMerge:
 				groupSize = int(rt.Runtime.Merge.GroupSize)
 				groupBackupSize = int(rt.Runtime.Merge.GroupBackupSize)
 			case scheduler.KindStorage:
 				groupSize = int(rt.Runtime.Storage.GroupSize)
 			}
 
-			if committee.Kind.NeedsLeader() {
+			var needsLeader bool
+			needsLeader, err = committee.Kind.NeedsLeader()
+			require.NoError(err, "needsLeader returns correctly")
+			if needsLeader {
 				require.Len(ret.workers, groupSize-1, "workers exist")
 				require.NotNil(ret.leader, "leader exist")
 			} else {
@@ -459,11 +462,11 @@ func mustGetCommittee(
 			require.Len(ret.backupWorkers, groupBackupSize, "backup workers exist")
 
 			switch committee.Kind {
-			case scheduler.KindTransactionScheduler:
+			case scheduler.KindComputeTxnScheduler:
 				txnSchedCommittee = &ret
-			case scheduler.KindExecutor:
+			case scheduler.KindComputeExecutor:
 				executorCommittee = &ret
-			case scheduler.KindMerge:
+			case scheduler.KindComputeMerge:
 				mergeCommittee = &ret
 			case scheduler.KindStorage:
 				storageCommittee = &ret

--- a/go/runtime/client/watcher.go
+++ b/go/runtime/client/watcher.go
@@ -117,7 +117,7 @@ func (w *blockWatcher) refreshCommittee(height int64) error {
 
 	var committee *scheduler.Committee
 	for _, c := range committees {
-		if c.Kind != scheduler.KindTransactionScheduler {
+		if c.Kind != scheduler.KindComputeTxnScheduler {
 			continue
 		}
 		committee = c

--- a/go/runtime/transaction/transaction.go
+++ b/go/runtime/transaction/transaction.go
@@ -35,15 +35,23 @@ const prefetchArtifactCount uint16 = 20000
 type artifactKind uint8
 
 const (
+	// kindInvalid is invalid (not set) artifact kind and should never be stored.
+	kindInvalid artifactKind = 0
 	// kindInput is the input artifact kind.
-	kindInput artifactKind = 0
+	kindInput artifactKind = 1
 	// kindOutput is the output artifact kind.
-	kindOutput artifactKind = 1
+	kindOutput artifactKind = 2
 )
 
 // MarshalBinary encodes an artifact kind into binary form.
 func (ak artifactKind) MarshalBinary() (data []byte, err error) {
+	// kindInvalid should not be marshaleld.
+	if ak == kindInvalid {
+		return nil, errMalformedArtifactKind
+	}
+
 	data = []byte{uint8(ak)}
+
 	return
 }
 
@@ -68,7 +76,8 @@ func (ak *artifactKind) UnmarshalBinary(data []byte) error {
 
 var (
 	// txnKeyFmt is the key format used for transaction artifacts.
-	txnKeyFmt = keyformat.New('T', &hash.Hash{}, artifactKind(0))
+	// The artifactKind parameter is needed to compute the enum size in bytes. We put some marshallable value there.
+	txnKeyFmt = keyformat.New('T', &hash.Hash{}, artifactKind(1))
 	// tagKeyFmt is the key format used for emitted tags.
 	//
 	// This is kept separate so that clients can query only tags they are

--- a/go/runtime/transaction/transaction_test.go
+++ b/go/runtime/transaction/transaction_test.go
@@ -131,7 +131,7 @@ func TestTransaction(t *testing.T) {
 	// NOTE: This root is synced with tests in runtime/src/transaction/tree.rs.
 	writeLog, rootHash, err := tree.Commit(ctx)
 	require.NoError(t, err, "Commit")
-	require.EqualValues(t, "4cc8bb6bdb377cc7f1ff8fe972004e1d66fa2c6726ec9e5f870865c190b6a47d", rootHash.String(), "transaction root should be stable")
+	require.EqualValues(t, "c65f4e8bd5314c26f245337a859ad244f4b1544acf60ef334cf0d0eadb47363b", rootHash.String(), "transaction root should be stable")
 
 	// Apply write log to tree and check if everything is still there.
 	err = store.ApplyWriteLog(ctx, writelog.NewStaticIterator(writeLog))

--- a/go/scheduler/api/api.go
+++ b/go/scheduler/api/api.go
@@ -67,47 +67,54 @@ type CommitteeNode struct {
 type CommitteeKind uint8
 
 const (
-	// KindExecutor is an executor committee.
-	KindExecutor CommitteeKind = 0
+	// KindInvalid is an invalid committee.
+	KindInvalid CommitteeKind = 0
+
+	// KindComputeExecutor is an executor committee.
+	KindComputeExecutor CommitteeKind = 1
+
+	// KindComputeTxnScheduler is a transaction scheduler committee.
+	KindComputeTxnScheduler CommitteeKind = 2
+
+	// KindComputeMerge is a merge committee.
+	KindComputeMerge CommitteeKind = 3
 
 	// KindStorage is a storage committee.
-	KindStorage CommitteeKind = 1
-
-	// KindTransactionScheduler is a transaction scheduler committee.
-	KindTransactionScheduler CommitteeKind = 2
-
-	// KindMerge is a merge committee.
-	KindMerge CommitteeKind = 3
+	KindStorage CommitteeKind = 4
 
 	// MaxCommitteeKind is a dummy value used for iterating all committee kinds.
-	MaxCommitteeKind = 4
+	MaxCommitteeKind = 5
 )
 
 // NeedsLeader returns if committee kind needs leader role.
-func (k CommitteeKind) NeedsLeader() bool {
+func (k CommitteeKind) NeedsLeader() (bool, error) {
 	switch k {
-	case KindExecutor:
-		return false
-	case KindMerge:
-		return false
+	case KindComputeExecutor:
+		return false, nil
+	case KindComputeTxnScheduler:
+		return true, nil
+	case KindComputeMerge:
+		return false, nil
 	case KindStorage:
-		return false
+		return false, nil
 	default:
-		return true
+		return false, fmt.Errorf("scheduler/NeedsLeader: unsupported committee kind %s", k)
 	}
 }
 
 // String returns a string representation of a CommitteeKind.
 func (k CommitteeKind) String() string {
 	switch k {
-	case KindExecutor:
+	case KindInvalid:
+		return "invalid"
+	case KindComputeExecutor:
 		return "executor"
+	case KindComputeTxnScheduler:
+		return "txn_scheduler"
+	case KindComputeMerge:
+		return "merge"
 	case KindStorage:
 		return "storage"
-	case KindTransactionScheduler:
-		return "txn_scheduler"
-	case KindMerge:
-		return "merge"
 	default:
 		return fmt.Sprintf("[unknown kind: %d]", k)
 	}

--- a/go/scheduler/tests/tester.go
+++ b/go/scheduler/tests/tester.go
@@ -42,10 +42,10 @@ func SchedulerImplementationTests(t *testing.T, name string, backend api.Backend
 	epochtime := consensus.EpochTime().(epochtime.SetableBackend)
 	epoch := epochtimeTests.MustAdvanceEpoch(t, epochtime, 1)
 
-	ensureValidCommittees := func(expectedExecutor, expectedStorage, expectedTransactionScheduler int) {
-		var executor, storage, transactionScheduler *api.Committee
+	ensureValidCommittees := func(expectedExecutor, expectedTransactionScheduler, expectedMerge, expectedStorage int) {
+		var executor, transactionScheduler, merge, storage *api.Committee
 		var seen int
-		for seen < 3 {
+		for seen < 4 {
 			select {
 			case committee := <-ch:
 				if committee.ValidFor < epoch {
@@ -56,18 +56,22 @@ func SchedulerImplementationTests(t *testing.T, name string, backend api.Backend
 				}
 
 				switch committee.Kind {
-				case api.KindExecutor:
+				case api.KindComputeExecutor:
 					require.Nil(executor, "haven't seen an executor committee yet")
 					executor = committee
 					require.Len(committee.Members, expectedExecutor, "committee has all executor nodes")
+				case api.KindComputeTxnScheduler:
+					require.Nil(transactionScheduler, "haven't seen a transaction scheduler committee yet")
+					require.Len(committee.Members, expectedTransactionScheduler, "committee has all transaction scheduler nodes")
+					transactionScheduler = committee
+				case api.KindComputeMerge:
+					require.Nil(merge, "haven't seen a merge committee yet")
+					require.Len(committee.Members, expectedMerge, "committee has all merge nodes")
+					merge = committee
 				case api.KindStorage:
 					require.Nil(storage, "haven't seen a storage committee yet")
 					require.Len(committee.Members, expectedStorage, "committee has all storage nodes")
 					storage = committee
-				case api.KindTransactionScheduler:
-					require.Nil(transactionScheduler, "haven't seen a transaction scheduler committee yet")
-					require.Len(committee.Members, expectedTransactionScheduler, "committee has all transaction scheduler nodes")
-					transactionScheduler = committee
 				}
 
 				requireValidCommitteeMembers(t, committee, rt.Runtime, nodes)
@@ -88,21 +92,25 @@ func SchedulerImplementationTests(t *testing.T, name string, backend api.Backend
 		require.NoError(err, "GetCommittees")
 		for _, committee := range committees {
 			switch committee.Kind {
-			case api.KindExecutor:
+			case api.KindComputeExecutor:
 				require.EqualValues(executor, committee, "fetched executor committee is identical")
 				executor = nil
+			case api.KindComputeTxnScheduler:
+				require.EqualValues(transactionScheduler, committee, "fetched transaction scheduler committee is identical")
+				transactionScheduler = nil
+			case api.KindComputeMerge:
+				require.EqualValues(merge, committee, "fetched merge committee is identical")
+				merge = nil
 			case api.KindStorage:
 				require.EqualValues(storage, committee, "fetched storage committee is identical")
 				storage = nil
-			case api.KindTransactionScheduler:
-				require.EqualValues(transactionScheduler, committee, "fetched transaction scheduler committee is identical")
-				transactionScheduler = nil
 			}
 		}
 
 		require.Nil(executor, "fetched an executor committee")
-		require.Nil(storage, "fetched a storage committee")
 		require.Nil(transactionScheduler, "fetched a transaction scheduler committee")
+		require.Nil(merge, "fetched a merge committee")
+		require.Nil(storage, "fetched a storage committee")
 	}
 
 	var nExecutor, nStorage int
@@ -114,7 +122,12 @@ func SchedulerImplementationTests(t *testing.T, name string, backend api.Backend
 			nStorage++
 		}
 	}
-	ensureValidCommittees(nExecutor, nStorage, int(rt.Runtime.TxnScheduler.GroupSize))
+	ensureValidCommittees(
+		nExecutor,
+		int(rt.Runtime.TxnScheduler.GroupSize),
+		int(rt.Runtime.Merge.GroupSize)+int(rt.Runtime.Merge.GroupBackupSize),
+		nStorage,
+	)
 
 	// Re-register the runtime with less nodes.
 	rt.Runtime.Executor.GroupSize = 2
@@ -124,7 +137,12 @@ func SchedulerImplementationTests(t *testing.T, name string, backend api.Backend
 
 	epoch = epochtimeTests.MustAdvanceEpoch(t, epochtime, 1)
 
-	ensureValidCommittees(3, 1, int(rt.Runtime.TxnScheduler.GroupSize))
+	ensureValidCommittees(
+		3,
+		int(rt.Runtime.TxnScheduler.GroupSize),
+		int(rt.Runtime.Merge.GroupSize)+int(rt.Runtime.Merge.GroupBackupSize),
+		1,
+	)
 
 	// Cleanup the registry.
 	rt.Cleanup(t, consensus.Registry(), consensus)
@@ -165,21 +183,25 @@ func requireValidCommitteeMembers(t *testing.T, committee *api.Committee, runtim
 		}
 	}
 
-	if committee.Kind.NeedsLeader() {
+	needsLeader, err := committee.Kind.NeedsLeader()
+	require.NoError(err, "needsLeader returns correctly")
+	if needsLeader {
 		require.Equal(1, leaders, fmt.Sprintf("%s committee should have a leader", committee.Kind))
 	} else {
 		require.Equal(0, leaders, fmt.Sprintf("%s committee shouldn't have a leader", committee.Kind))
 	}
 	switch committee.Kind {
-	case api.KindExecutor:
+	case api.KindComputeExecutor:
 		require.EqualValues(runtime.Executor.GroupSize, workers, "executor committee should have the correct number of workers")
 		require.EqualValues(runtime.Executor.GroupBackupSize, backups, "executor committee should have the correct number of backup workers")
-	case api.KindMerge:
+	case api.KindComputeMerge:
 		require.EqualValues(runtime.Merge.GroupSize, workers, "merge committee should have the correct number of workers")
 		require.EqualValues(runtime.Merge.GroupBackupSize, backups, "merge committee should have the correct number of backup workers")
-	case api.KindStorage, api.KindTransactionScheduler:
+	case api.KindStorage, api.KindComputeTxnScheduler:
 		numCommitteeMembersWithoutLeader := len(committee.Members)
-		if committee.Kind.NeedsLeader() {
+		needsLeader, err := committee.Kind.NeedsLeader()
+		require.NoError(err, "needsLeader returns correctly")
+		if needsLeader {
 			numCommitteeMembersWithoutLeader--
 		}
 		require.EqualValues(numCommitteeMembersWithoutLeader, workers, fmt.Sprintf("all %s committee members except for the leader (if present) should be workers", committee.Kind))

--- a/go/worker/common/committee/group.go
+++ b/go/worker/common/committee/group.go
@@ -192,7 +192,7 @@ func (e *EpochSnapshot) VerifyCommitteeSignatures(kind scheduler.CommitteeKind, 
 	switch kind {
 	case scheduler.KindStorage:
 		committee = e.storageCommittee
-	case scheduler.KindTransactionScheduler:
+	case scheduler.KindComputeTxnScheduler:
 		committee = e.txnSchedulerCommittee
 	default:
 		return fmt.Errorf("epoch: unsupported committee kind: %s", kind)
@@ -327,7 +327,7 @@ func (g *Group) EpochTransition(ctx context.Context, height int64) error {
 		}
 
 		switch cm.Kind {
-		case scheduler.KindExecutor:
+		case scheduler.KindComputeExecutor:
 			// There can be multiple executor committees per runtime.
 			cID := cm.EncodedMembersHash()
 			executorCommittees[cID] = ci
@@ -343,12 +343,12 @@ func (g *Group) EpochTransition(ctx context.Context, height int64) error {
 			for _, n := range nodes {
 				executorCommitteesByPeer[n.P2P.ID] = true
 			}
-		case scheduler.KindTransactionScheduler:
+		case scheduler.KindComputeTxnScheduler:
 			txnSchedulerCommittee = ci
 			if leader != -1 {
 				txnSchedulerLeaderPeerID = nodes[leader].P2P.ID
 			}
-		case scheduler.KindMerge:
+		case scheduler.KindComputeMerge:
 			mergeCommittee = ci
 		case scheduler.KindStorage:
 			storageCommittee = ci

--- a/runtime/src/common/roothash.rs
+++ b/runtime/src/common/roothash.rs
@@ -5,6 +5,7 @@
 //! This **MUST** be kept in sync with go/roothash/api/block.
 //!
 use serde_derive::{Deserialize, Serialize};
+use serde_repr::*;
 
 use super::{
     cbor,
@@ -29,6 +30,25 @@ pub struct AnnotatedBlock {
 
 impl_bytes!(Namespace, 32, "Chain namespace.");
 
+/// Header type.
+///
+/// NOTE: This should be kept in sync with go/roothash/api/block/header.go.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+pub enum HeaderType {
+    Invalid = 0,
+    Normal = 1,
+    RoundFailed = 2,
+    EpochTransition = 3,
+    Suspended = 4,
+}
+
+impl Default for HeaderType {
+    fn default() -> Self {
+        HeaderType::Invalid
+    }
+}
+
 /// Roothash message.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Message {}
@@ -45,7 +65,7 @@ pub struct Header {
     /// Timestamp (POSIX time).
     pub timestamp: u64,
     /// Header type.
-    pub header_type: u8,
+    pub header_type: HeaderType,
     /// Previous block hash.
     pub previous_hash: Hash,
     /// I/O merkle root.
@@ -103,7 +123,7 @@ mod tests {
             namespace: Namespace::from(Hash::empty_hash().as_ref()),
             round: 1000,
             timestamp: 1560257841,
-            header_type: 1,
+            header_type: HeaderType::RoundFailed,
             previous_hash: empty.encoded_hash(),
             io_root: Hash::empty_hash(),
             state_root: Hash::empty_hash(),
@@ -112,7 +132,7 @@ mod tests {
         };
         assert_eq!(
             populated.encoded_hash(),
-            Hash::from("e42c423b85e6ac261712f65b50ddbdef4758ed214c316c1f61ee76db28d1d8a5")
+            Hash::from("c39e8aefea5a1f794fb57f294a4ea8599381cd8739e67a8a9acb7763b54a630a")
         );
     }
 }

--- a/runtime/src/transaction/tree.rs
+++ b/runtime/src/transaction/tree.rs
@@ -17,13 +17,16 @@ use crate::{
 // NOTE: This should be kept in sync with go/runtime/transaction/transaction.go.
 
 #[derive(Debug)]
+#[repr(u8)]
 enum ArtifactKind {
-    Input,
-    Output,
+    Input = 1,
+    Output = 2,
 }
 
-const ARTIFACT_KIND_INPUT: u8 = 0;
-const ARTIFACT_KIND_OUTPUT: u8 = 1;
+// Workaround because rust doesn't support `as u8` inside match arms.
+// See https://github.com/rust-lang/rust/issues/44266
+const ARTIFACT_KIND_INPUT: u8 = ArtifactKind::Input as u8;
+const ARTIFACT_KIND_OUTPUT: u8 = ArtifactKind::Output as u8;
 
 /// Key format used for transaction artifacts.
 #[derive(Debug)]
@@ -277,7 +280,7 @@ mod test {
         let (_, root_hash) = tree.commit(Context::background()).unwrap();
         assert_eq!(
             format!("{:?}", root_hash),
-            "4cc8bb6bdb377cc7f1ff8fe972004e1d66fa2c6726ec9e5f870865c190b6a47d",
+            "c65f4e8bd5314c26f245337a859ad244f4b1544acf60ef334cf0d0eadb47363b",
         );
     }
 }


### PR DESCRIPTION
PR for #2527:
- adds `KindInvalid` to `RuntimeKind` enum,
- adds `KindInvalid` to `CommitteeKind` enum,
- adds `ContextInvalid` to `ContextType` enum,
- adds `HeaderInvalid` to `HeaderType` enum,
- adds `Invalid` to `artifactType` enum both in go and rust,
- in `CommitteeKind` enum renames `KindExecutor` -> `KindComputeExecutor`, `KindTransactionScheduler` -> `KindComputeTxnScheduler`, and `KindMerge` -> `KindComputeMerge`.