### PR TITLE
"unfatalize"

### DIFF
--- a/.changelog/2554.bugfix.md
+++ b/.changelog/2554.bugfix.md
@@ -1,0 +1,6 @@
+go tendermint: Unfatalize seed populating nodes from genesis
+
+In some cases we'd prefer to include some nodes in the genesis document
+even when they're registered with an invalid address.
+This makes the seed node ignore those entries and carry on, while
+keeping those entries available for the rest of the system.

--- a/go/consensus/tendermint/seed.go
+++ b/go/consensus/tendermint/seed.go
@@ -21,6 +21,8 @@ import (
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
 )
 
+var logger = logging.GetLogger("consensus/tendermint/seed")
+
 // SeedService is a Tendermint seed service.
 type SeedService struct {
 	addr      *p2p.NetAddress
@@ -169,7 +171,7 @@ func populateAddrBookFromGenesis(addrBook p2p.AddrBook, doc *genesis.Document, o
 		var tmvAddr *p2p.NetAddress
 		tmvAddr, err := api.NodeToP2PAddr(&openedNode)
 		if err != nil {
-			logging.GetLogger("seed").Error("tendermint/seed: failed to reformat genesis validator address",
+			logger.Error("failed to reformat genesis validator address",
 				"err", err,
 			)
 			continue
@@ -186,7 +188,7 @@ func populateAddrBookFromGenesis(addrBook p2p.AddrBook, doc *genesis.Document, o
 		addrBook.RemoveAddress(v)
 
 		if err := addrBook.AddAddress(v, ourAddr); err != nil {
-			logging.GetLogger("seed").Error("tendermint/seed: failed to add genesis validator to address book",
+			logger.Error("failed to add genesis validator to address book",
 				"err", err,
 			)
 		}

--- a/go/consensus/tendermint/seed.go
+++ b/go/consensus/tendermint/seed.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tendermint/tendermint/version"
 
 	"github.com/oasislabs/oasis-core/go/common/identity"
+	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/crypto"
@@ -168,7 +169,10 @@ func populateAddrBookFromGenesis(addrBook p2p.AddrBook, doc *genesis.Document, o
 		var tmvAddr *p2p.NetAddress
 		tmvAddr, err := api.NodeToP2PAddr(&openedNode)
 		if err != nil {
-			return errors.Wrap(err, "tendermint/seed: failed to reformat genesis validator address")
+			logging.GetLogger("seed").Error("tendermint/seed: failed to reformat genesis validator address",
+				"err", err,
+			)
+			continue
 		}
 
 		addrs = append(addrs, tmvAddr)
@@ -182,7 +186,9 @@ func populateAddrBookFromGenesis(addrBook p2p.AddrBook, doc *genesis.Document, o
 		addrBook.RemoveAddress(v)
 
 		if err := addrBook.AddAddress(v, ourAddr); err != nil {
-			return errors.Wrap(err, "tendermint/seed: failed to add genesis validator to address book")
+			logging.GetLogger("seed").Error("tendermint/seed: failed to add genesis validator to address book",
+				"err", err,
+			)
 		}
 	}
 


### PR DESCRIPTION
for record keeping: we put these bandaids on the seed node to skip over the unroutable nodes in the genesis document