### PR TITLE
Consensus simulation mode and fee estimator

### DIFF
--- a/.changelog/2521.feature.md
+++ b/.changelog/2521.feature.md
@@ -1,0 +1,13 @@
+Consensus simulation mode and fee estimator
+
+This change allows the compute nodes to participate in networks which require gas fees for various
+operations in the network. Gas is automatically estimated by simulating transactions while gas price
+is currently "discovered" manually via node configuration.
+
+The following configuration flags are added:
+
+* `consensus.tendermint.submission.gas_price` should specify the gas price that the node will be
+  using in all submitted transactions.
+* `consensus.tendermint.submission.max_fee` can optionally specify the maximum gas fee that the node
+  will use in submitted transactions. If the computed fee would ever go over this limit, the
+  transaction will not be submitted and an error will be returned instead.

--- a/go/common/quantity/quantity.go
+++ b/go/common/quantity/quantity.go
@@ -79,6 +79,14 @@ func (q *Quantity) FromInt64(n int64) error {
 	return q.FromBigInt(big.NewInt(n))
 }
 
+// FromUint64 converts from an uint64 to a Quantity.
+func (q *Quantity) FromUint64(n uint64) error {
+	var tmp big.Int
+	tmp.SetUint64(n)
+
+	return q.FromBigInt(&tmp)
+}
+
 // FromBigInt converts from a big.Int to a Quantity.
 func (q *Quantity) FromBigInt(n *big.Int) error {
 	if n == nil || !isValid(n) {

--- a/go/common/quantity/quantity_test.go
+++ b/go/common/quantity/quantity_test.go
@@ -58,6 +58,22 @@ func TestFromInt64(t *testing.T) {
 	require.True(q.eqInt(23), "FromInt64(23) value")
 }
 
+func TestFromUint64(t *testing.T) {
+	require := require.New(t)
+
+	var q Quantity
+	err := q.FromUint64(46)
+	require.NoError(err, "FromUint64(46)")
+	require.True(q.eqInt(46), "FromUint64(46) value")
+
+	err = q.FromUint64(0xFFFFFFFFFFFFFFFF)
+	require.NoError(err, "FromUint64(0xFFFFFFFFFFFFFFFF)")
+
+	var p Quantity
+	p.inner.SetUint64(0xFFFFFFFFFFFFFFFF)
+	require.True(q.Cmp(&p) == 0)
+}
+
 func TestQuantityBinaryRoundTrip(t *testing.T) {
 	const expected int = 0xdeadbeef
 

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -81,6 +81,9 @@ type Block struct {
 type Backend interface {
 	ClientBackend
 
+	// EstimateGas calculates the amount of gas required to execute the given transaction.
+	EstimateGas(ctx context.Context, caller signature.PublicKey, tx *transaction.Transaction) (transaction.Gas, error)
+
 	// Synced returns a channel that is closed once synchronization is
 	// complete.
 	Synced() <-chan struct{}

--- a/go/consensus/api/submission.go
+++ b/go/consensus/api/submission.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -85,7 +86,7 @@ func NewSubmissionManager(backend Backend) SubmissionManager {
 	}
 }
 
-// SignAndSubmitTx is a helper method that signs and submits a transaction to
+// SignAndSubmitTx is a helper function that signs and submits a transaction to
 // the consensus backend.
 //
 // If a nonce is set to zero, the transaction will be submitted by using the

--- a/go/consensus/api/submission.go
+++ b/go/consensus/api/submission.go
@@ -10,6 +10,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/errors"
 	"github.com/oasislabs/oasis-core/go/common/logging"
+	"github.com/oasislabs/oasis-core/go/common/quantity"
 	"github.com/oasislabs/oasis-core/go/consensus/api/transaction"
 )
 
@@ -18,15 +19,43 @@ const (
 	maxSubmissionRetryInterval    = 10 * time.Second
 )
 
+// PriceDiscovery is the consensus fee price discovery interface.
+type PriceDiscovery interface {
+	// GasPrice returns the current consensus gas price.
+	GasPrice(ctx context.Context) (*quantity.Quantity, error)
+}
+
+type staticPriceDiscovery struct {
+	price quantity.Quantity
+}
+
+// NewStaticPriceDiscovery creates a price discovery mechanism which always returns the same static
+// price specified at construction time.
+func NewStaticPriceDiscovery(price uint64) (PriceDiscovery, error) {
+	pd := &staticPriceDiscovery{}
+	if err := pd.price.FromUint64(price); err != nil {
+		return nil, fmt.Errorf("submission: failed to convert gas price: %w", err)
+	}
+	return pd, nil
+}
+
+func (pd *staticPriceDiscovery) GasPrice(ctx context.Context) (*quantity.Quantity, error) {
+	return pd.price.Clone(), nil
+}
+
 // SubmissionManager is a transaction submission manager interface.
 type SubmissionManager interface {
-	// SignAndSubmitTx populates the nonce of the transaction, signs it
+	// SignAndSubmitTx populates the nonce and fee fields in the transaction, signs the transaction
 	// with the passed signer and submits it to consensus backend.
+	//
+	// It also automatically handles retries in case the nonce was incorrectly estimated.
 	SignAndSubmitTx(ctx context.Context, signer signature.Signer, tx *transaction.Transaction) error
 }
 
 type submissionManager struct {
-	backend Backend
+	backend        Backend
+	priceDiscovery PriceDiscovery
+	maxFee         quantity.Quantity
 
 	logger *logging.Logger
 }
@@ -42,6 +71,43 @@ func (m *submissionManager) signAndSubmitTx(ctx context.Context, signer signatur
 			return err
 		}
 		return backoff.Permanent(err)
+	}
+
+	// In case the fee is not specified, perform fee estimation.
+	if tx.Fee == nil {
+		// Estimate amount of gas needed to perform the update.
+		var gas transaction.Gas
+		gas, err = m.backend.EstimateGas(ctx, signer.Public(), tx)
+		if err != nil {
+			return fmt.Errorf("failed to estimate gas: %w", err)
+		}
+
+		// Fetch current consensus gas price and compute the fee.
+		var amount *quantity.Quantity
+		amount, err = m.priceDiscovery.GasPrice(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to determine gas price: %w", err)
+		}
+		var gasQuantity quantity.Quantity
+		if err = gasQuantity.FromUint64(uint64(gas)); err != nil {
+			return fmt.Errorf("failed to compute fee amount: %w", err)
+		}
+		if err = amount.Mul(&gasQuantity); err != nil {
+			return fmt.Errorf("failed to compute fee amount: %w", err)
+		}
+
+		// Verify that the fee doesn't exceed a configured ceiling.
+		if !m.maxFee.IsZero() && amount.Cmp(&m.maxFee) == 1 {
+			return fmt.Errorf("computed fee exceeds configured maximum: %s (max: %s)",
+				amount,
+				m.maxFee,
+			)
+		}
+
+		tx.Fee = &transaction.Fee{
+			Gas:    gas,
+			Amount: *amount,
+		}
 	}
 
 	// Sign the transaction.
@@ -79,27 +145,25 @@ func (m *submissionManager) SignAndSubmitTx(ctx context.Context, signer signatur
 }
 
 // NewSubmissionManager creates a new transaction submission manager.
-func NewSubmissionManager(backend Backend) SubmissionManager {
-	return &submissionManager{
-		backend: backend,
-		logger:  logging.GetLogger("consensus/submission"),
+func NewSubmissionManager(backend Backend, priceDiscovery PriceDiscovery, maxFee uint64) SubmissionManager {
+	sm := &submissionManager{
+		backend:        backend,
+		priceDiscovery: priceDiscovery,
+		logger:         logging.GetLogger("consensus/submission"),
 	}
+	_ = sm.maxFee.FromUint64(maxFee)
+
+	return sm
 }
 
 // SignAndSubmitTx is a helper function that signs and submits a transaction to
 // the consensus backend.
 //
-// If a nonce is set to zero, the transaction will be submitted by using the
-// submission manager which will automatically use the correct nonce.
+// If the nonce is set to zero, it will be automatically filled in based on the
+// current consensus state.
+//
+// If the fee is set to nil, it will be automatically filled in based on gas
+// estimation and current gas price discovery.
 func SignAndSubmitTx(ctx context.Context, backend Backend, signer signature.Signer, tx *transaction.Transaction) error {
-	if tx.Nonce == 0 {
-		return backend.SubmissionManager().SignAndSubmitTx(ctx, signer, tx)
-	}
-
-	// Sign the transaction.
-	sigTx, err := transaction.Sign(signer, tx)
-	if err != nil {
-		return err
-	}
-	return backend.SubmitTx(ctx, sigTx)
+	return backend.SubmissionManager().SignAndSubmitTx(ctx, signer, tx)
 }

--- a/go/consensus/tendermint/abci/context.go
+++ b/go/consensus/tendermint/abci/context.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tendermint/tendermint/abci/types"
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
 )
 
@@ -68,6 +69,8 @@ type Context struct {
 	state       *iavl.MutableTree
 	blockHeight int64
 	blockCtx    *BlockContext
+
+	logger *logging.Logger
 }
 
 // NewMockContext creates a new mock context for use in tests.
@@ -76,6 +79,7 @@ func NewMockContext(mode ContextMode, now time.Time) *Context {
 		mode:          mode,
 		currentTime:   now,
 		gasAccountant: NewNopGasAccountant(),
+		logger:        logging.GetLogger("consensus/tendermint/abci").With("mode", mode),
 	}
 }
 
@@ -90,6 +94,7 @@ func NewContext(mode ContextMode, now time.Time, appState *ApplicationState) *Co
 		gasAccountant: NewNopGasAccountant(),
 		appState:      appState,
 		blockHeight:   appState.blockHeight,
+		logger:        logging.GetLogger("consensus/tendermint/abci").With("mode", mode),
 	}
 
 	switch mode {
@@ -136,6 +141,11 @@ func (c *Context) Close() {
 	c.appState = nil
 	c.state = nil
 	c.blockCtx = nil
+}
+
+// Logger returns the logger associated with this context.
+func (c *Context) Logger() *logging.Logger {
+	return c.logger
 }
 
 // Ctx returns a context.Context that is associated with this ABCI context.

--- a/go/consensus/tendermint/abci/context.go
+++ b/go/consensus/tendermint/abci/context.go
@@ -3,6 +3,7 @@ package abci
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/tendermint/iavl"
@@ -14,25 +15,47 @@ import (
 
 type contextKey struct{}
 
-// ContextType is a context type.
-type ContextType uint
+// ContextMode is a context mode.
+type ContextMode uint
 
 const (
 	// ContextInitChain is InitChain context.
-	ContextInitChain ContextType = iota
+	ContextInitChain ContextMode = iota
 	// ContextCheckTx is CheckTx context.
 	ContextCheckTx
 	// ContextDeliverTx is DeliverTx context.
 	ContextDeliverTx
+	// ContextSimulateTx is SimulateTx context.
+	ContextSimulateTx
 	// ContextBeginBlock is BeginBlock context.
 	ContextBeginBlock
 	// ContextEndBlock is EndBlock context.
 	ContextEndBlock
 )
 
+// String returns a string representation of the context mode.
+func (m ContextMode) String() string {
+	switch m {
+	case ContextInitChain:
+		return "init chain"
+	case ContextCheckTx:
+		return "check tx"
+	case ContextDeliverTx:
+		return "deliver tx"
+	case ContextSimulateTx:
+		return "simulate tx"
+	case ContextBeginBlock:
+		return "begin block"
+	case ContextEndBlock:
+		return "end block"
+	default:
+		return "[invalid]"
+	}
+}
+
 // Context is the context of processing a transaction/block.
 type Context struct {
-	outputType  ContextType
+	mode        ContextMode
 	currentTime time.Time
 
 	data          interface{}
@@ -41,17 +64,57 @@ type Context struct {
 
 	txSigner signature.PublicKey
 
-	state *ApplicationState
+	appState    *ApplicationState
+	state       *iavl.MutableTree
+	blockHeight int64
+	blockCtx    *BlockContext
+}
+
+// NewMockContext creates a new mock context for use in tests.
+func NewMockContext(mode ContextMode, now time.Time) *Context {
+	return &Context{
+		mode:          mode,
+		currentTime:   now,
+		gasAccountant: NewNopGasAccountant(),
+	}
 }
 
 // NewContext creates a new Context of the given type.
-func NewContext(outputType ContextType, now time.Time, state *ApplicationState) *Context {
-	return &Context{
-		outputType:    outputType,
+func NewContext(mode ContextMode, now time.Time, appState *ApplicationState) *Context {
+	appState.blockLock.RLock()
+	defer appState.blockLock.RUnlock()
+
+	c := &Context{
+		mode:          mode,
 		currentTime:   now,
 		gasAccountant: NewNopGasAccountant(),
-		state:         state,
+		appState:      appState,
+		blockHeight:   appState.blockHeight,
 	}
+
+	switch mode {
+	case ContextInitChain:
+		c.state = appState.deliverTxTree
+	case ContextCheckTx:
+		c.state = appState.checkTxTree
+	case ContextDeliverTx, ContextBeginBlock, ContextEndBlock:
+		c.state = appState.deliverTxTree
+		c.blockCtx = appState.blockCtx
+	case ContextSimulateTx:
+		// Since simulation is running in parallel to any changes to the database, we make sure
+		// to create a separate in-memory tree at the given block height.
+		c.state = iavl.NewMutableTree(appState.db, 128)
+		// NOTE: This requires a specific implementation of `LoadVersion` which doesn't rely
+		//       on cached metadata. Such an implementation is provided in our fork of IAVL.
+		if _, err := c.state.LoadVersion(c.blockHeight); err != nil {
+			panic(fmt.Errorf("context: failed to load state at height %d: %w", c.blockHeight, err))
+		}
+		c.currentTime = appState.blockTime
+	default:
+		panic(fmt.Errorf("context: invalid mode: %s (%d)", mode, mode))
+	}
+
+	return c
 }
 
 // FromCtx extracts an ABCI context from a context.Context if one has been
@@ -61,14 +124,28 @@ func FromCtx(ctx context.Context) *Context {
 	return abciCtx
 }
 
-// Ctx returns a context.Context that is associated with this ABCI context.
-func (c *Context) Ctx() context.Context {
-	return context.WithValue(c.state.ctx, contextKey{}, c)
+// Close releases all resources associated with this context.
+//
+// After calling this method, the context should no longer be used.
+func (c *Context) Close() {
+	if c.IsSimulation() {
+		c.state.Rollback()
+	}
+
+	c.events = nil
+	c.appState = nil
+	c.state = nil
+	c.blockCtx = nil
 }
 
-// Type returns the type of this output.
-func (c *Context) Type() ContextType {
-	return c.outputType
+// Ctx returns a context.Context that is associated with this ABCI context.
+func (c *Context) Ctx() context.Context {
+	return context.WithValue(c.appState.ctx, contextKey{}, c)
+}
+
+// Mode returns the context mode.
+func (c *Context) Mode() ContextMode {
+	return c.mode
 }
 
 // Data returns the data to be serialized with this output.
@@ -81,10 +158,12 @@ func (c *Context) Data() interface{} {
 // In case the method is called on a non-transaction context, this method
 // will panic.
 func (c *Context) TxSigner() signature.PublicKey {
-	if c.outputType != ContextCheckTx && c.outputType != ContextDeliverTx {
+	switch c.mode {
+	case ContextCheckTx, ContextDeliverTx, ContextSimulateTx:
+		return c.txSigner
+	default:
 		panic("context: only available in transaction context")
 	}
-	return c.txSigner
 }
 
 // SetTxSigner sets the authenticated transaction signer.
@@ -94,20 +173,27 @@ func (c *Context) TxSigner() signature.PublicKey {
 // In case the method is called on a non-transaction context, this method
 // will panic.
 func (c *Context) SetTxSigner(txSigner signature.PublicKey) {
-	if c.outputType != ContextCheckTx && c.outputType != ContextDeliverTx {
+	switch c.mode {
+	case ContextCheckTx, ContextDeliverTx, ContextSimulateTx:
+		c.txSigner = txSigner
+	default:
 		panic("context: only available in transaction context")
 	}
-	c.txSigner = txSigner
 }
 
-// IsInitChain returns true if this output is part of a InitChain.
+// IsInitChain returns true if this ia an init chain context.
 func (c *Context) IsInitChain() bool {
-	return c.outputType == ContextInitChain
+	return c.mode == ContextInitChain
 }
 
-// IsCheckOnly returns true if this output is part of a CheckTx.
+// IsCheckOnly returns true if this is a CheckTx context.
 func (c *Context) IsCheckOnly() bool {
-	return c.outputType == ContextCheckTx
+	return c.mode == ContextCheckTx
+}
+
+// IsSimulation returns true if this is a simulation-only context.
+func (c *Context) IsSimulation() bool {
+	return c.mode == ContextSimulateTx
 }
 
 // EmitData emits data to be serialized as transaction output.
@@ -166,20 +252,22 @@ func (c *Context) Now() time.Time {
 
 // State returns the mutable state tree.
 func (c *Context) State() *iavl.MutableTree {
-	if c.IsCheckOnly() {
-		return c.state.CheckTxTree()
-	}
-	return c.state.DeliverTxTree()
+	return c.state
 }
 
 // AppState returns the application state.
+//
+// Accessing application state in simulation mode is not allowed and will result in a panic.
 func (c *Context) AppState() *ApplicationState {
-	return c.state
+	if c.IsSimulation() {
+		panic("context: application state is not available in simulation mode")
+	}
+	return c.appState
 }
 
 // BlockHeight returns the current block height.
 func (c *Context) BlockHeight() int64 {
-	return c.state.BlockHeight()
+	return c.blockHeight
 }
 
 // BlockContext returns the current block context.
@@ -187,10 +275,7 @@ func (c *Context) BlockHeight() int64 {
 // In case there is no current block (e.g., because the current context is not
 // an execution context), this will return nil.
 func (c *Context) BlockContext() *BlockContext {
-	if c.IsInitChain() || c.IsCheckOnly() {
-		return nil
-	}
-	return c.state.BlockContext()
+	return c.blockCtx
 }
 
 // NewStateCheckpoint creates a new state checkpoint.

--- a/go/consensus/tendermint/apps/beacon/genesis.go
+++ b/go/consensus/tendermint/apps/beacon/genesis.go
@@ -22,7 +22,7 @@ func (app *beaconApplication) InitChain(ctx *abci.Context, req types.RequestInit
 	state.SetConsensusParameters(&doc.Beacon.Parameters)
 
 	if doc.Beacon.Parameters.DebugDeterministic {
-		app.logger.Warn("Determistic beacon entropy is NOT FOR PRODUCTION USE")
+		ctx.Logger().Warn("Determistic beacon entropy is NOT FOR PRODUCTION USE")
 	}
 	return nil
 }

--- a/go/consensus/tendermint/apps/epochtime_mock/epochtime_mock.go
+++ b/go/consensus/tendermint/apps/epochtime_mock/epochtime_mock.go
@@ -7,7 +7,6 @@ import (
 	"github.com/tendermint/tendermint/abci/types"
 
 	"github.com/oasislabs/oasis-core/go/common/cbor"
-	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/consensus/api/transaction"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
@@ -18,8 +17,7 @@ import (
 var _ abci.Application = (*epochTimeMockApplication)(nil)
 
 type epochTimeMockApplication struct {
-	logger *logging.Logger
-	state  *abci.ApplicationState
+	state *abci.ApplicationState
 }
 
 func (app *epochTimeMockApplication) Name() string {
@@ -67,14 +65,14 @@ func (app *epochTimeMockApplication) BeginBlock(ctx *abci.Context, request types
 
 	height := ctx.BlockHeight()
 	if future.Height != height {
-		app.logger.Error("BeginBlock: height mismatch in defered set",
+		ctx.Logger().Error("BeginBlock: height mismatch in defered set",
 			"height", height,
 			"expected_height", future.Height,
 		)
 		return fmt.Errorf("epochtime_mock: height mismatch in defered set")
 	}
 
-	app.logger.Info("setting epoch",
+	ctx.Logger().Info("setting epoch",
 		"epoch", future.Epoch,
 		"current_height", height,
 	)
@@ -120,7 +118,7 @@ func (app *epochTimeMockApplication) setEpoch(
 ) error {
 	height := ctx.BlockHeight()
 
-	app.logger.Info("scheduling epoch transition",
+	ctx.Logger().Info("scheduling epoch transition",
 		"epoch", epoch,
 		"current_height", height,
 		"next_height", height+1,
@@ -132,7 +130,5 @@ func (app *epochTimeMockApplication) setEpoch(
 
 // New constructs a new mock epochtime application instance.
 func New() abci.Application {
-	return &epochTimeMockApplication{
-		logger: logging.GetLogger("tendermint/epochtime_mock"),
-	}
+	return &epochTimeMockApplication{}
 }

--- a/go/consensus/tendermint/apps/keymanager/genesis.go
+++ b/go/consensus/tendermint/apps/keymanager/genesis.go
@@ -21,7 +21,7 @@ func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.Req
 	st := doc.KeyManager
 
 	b, _ := json.Marshal(st)
-	app.logger.Debug("InitChain: Genesis state",
+	ctx.Logger().Debug("InitChain: Genesis state",
 		"state", string(b),
 	)
 
@@ -31,9 +31,9 @@ func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.Req
 	regSt := doc.Registry
 	rtMap := make(map[common.Namespace]*registry.Runtime)
 	for _, v := range regSt.Runtimes {
-		rt, err := registry.VerifyRegisterRuntimeArgs(&regSt.Parameters, app.logger, v, true)
+		rt, err := registry.VerifyRegisterRuntimeArgs(&regSt.Parameters, ctx.Logger(), v, true)
 		if err != nil {
-			app.logger.Error("InitChain: Invalid runtime",
+			ctx.Logger().Error("InitChain: Invalid runtime",
 				"err", err,
 			)
 			continue
@@ -49,19 +49,19 @@ func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.Req
 	for _, v := range st.Statuses {
 		rt := rtMap[v.ID]
 		if rt == nil {
-			app.logger.Error("InitChain: State for unknown key manager runtime",
+			ctx.Logger().Error("InitChain: State for unknown key manager runtime",
 				"id", v.ID,
 			)
 			continue
 		}
 
-		app.logger.Debug("InitChain: Registering genesis key manager",
+		ctx.Logger().Debug("InitChain: Registering genesis key manager",
 			"id", v.ID,
 		)
 
 		// Make sure the Nodes field is empty when applying genesis state.
 		if v.Nodes != nil {
-			app.logger.Error("InitChain: Genesis key manager has nodes",
+			ctx.Logger().Error("InitChain: Genesis key manager has nodes",
 				"id", v.ID,
 			)
 			return errors.New("tendermint/keymanager: genesis key manager has nodes")

--- a/go/consensus/tendermint/apps/registry/registry.go
+++ b/go/consensus/tendermint/apps/registry/registry.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/entity"
-	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/consensus/api/transaction"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
@@ -23,8 +22,7 @@ import (
 var _ abci.Application = (*registryApplication)(nil)
 
 type registryApplication struct {
-	logger *logging.Logger
-	state  *abci.ApplicationState
+	state *abci.ApplicationState
 }
 
 func (app *registryApplication) Name() string {
@@ -97,7 +95,7 @@ func (app *registryApplication) ExecuteTx(ctx *abci.Context, tx *transaction.Tra
 
 		params, err := state.ConsensusParameters()
 		if err != nil {
-			app.logger.Error("RegisterRuntime: failed to fetch consensus parameters",
+			ctx.Logger().Error("RegisterRuntime: failed to fetch consensus parameters",
 				"err", err,
 			)
 			return err
@@ -130,7 +128,7 @@ func (app *registryApplication) onRegistryEpochChanged(ctx *abci.Context, regist
 
 	nodes, err := state.Nodes()
 	if err != nil {
-		app.logger.Error("onRegistryEpochChanged: failed to get nodes",
+		ctx.Logger().Error("onRegistryEpochChanged: failed to get nodes",
 			"err", err,
 		)
 		return fmt.Errorf("registry: onRegistryEpochChanged: failed to get nodes: %w", err)
@@ -138,7 +136,7 @@ func (app *registryApplication) onRegistryEpochChanged(ctx *abci.Context, regist
 
 	debondingInterval, err := stakeState.DebondingInterval()
 	if err != nil {
-		app.logger.Error("onRegistryEpochChanged: failed to get debonding interval",
+		ctx.Logger().Error("onRegistryEpochChanged: failed to get debonding interval",
 			"err", err,
 		)
 		return fmt.Errorf("registry: onRegistryEpochChanged: failed to get debonding interval: %w", err)
@@ -173,7 +171,7 @@ func (app *registryApplication) onRegistryEpochChanged(ctx *abci.Context, regist
 
 		// If node has been expired for the debonding interval, finally remove it.
 		if epochtime.EpochTime(node.Expiration)+debondingInterval < registryEpoch {
-			app.logger.Debug("removing expired node",
+			ctx.Logger().Debug("removing expired node",
 				"node_id", node.ID,
 			)
 			state.RemoveNode(node)
@@ -198,7 +196,5 @@ func (app *registryApplication) onRegistryEpochChanged(ctx *abci.Context, regist
 
 // New constructs a new registry application instance.
 func New() abci.Application {
-	return &registryApplication{
-		logger: logging.GetLogger("tendermint/registry"),
-	}
+	return &registryApplication{}
 }

--- a/go/consensus/tendermint/apps/roothash/genesis.go
+++ b/go/consensus/tendermint/apps/roothash/genesis.go
@@ -32,7 +32,7 @@ func (app *rootHashApplication) InitChain(ctx *abci.Context, request types.Reque
 	regState := registryState.NewMutableState(ctx.State())
 	runtimes, _ := regState.Runtimes()
 	for _, v := range runtimes {
-		app.logger.Info("InitChain: allocating per-runtime state",
+		ctx.Logger().Info("InitChain: allocating per-runtime state",
 			"runtime", v.ID,
 		)
 		app.onNewRuntime(ctx, v, &st)

--- a/go/consensus/tendermint/apps/roothash/transactions.go
+++ b/go/consensus/tendermint/apps/roothash/transactions.go
@@ -80,7 +80,7 @@ func (app *rootHashApplication) getRuntimeState(
 
 	// If the round was finalized, transition.
 	if rtState.Round.CurrentBlock.Header.Round != rtState.CurrentBlock.Header.Round {
-		app.logger.Debug("round was finalized, transitioning round",
+		ctx.Logger().Debug("round was finalized, transitioning round",
 			"round", rtState.CurrentBlock.Header.Round,
 		)
 
@@ -102,7 +102,7 @@ func (app *rootHashApplication) executorCommit(
 	// Charge gas for this transaction.
 	params, err := state.ConsensusParameters()
 	if err != nil {
-		app.logger.Error("ComputeCommit: failed to fetch consensus parameters",
+		ctx.Logger().Error("ComputeCommit: failed to fetch consensus parameters",
 			"err", err,
 		)
 		return err
@@ -121,7 +121,7 @@ func (app *rootHashApplication) executorCommit(
 	for _, commit := range cc.Commits {
 		var pool *commitment.Pool
 		if pool, err = rtState.Round.AddExecutorCommitment(&commit, sv); err != nil {
-			app.logger.Error("failed to add compute commitment to round",
+			ctx.Logger().Error("failed to add compute commitment to round",
 				"err", err,
 				"round", rtState.CurrentBlock.Header.Round,
 			)
@@ -151,7 +151,7 @@ func (app *rootHashApplication) mergeCommit(
 	// Charge gas for this transaction.
 	params, err := state.ConsensusParameters()
 	if err != nil {
-		app.logger.Error("MergeCommit: failed to fetch consensus parameters",
+		ctx.Logger().Error("MergeCommit: failed to fetch consensus parameters",
 			"err", err,
 		)
 		return err
@@ -169,7 +169,7 @@ func (app *rootHashApplication) mergeCommit(
 	// Add commitments.
 	for _, commit := range mc.Commits {
 		if err = rtState.Round.AddMergeCommitment(&commit, sv); err != nil {
-			app.logger.Error("failed to add merge commitment to round",
+			ctx.Logger().Error("failed to add merge commitment to round",
 				"err", err,
 				"round", rtState.CurrentBlock.Header.Round,
 			)
@@ -179,7 +179,7 @@ func (app *rootHashApplication) mergeCommit(
 
 	// Try to finalize round.
 	if err = app.tryFinalizeBlock(ctx, rtState, false); err != nil {
-		app.logger.Error("failed to finalize block",
+		ctx.Logger().Error("failed to finalize block",
 			"err", err,
 		)
 		return err

--- a/go/consensus/tendermint/apps/scheduler/genesis.go
+++ b/go/consensus/tendermint/apps/scheduler/genesis.go
@@ -28,14 +28,14 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 	state.SetConsensusParameters(&doc.Scheduler.Parameters)
 
 	if doc.Scheduler.Parameters.DebugStaticValidators {
-		app.logger.Warn("static validators are configured")
+		ctx.Logger().Warn("static validators are configured")
 
 		var staticValidators []signature.PublicKey
 		for _, v := range req.Validators {
 			tmPk := v.GetPubKey()
 
 			if t := tmPk.GetType(); t != types.PubKeyEd25519 {
-				app.logger.Error("invalid static validator public key type",
+				ctx.Logger().Error("invalid static validator public key type",
 					"public_key", hex.EncodeToString(tmPk.GetData()),
 					"type", t,
 				)
@@ -44,7 +44,7 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 
 			var id signature.PublicKey
 			if err = id.UnmarshalBinary(tmPk.GetData()); err != nil {
-				app.logger.Error("invalid static validator public key",
+				ctx.Logger().Error("invalid static validator public key",
 					"err", err,
 					"public_key", hex.EncodeToString(tmPk.GetData()),
 				)
@@ -71,7 +71,7 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 	}
 	if doc.Scheduler.Parameters.MaxValidatorsPerEntity > 1 {
 		// This should only ever be true for test deployments.
-		app.logger.Warn("maximum number of validators is non-standard, fairness not guaranteed",
+		ctx.Logger().Warn("maximum number of validators is non-standard, fairness not guaranteed",
 			"max_valiators_per_entity", doc.Scheduler.Parameters.MaxValidatorsPerEntity,
 		)
 	}
@@ -96,7 +96,7 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 		tmPk := v.GetPubKey()
 
 		if t := tmPk.GetType(); t != types.PubKeyEd25519 {
-			app.logger.Error("invalid genesis validator public key type",
+			ctx.Logger().Error("invalid genesis validator public key type",
 				"public_key", hex.EncodeToString(tmPk.GetData()),
 				"type", t,
 			)
@@ -105,7 +105,7 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 
 		var id signature.PublicKey
 		if err = id.UnmarshalBinary(tmPk.GetData()); err != nil {
-			app.logger.Error("invalid genesis validator public key",
+			ctx.Logger().Error("invalid genesis validator public key",
 				"err", err,
 				"public_key", hex.EncodeToString(tmPk.GetData()),
 			)
@@ -113,7 +113,7 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 		}
 
 		if power := v.GetPower(); power != consensus.VotingPower {
-			app.logger.Error("invalid voting power",
+			ctx.Logger().Error("invalid voting power",
 				"id", id,
 				"power", power,
 			)
@@ -122,12 +122,12 @@ func (app *schedulerApplication) InitChain(ctx *abci.Context, req types.RequestI
 
 		n := registeredValidators[id]
 		if n == nil {
-			app.logger.Error("genesis validator not in registry",
+			ctx.Logger().Error("genesis validator not in registry",
 				"id", id,
 			)
 			return fmt.Errorf("scheduler: genesis validator not in registry")
 		}
-		app.logger.Debug("adding validator to current validator set",
+		ctx.Logger().Debug("adding validator to current validator set",
 			"id", id,
 		)
 		currentValidators = append(currentValidators, n.Consensus.ID)

--- a/go/consensus/tendermint/apps/staking/fees.go
+++ b/go/consensus/tendermint/apps/staking/fees.go
@@ -25,7 +25,7 @@ func (app *stakingApplication) disburseFees(ctx *abci.Context, signingEntities [
 		return fmt.Errorf("staking: failed to query last block fees: %w", err)
 	}
 
-	app.logger.Debug("disbursing fees",
+	ctx.Logger().Debug("disbursing fees",
 		"total_amount", totalFees,
 	)
 	if totalFees.IsZero() {
@@ -65,7 +65,7 @@ func (app *stakingApplication) disburseFees(ctx *abci.Context, signingEntities [
 		// Perform the transfer.
 		acct := stakeState.Account(d.id)
 		if err := quantity.Move(&acct.General.Balance, totalFees, disburseAmount); err != nil {
-			app.logger.Error("failed to disburse fees",
+			ctx.Logger().Error("failed to disburse fees",
 				"err", err,
 				"to", d.id,
 				"amount", disburseAmount,
@@ -81,7 +81,7 @@ func (app *stakingApplication) disburseFees(ctx *abci.Context, signingEntities [
 			return fmt.Errorf("staking: failed to query common pool: %w", err)
 		}
 		if err := quantity.Move(commonPool, totalFees, totalFees); err != nil {
-			app.logger.Error("failed to move remainder to common pool",
+			ctx.Logger().Error("failed to move remainder to common pool",
 				"err", err,
 				"amount", totalFees,
 			)

--- a/go/consensus/tendermint/apps/staking/slashing.go
+++ b/go/consensus/tendermint/apps/staking/slashing.go
@@ -29,7 +29,7 @@ func (app *stakingApplication) onEvidenceDoubleSign(
 	// the debonding period after expiration.
 	node, err := regState.NodeByConsensusAddress(addr)
 	if err != nil {
-		app.logger.Warn("failed to get validator node",
+		ctx.Logger().Warn("failed to get validator node",
 			"err", err,
 			"address", hex.EncodeToString(addr),
 		)
@@ -38,7 +38,7 @@ func (app *stakingApplication) onEvidenceDoubleSign(
 
 	nodeStatus, err := regState.NodeStatus(node.ID)
 	if err != nil {
-		app.logger.Warn("failed to get validator node status",
+		ctx.Logger().Warn("failed to get validator node status",
 			"err", err,
 			"node_id", node.ID,
 		)
@@ -47,7 +47,7 @@ func (app *stakingApplication) onEvidenceDoubleSign(
 
 	// Do not slash a frozen validator.
 	if nodeStatus.IsFrozen() {
-		app.logger.Debug("not slashing frozen validator",
+		ctx.Logger().Debug("not slashing frozen validator",
 			"node_id", node.ID,
 			"entity_id", node.EntityID,
 			"freeze_end_time", nodeStatus.FreezeEndTime,
@@ -58,7 +58,7 @@ func (app *stakingApplication) onEvidenceDoubleSign(
 	// Retrieve the slash procedure for double signing.
 	st, err := stakeState.Slashing()
 	if err != nil {
-		app.logger.Error("failed to get slashing table entry for double signing",
+		ctx.Logger().Error("failed to get slashing table entry for double signing",
 			"err", err,
 		)
 		return err
@@ -81,7 +81,7 @@ func (app *stakingApplication) onEvidenceDoubleSign(
 	// Slash validator.
 	_, err = stakeState.SlashEscrow(ctx, node.EntityID, &penalty.Amount)
 	if err != nil {
-		app.logger.Error("failed to slash validator entity",
+		ctx.Logger().Error("failed to slash validator entity",
 			"err", err,
 			"node_id", node.ID,
 			"entity_id", node.EntityID,
@@ -90,7 +90,7 @@ func (app *stakingApplication) onEvidenceDoubleSign(
 	}
 
 	if err = regState.SetNodeStatus(node.ID, nodeStatus); err != nil {
-		app.logger.Error("failed to set validator node status",
+		ctx.Logger().Error("failed to set validator node status",
 			"err", err,
 			"node_id", node.ID,
 			"entity_id", node.EntityID,
@@ -98,7 +98,7 @@ func (app *stakingApplication) onEvidenceDoubleSign(
 		return err
 	}
 
-	app.logger.Warn("slashed validator for double signing",
+	ctx.Logger().Warn("slashed validator for double signing",
 		"node_id", node.ID,
 		"entity_id", node.EntityID,
 	)

--- a/go/consensus/tendermint/apps/staking/state/gas.go
+++ b/go/consensus/tendermint/apps/staking/state/gas.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/quantity"
@@ -34,6 +35,14 @@ func AuthenticateAndPayFees(
 	fee *transaction.Fee,
 ) error {
 	state := NewMutableState(ctx.State())
+
+	if ctx.IsSimulation() {
+		// If this is a simulation, the caller can use any amount of gas (as we usually want to
+		// estimate the amount of gas needed).
+		ctx.SetGasAccountant(abci.NewGasAccountant(transaction.Gas(math.MaxUint64)))
+
+		return nil
+	}
 
 	// Fetch account and make sure the nonce is correct.
 	account := state.Account(id)

--- a/go/consensus/tendermint/apps/staking/state/state_test.go
+++ b/go/consensus/tendermint/apps/staking/state/state_test.go
@@ -136,7 +136,7 @@ func TestRewardAndSlash(t *testing.T) {
 	escrowAccount = s.Account(escrowID)
 	require.Equal(t, mustInitQuantity(t, 300), escrowAccount.Escrow.Active.Balance, "reward late epoch - escrow active escrow")
 
-	slashedNonzero, err := s.SlashEscrow(abci.NewContext(abci.ContextDeliverTx, time.Now(), nil), escrowID, mustInitQuantityP(t, 40))
+	slashedNonzero, err := s.SlashEscrow(abci.NewMockContext(abci.ContextDeliverTx, time.Now()), escrowID, mustInitQuantityP(t, 40))
 	require.NoError(t, err, "slash escrow")
 	require.True(t, slashedNonzero, "slashed nonzero")
 

--- a/go/consensus/tendermint/apps/staking/votes.go
+++ b/go/consensus/tendermint/apps/staking/votes.go
@@ -23,7 +23,7 @@ func (app *stakingApplication) resolveEntityIDsFromVotes(ctx *abci.Context, last
 		// Map address to node/entity.
 		node, err := regState.NodeByConsensusAddress(valAddr)
 		if err != nil {
-			app.logger.Warn("failed to get validator node",
+			ctx.Logger().Warn("failed to get validator node",
 				"err", err,
 				"address", hex.EncodeToString(valAddr),
 			)

--- a/go/consensus/tendermint/scheduler/scheduler.go
+++ b/go/consensus/tendermint/scheduler/scheduler.go
@@ -172,11 +172,8 @@ func (tb *tendermintBackend) onEventDataNewBlock(ctx context.Context, ev tmtypes
 // New constracts a new tendermint-based scheduler Backend instance.
 func New(ctx context.Context, service service.TendermintService) (api.Backend, error) {
 	// Initialze and register the tendermint service component.
-	a, err := app.New()
-	if err != nil {
-		return nil, err
-	}
-	if err = service.RegisterApplication(a); err != nil {
+	a := app.New()
+	if err := service.RegisterApplication(a); err != nil {
 		return nil, err
 	}
 

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -97,6 +97,10 @@ const (
 
 	// CfgConsensusMinGasPrice configures the minimum gas price for this validator.
 	CfgConsensusMinGasPrice = "consensus.tendermint.min_gas_price"
+	// CfgConsensusSubmissionGasPrice configures the gas price used when submitting transactions.
+	CfgConsensusSubmissionGasPrice = "consensus.tendermint.submission.gas_price"
+	// CfgConsensusSubmissionMaxFee configures the maximum fee that can be set.
+	CfgConsensusSubmissionMaxFee = "consensus.tendermint.submission.max_fee"
 
 	// StateDir is the name of the directory located inside the node's data
 	// directory which contains the tendermint state.
@@ -1190,7 +1194,11 @@ func New(ctx context.Context, dataDir string, identity *identity.Identity, genes
 	}
 
 	// Create the submission manager.
-	t.submissionMgr = consensusAPI.NewSubmissionManager(t)
+	pd, err := consensusAPI.NewStaticPriceDiscovery(viper.GetUint64(CfgConsensusSubmissionGasPrice))
+	if err != nil {
+		return nil, fmt.Errorf("tendermint: failed to create submission manager: %w", err)
+	}
+	t.submissionMgr = consensusAPI.NewSubmissionManager(t, pd, viper.GetUint64(CfgConsensusSubmissionMaxFee))
 
 	return t, t.initialize()
 }
@@ -1334,6 +1342,8 @@ func init() {
 	Flags.Bool(CfgDebugP2PAddrBookLenient, false, "allow non-routable addresses")
 	Flags.Bool(CfgDebugP2PAllowDuplicateIP, false, "Allow multiple connections from the same IP")
 	Flags.Uint64(CfgConsensusMinGasPrice, 0, "minimum gas price")
+	Flags.Uint64(CfgConsensusSubmissionGasPrice, 0, "gas price used when submitting consensus transactions")
+	Flags.Uint64(CfgConsensusSubmissionMaxFee, 0, "maximum transaction fee when submitting consensus transactions")
 
 	_ = Flags.MarkHidden(cfgLogDebug)
 	_ = Flags.MarkHidden(CfgDebugP2PAddrBookLenient)

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -531,6 +531,10 @@ func (t *tendermintService) SubmitEvidence(ctx context.Context, evidence consens
 	return nil
 }
 
+func (t *tendermintService) EstimateGas(ctx context.Context, caller signature.PublicKey, tx *transaction.Transaction) (transaction.Gas, error) {
+	return t.mux.EstimateGas(caller, tx)
+}
+
 func (t *tendermintService) Subscribe(subscriber string, query tmpubsub.Query) (tmtypes.Subscription, error) {
 	// Note: The tendermint documentation claims using SubscribeUnbuffered can
 	// freeze the server, however, the buffered Subscribe can drop events, and

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -247,6 +247,9 @@ func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []stri
 			DebugAllowRuntimeRegistration: viper.GetBool(CfgRegistryDebugAllowRuntimeRegistration),
 			DebugAllowTestRuntimes:        viper.GetBool(CfgRegistryDebugAllowTestRuntimes),
 			DebugBypassStake:              viper.GetBool(cfgRegistryDebugBypassStake),
+
+			// TODO: Make these configurable.
+			GasCosts: registry.DefaultGasCosts,
 		},
 		Entities: make([]*entity.SignedEntity, 0, len(entities)),
 		Runtimes: make([]*registry.SignedRuntime, 0, len(runtimes)),
@@ -409,6 +412,11 @@ func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []stri
 func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Logger) error {
 	rootSt := roothash.Genesis{
 		RuntimeStates: make(map[common.Namespace]*registry.RuntimeGenesis),
+
+		Parameters: roothash.ConsensusParameters{
+			// TODO: Make these configurable.
+			GasCosts: roothash.DefaultGasCosts,
+		},
 	}
 
 	for _, v := range exports {

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -75,6 +75,13 @@ func (args *argBuilder) tendermintMinGasPrice(price uint64) *argBuilder {
 	return args
 }
 
+func (args *argBuilder) tendermintSubmissionGasPrice(price uint64) *argBuilder {
+	args.vec = append(args.vec, []string{
+		"--" + tendermint.CfgConsensusSubmissionGasPrice, strconv.Itoa(int(price)),
+	}...)
+	return args
+}
+
 func (args *argBuilder) tendermintCoreListenAddress(port uint16) *argBuilder {
 	args.vec = append(args.vec, []string{
 		"--" + tendermint.CfgCoreListenAddress, "tcp://0.0.0.0:" + strconv.Itoa(int(port)),

--- a/go/oasis-test-runner/oasis/byzantine.go
+++ b/go/oasis-test-runner/oasis/byzantine.go
@@ -39,6 +39,7 @@ func (worker *Byzantine) startNode() error {
 		debugAllowTestKeys().
 		tendermintCoreListenAddress(worker.consensusPort).
 		tendermintDebugAddrBookLenient().
+		tendermintSubmissionGasPrice(worker.submissionGasPrice).
 		workerP2pPort(worker.p2pPort).
 		appendSeedNodes(worker.net).
 		appendEntity(worker.entity).
@@ -88,12 +89,9 @@ func (net *Network) NewByzantine(cfg *ByzantineCfg) (*Byzantine, error) {
 	if cfg.IdentitySeed == "" {
 		return nil, errors.New("oasis/byzantine: empty identity seed")
 	}
-	if err = net.generateDeterministicNodeIdentity(byzantineDir, cfg.IdentitySeed); err != nil {
-		return nil, errors.Wrap(err, "oasis/byzantine: failed to generate deterministic identity")
-	}
 
 	// Pre-provision the node identity so that we can update the entity.
-	publicKey, err := provisionNodeIdentity(byzantineDir)
+	publicKey, err := net.provisionNodeIdentity(byzantineDir, cfg.IdentitySeed)
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/byzantine: failed to provision node identity")
 	}
@@ -108,6 +106,7 @@ func (net *Network) NewByzantine(cfg *ByzantineCfg) (*Byzantine, error) {
 			dir:                                      byzantineDir,
 			disableDefaultLogWatcherHandlerFactories: cfg.DisableDefaultLogWatcherHandlerFactories,
 			logWatcherHandlerFactories:               cfg.LogWatcherHandlerFactories,
+			submissionGasPrice:                       cfg.SubmissionGasPrice,
 		},
 		script:          cfg.Script,
 		entity:          cfg.Entity,

--- a/go/oasis-test-runner/oasis/cli/registry.go
+++ b/go/oasis-test-runner/oasis/cli/registry.go
@@ -36,7 +36,7 @@ func (r *RegistryHelpers) GenerateRegisterRuntimeTx(
 		"--" + consensus.CfgTxNonce, strconv.FormatUint(nonce, 10),
 		"--" + consensus.CfgTxFile, txPath,
 		"--" + consensus.CfgTxFeeAmount, strconv.Itoa(0), // TODO: Make fee configurable.
-		"--" + consensus.CfgTxFeeGas, strconv.Itoa(10), // TODO: Make fee configurable.
+		"--" + consensus.CfgTxFeeGas, strconv.Itoa(10000), // TODO: Make fee configurable.
 		"--" + flags.CfgDebugDontBlameOasis,
 		"--" + cmdCommon.CfgDebugAllowTestKeys,
 		"--" + flags.CfgDebugTestEntity,

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -123,7 +123,8 @@ type ValidatorFixture struct {
 
 	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
 
-	MinGasPrice uint64 `json:"min_gas_price"`
+	MinGasPrice        uint64 `json:"min_gas_price"`
+	SubmissionGasPrice uint64 `json:"submission_gas_price"`
 
 	Sentries []int `json:"sentries,omitempty"`
 }
@@ -143,6 +144,7 @@ func (f *ValidatorFixture) Create(net *Network) (*Validator, error) {
 		NodeCfg: NodeCfg{
 			Restartable:                f.Restartable,
 			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
+			SubmissionGasPrice:         f.SubmissionGasPrice,
 		},
 		Entity:      entity,
 		MinGasPrice: f.MinGasPrice,
@@ -216,6 +218,8 @@ type KeymanagerFixture struct {
 
 	Restartable bool `json:"restartable"`
 
+	SubmissionGasPrice uint64 `json:"submission_gas_price"`
+
 	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
 }
 
@@ -234,6 +238,7 @@ func (f *KeymanagerFixture) Create(net *Network) (*Keymanager, error) {
 		NodeCfg: NodeCfg{
 			Restartable:                f.Restartable,
 			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
+			SubmissionGasPrice:         f.SubmissionGasPrice,
 		},
 		Runtime: runtime,
 		Entity:  entity,
@@ -246,6 +251,8 @@ type StorageWorkerFixture struct { // nolint: maligned
 	Entity  int    `json:"entity"`
 
 	Restartable bool `json:"restartable"`
+
+	SubmissionGasPrice uint64 `json:"submission_gas_price"`
 
 	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
 
@@ -263,6 +270,7 @@ func (f *StorageWorkerFixture) Create(net *Network) (*Storage, error) {
 		NodeCfg: NodeCfg{
 			Restartable:                f.Restartable,
 			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
+			SubmissionGasPrice:         f.SubmissionGasPrice,
 		},
 		Backend:       f.Backend,
 		Entity:        entity,
@@ -278,6 +286,8 @@ type ComputeWorkerFixture struct {
 
 	Restartable bool `json:"restartable"`
 
+	SubmissionGasPrice uint64 `json:"submission_gas_price"`
+
 	LogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
 }
 
@@ -292,6 +302,7 @@ func (f *ComputeWorkerFixture) Create(net *Network) (*Compute, error) {
 		NodeCfg: NodeCfg{
 			Restartable:                f.Restartable,
 			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
+			SubmissionGasPrice:         f.SubmissionGasPrice,
 		},
 		Entity:         entity,
 		RuntimeBackend: f.RuntimeBackend,
@@ -332,6 +343,8 @@ type ByzantineFixture struct {
 
 	ActivationEpoch epochtime.EpochTime `json:"activation_epoch"`
 
+	SubmissionGasPrice uint64 `json:"submission_gas_price"`
+
 	EnableDefaultLogWatcherHandlerFactories bool                        `json:"enable_default_log_fac"`
 	LogWatcherHandlerFactories              []log.WatcherHandlerFactory `json:"-"`
 }
@@ -347,6 +360,7 @@ func (f *ByzantineFixture) Create(net *Network) (*Byzantine, error) {
 		NodeCfg: NodeCfg{
 			DisableDefaultLogWatcherHandlerFactories: !f.EnableDefaultLogWatcherHandlerFactories,
 			LogWatcherHandlerFactories:               f.LogWatcherHandlerFactories,
+			SubmissionGasPrice:                       f.SubmissionGasPrice,
 		},
 		Script:          f.Script,
 		IdentitySeed:    f.IdentitySeed,

--- a/go/oasis-test-runner/scenario/e2e/gas_fees_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees_runtimes.go
@@ -1,0 +1,76 @@
+package e2e
+
+import (
+	"context"
+
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/scenario"
+)
+
+var (
+	// GasFeesRuntimes is the runtime gas fees scenario.
+	GasFeesRuntimes scenario.Scenario = &gasFeesRuntimesImpl{
+		basicImpl: *newBasicImpl("gas-fees/runtimes", "", nil),
+	}
+)
+
+// gasPrice is the gas price used during the test.
+const gasPrice = 1
+
+type gasFeesRuntimesImpl struct {
+	basicImpl
+}
+
+func (sc *gasFeesRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := sc.basicImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	// Use deterministic identities as we need to allocate funds to nodes.
+	f.Network.DeterministicIdentities = true
+	// Give our nodes some tokens.
+	f.Network.StakingGenesis = "tests/fixture-data/gas-fees-runtimes/staking-genesis.json"
+	// Update validators to require fee payments.
+	for i := range f.Validators {
+		f.Validators[i].MinGasPrice = gasPrice
+		f.Validators[i].SubmissionGasPrice = gasPrice
+	}
+	// Update all other nodes to use a specific gas price.
+	for i := range f.Keymanagers {
+		f.Keymanagers[i].SubmissionGasPrice = gasPrice
+	}
+	for i := range f.StorageWorkers {
+		f.StorageWorkers[i].SubmissionGasPrice = gasPrice
+	}
+	for i := range f.ComputeWorkers {
+		f.ComputeWorkers[i].SubmissionGasPrice = gasPrice
+	}
+	for i := range f.ByzantineNodes {
+		f.ByzantineNodes[i].SubmissionGasPrice = gasPrice
+	}
+
+	return f, nil
+}
+
+func (sc *gasFeesRuntimesImpl) Run(childEnv *env.Env) error {
+	if err := sc.net.Start(); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	// Wait for all nodes to be synced before we proceed.
+	if err := sc.waitNodesSynced(); err != nil {
+		return err
+	}
+
+	// Submit a runtime transaction to check whether transaction processing works.
+	sc.logger.Info("submitting transaction to runtime")
+	if err := sc.submitRuntimeTx(ctx, runtimeID, "hello", "non-free world"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
@@ -23,9 +23,9 @@ import (
 )
 
 var (
-	// GasFees is the gas fees scenario.
-	GasFees scenario.Scenario = &gasFeesImpl{
-		logger: logging.GetLogger("scenario/e2e/gas_fees"),
+	// GasFeesStaking is the staking gas fees scenario.
+	GasFeesStaking scenario.Scenario = &gasFeesImpl{
+		logger: logging.GetLogger("scenario/e2e/gas-fees/staking"),
 	}
 
 	// srcSigner is the signer for public key defined in the staking genesis
@@ -41,7 +41,7 @@ type gasFeesImpl struct {
 }
 
 func (sc *gasFeesImpl) Name() string {
-	return "gas-fees"
+	return "gas-fees/staking"
 }
 
 func (sc *gasFeesImpl) Fixture() (*oasis.NetworkFixture, error) {

--- a/go/oasis-test-runner/scenario/e2e/stake_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/stake_cli.go
@@ -41,7 +41,7 @@ const (
 	feeAmount = 10
 
 	// Transaction fee gas.
-	feeGas = 10
+	feeGas = 10000
 
 	// Source address in the genesis block.
 	srcAddress = "4ea5328f943ef6f66daaed74cb0e99c3b1c45f76307b425003dbc7cb3638ed35"

--- a/go/oasis-test-runner/test-runner.go
+++ b/go/oasis-test-runner/test-runner.go
@@ -47,8 +47,9 @@ func main() {
 	_ = cmd.Register(e2e.StakeCLI)
 	// Node shutdown test.
 	_ = cmd.Register(e2e.NodeShutdown)
-	// Gas fees test.
-	_ = cmd.Register(e2e.GasFees)
+	// Gas fees tests.
+	_ = cmd.Register(e2e.GasFeesStaking)
+	_ = cmd.Register(e2e.GasFeesRuntimes)
 	// Identity CLI test.
 	_ = cmd.Register(e2e.IdentityCLI)
 	// Runtime prune test.

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -1118,6 +1118,18 @@ const (
 	GasOpRuntimeEpochMaintenance transaction.Op = "runtime_epoch_maintenance"
 )
 
+// XXX: Define reasonable default gas costs.
+
+// DefaultGasCosts are the "default" gas costs for operations.
+var DefaultGasCosts = transaction.Costs{
+	GasOpRegisterEntity:          1000,
+	GasOpDeregisterEntity:        1000,
+	GasOpRegisterNode:            1000,
+	GasOpUnfreezeNode:            1000,
+	GasOpRegisterRuntime:         1000,
+	GasOpRuntimeEpochMaintenance: 1000,
+}
+
 // SanityCheckEntities examines the entities table.
 // Returns lookup of entity ID to the entity record for use in other checks.
 func SanityCheckEntities(entities []*entity.SignedEntity) (map[signature.PublicKey]*entity.Entity, error) {

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -20,7 +20,6 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	consensusAPI "github.com/oasislabs/oasis-core/go/consensus/api"
-	"github.com/oasislabs/oasis-core/go/consensus/api/transaction"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	epochtimeTests "github.com/oasislabs/oasis-core/go/epochtime/tests"
 	"github.com/oasislabs/oasis-core/go/registry/api"
@@ -288,14 +287,6 @@ func testRegistryEntityNodes( // nolint: gocyclo
 		err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, entity.Signer, tx)
 		require.Error(err, "UnfreezeNode (with invalid node)")
 		require.Equal(err, api.ErrNoSuchNode)
-
-		// Try to unfreeze with an invalid nonce (should fail).
-		tx = api.NewUnfreezeNodeTx(123, nil, &api.UnfreezeNode{
-			NodeID: node.Node.ID,
-		})
-		err = consensusAPI.SignAndSubmitTx(context.Background(), consensus, entity.Signer, tx)
-		require.Error(err, "UnfreezeNode (with invalid nonce)")
-		require.Equal(err, transaction.ErrInvalidNonce)
 
 		// Try to unfreeze a node using the node signing key (should fail
 		// as unfreeze must be signed by entity signing key).

--- a/go/roothash/api/api.go
+++ b/go/roothash/api/api.go
@@ -188,6 +188,14 @@ const (
 	GasOpMergeCommit transaction.Op = "merge_commit"
 )
 
+// XXX: Define reasonable default gas costs.
+
+// DefaultGasCosts are the "default" gas costs for operations.
+var DefaultGasCosts = transaction.Costs{
+	GasOpComputeCommit: 1000,
+	GasOpMergeCommit:   1000,
+}
+
 // SanityCheckBlocks examines the blocks table.
 func SanityCheckBlocks(blocks map[common.Namespace]*block.Block) error {
 	for _, blk := range blocks {

--- a/tests/fixture-data/gas-fees-runtimes/staking-genesis.json
+++ b/tests/fixture-data/gas-fees-runtimes/staking-genesis.json
@@ -1,0 +1,17 @@
+{
+  "total_supply": "90000000",
+  "ledger": {
+    "LQu4ZtFg8OJ0MC4M4QMeUR7Is6Xt4A/CW+PK/7TPiH0=": {"general": {"balance": "10000000"}},
+    "IluobMWMoZvxeW5ceAEiQj+TJUXZZJu6ZCWgtZxsHds=": {"general": {"balance": "10000000"}},
+    "toAWSrxsxSFbGXQIhu4p2fOL0z/fnirrGT/MuzRgcW8=": {"general": {"balance": "10000000"}},
+
+    "DbeoxcRwDO4Wh8bwq5rAR7wzhiB+LeYn+y7lFSGAZ7I=": {"general": {"balance": "10000000"}},
+    "oWk0qdNhp7XNQDX4YFJY2KeFM+9u4fo16DeSdW1gChg=": {"general": {"balance": "10000000"}},
+    "hcWVUucu/MwOyEDmj5T4TACwpgre5e2cJLczBggxxm0=": {"general": {"balance": "10000000"}},
+
+    "B14NG+Joea3j09rVt0SEPQ4Z6Ned1EEi6rzZoa2YrYw=": {"general": {"balance": "10000000"}},
+    "iPYyR3I45FRGK568PTJIZUmELgcFYPhIb80e2GxrIf0=": {"general": {"balance": "10000000"}},
+
+    "mh+b9hN+2oLAflZACgBgVHA0EjeZK3ew6kml75s2wN4=": {"general": {"balance": "10000000"}}
+  }
+}


### PR DESCRIPTION
Fixes #2521 

* Add simulation mode for gas estimation
  
  In simulation mode, transactions are processed as if they were executed normally
  via DeliverTx except some checks are disabled. This is used to estimate gas.

* Add fee estimator and use it in workers

TODO
* [X] Basic simulation mode implementation (probably racy and unsafe).
* [X] Basic fee estimator helper.
* [x] Make simulation mode non-racy and safe.
* [x] Configuration-based price discovery (e.g., price is manually set via config).
* [x] Configurable ceiling for gas fees (to avoid bugs consuming everything).
* [x] Use fee estimator in registration worker.
* [x] E2E tests with parameters that require fees for all transactions.
