### PR TITLE
Release tooling improvements

### DIFF
--- a/.changelog/2559.trivial.md
+++ b/.changelog/2559.trivial.md
@@ -1,0 +1,1 @@
+Release tooling improvements

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,18 @@
 name: Continuous integration
 
-on: push
+# Trigger the workflow when:
+on:
+  # A push occurs to one of the matched branches.
+  push:
+    branches:
+      - master
+      - stable/*
+  # Or when a pull request event occurs for a pull request against one of the
+  # matched branches.
+  pull_request:
+    branches:
+      - master
+      - stable/*
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,13 @@ jobs:
       - name: Install prerequisites
         run: |
           python -m pip install https://github.com/oasislabs/towncrier/archive/oasis-master.tar.gz
-      - name: Check for presence of a Change Log fragment
+      - name: Check for presence of a Change Log fragment (only pull requests)
         run: |
-          # Fetch the master branch so towncrier will be able to compare the
-          # current branch to the master branch.
+          # Fetch the pull request' base branch so towncrier will be able to
+          # compare the current branch with the base branch.
           # Source: https://github.com/actions/checkout/#fetch-all-branches.
-          git fetch --no-tags --prune --depth=1 origin +refs/heads/master:refs/remotes/origin/master
-          towncrier check
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}
+          towncrier check --compare-with origin/${BASE_BRANCH}
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+        if: github.event_name == 'pull_request'

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test-e2e:
 test: $(test-targets)
 
 # Clean.
-clean-targets := clean-runtimes clean-rust clean-go
+clean-targets := clean-runtimes clean-rust clean-go clean-version-files
 
 clean-runtimes:
 	@$(ECHO) "$(CYAN)*** Cleaning up runtimes...$(OFF)"
@@ -92,6 +92,10 @@ clean-rust:
 
 clean-go:
 	@$(MAKE) -C go clean
+
+clean-version-files:
+	@$(ECHO) "$(CYAN)*** Cleaning Punch version files...$(OFF)"
+	@rm --force $(_PUNCH_VERSION_FILE_PATH_PREFIX)*.py
 
 clean: $(clean-targets)
 

--- a/Makefile
+++ b/Makefile
@@ -99,23 +99,30 @@ clean-version-files:
 
 clean: $(clean-targets)
 
+# Fetch all the latest changes (including tags) from the canonical upstream git
+# repository.
+fetch-git:
+	@$(ECHO_STDERR) "Fetching the latests changes (including tags) from $(OASIS_CORE_GIT_ORIGIN_REMOTE) remote..."
+	@git fetch $(OASIS_CORE_GIT_ORIGIN_REMOTE) --tags
+
 # Assemble Change log.
-changelog:
+changelog: fetch-git
 	@$(ENSURE_NEXT_VERSION)
 	@$(ECHO_STDERR) "Generating Change Log for version $(NEXT_VERSION)..."
 	towncrier build --version $(NEXT_VERSION)
 	@$(ECHO_STDERR) "Next, review the staged changes, commit them and make a pull request."
 
 # Tag the next release.
-tag-next-release:
+tag-next-release: fetch-git
 	@$(ENSURE_NEXT_VERSION)
 	@$(ECHO_STDERR) "Checking if we can tag version $(NEXT_VERSION) as the next release..."
+	@$(ENSURE_VALID_RELEASE_BRANCH_NAME)
 	@$(ENSURE_NO_CHANGELOG_FRAGMENTS)
 	@$(ENSURE_NEXT_VERSION_IN_CHANGELOG)
-	@$(ECHO_STDERR) "All checks have passed. Proceeding with tagging the $(OASIS_CORE_GIT_ORIGIN_REMOTE)/master HEAD with tag 'v$(NEXT_VERSION)'."
+	@$(ECHO_STDERR) "All checks have passed. Proceeding with tagging the $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH)'s HEAD with tag 'v$(NEXT_VERSION)'."
 	@$(CONFIRM_ACTION)
 	@$(ECHO_STDERR) "If this appears to be stuck, you might need to touch your security key for GPG sign operation."
-	@git tag --sign --message="Version $(NEXT_VERSION)" v$(NEXT_VERSION) $(OASIS_CORE_GIT_ORIGIN_REMOTE)/master
+	@git tag --sign --message="Version $(NEXT_VERSION)" v$(NEXT_VERSION) $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH)
 	@git push $(OASIS_CORE_GIT_ORIGIN_REMOTE) v$(NEXT_VERSION)
 	@$(ECHO_STDERR) "$(CYAN)Tag 'v$(NEXT_VERSION)' has been successfully pushed to $(OASIS_CORE_GIT_ORIGIN_REMOTE) remote.$(OFF)"
 
@@ -141,5 +148,5 @@ docker-shell:
 	$(fmt-targets) fmt \
 	$(test-unit-targets) $(test-targets) test \
 	$(clean-targets) clean \
-	changelog tag-next-release release docker-shell \
+	fetch-git changelog tag-next-release release docker-shell \
 	all

--- a/common.mk
+++ b/common.mk
@@ -35,6 +35,9 @@ endef
 # git@github.com:oasislabs/oasis-core.git.
 OASIS_CORE_GIT_ORIGIN_REMOTE ?= origin
 
+# Name of the branch where to tag the next release.
+RELEASE_BRANCH ?= master
+
 # Try to determine Oasis Core's version from git.
 LATEST_TAG := $(shell git describe --tags --match 'v*' --abbrev=0 2>/dev/null)
 VERSION := $(subst v,,$(LATEST_TAG))
@@ -49,7 +52,7 @@ export VERSION
 # Try to compute the next version based on the latest tag of the origin remote
 # using the Punch tool.
 # First, all tags from the origin remote are fetched. Next, the latest tag on
-# the origin/master branch is determined. It represents Oasis Core's current
+# origin's release branch is determined. It represents Oasis Core's current
 # version. Lastly, the Punch tool is used to bump the version according to the
 # configurated versioning scheme in .punch_config.py.
 #
@@ -68,8 +71,6 @@ _PUNCH_VERSION_FILE = $(eval _PUNCH_VERSION_FILE := $$(shell \
 	))$(_PUNCH_VERSION_FILE)
 NEXT_VERSION ?= $(eval NEXT_VERSION := $$(shell \
 	set -e; \
-	echo "Fetching all tags from the $(OASIS_CORE_GIT_ORIGIN_REMOTE) remote..." 1>&2; \
-	git fetch $(OASIS_CORE_GIT_ORIGIN_REMOTE) --tags; \
 	LATEST_TAG_ORIGIN=`git describe --tags --match 'v*' --abbrev=0 $(OASIS_CORE_GIT_ORIGIN_REMOTE)/master` \
 	python3 -c "import os; year, minor = os.environ['LATEST_TAG_ORIGIN'].lstrip('v').split('.'); \
 		print(f'year=\"{year}\"\nminor={minor}')" > $(_PUNCH_VERSION_FILE); \
@@ -139,22 +140,32 @@ define ENSURE_NEXT_VERSION =
 	fi
 endef
 
-# Helper that ensures the origin/master's HEAD doesn't contain any Change Log fragments.
+# Helper that ensures $(RELEASE_BRANCH) variable contains a valid release branch name.
+define ENSURE_VALID_RELEASE_BRANCH_NAME =
+	if [[ ! $(RELEASE_BRANCH) =~ ^(master|(stable/[0-9]+\.[0-9]+\.x$$)) ]]; then \
+		$(ECHO_STDERR) "$(RED)Error: Invalid release branch name: $(RELEASE_BRANCH)."; \
+		exit 1; \
+	fi
+endef
+
+# Helper that ensures the origin's release branch's HEAD doesn't contain any Change Log fragments.
 define ENSURE_NO_CHANGELOG_FRAGMENTS =
-	CHANGELOG_FRAGMENTS=`git ls-tree -r --name-only $(OASIS_CORE_GIT_ORIGIN_REMOTE)/master .changelog | \
-	    grep --invert-match --extended-regexp '(README.md|template.md.j2)'`; \
-	if [[ -n $${CHANGELOG_FRAGMENTS} ]]; then \
-		$(ECHO_STDERR) "$(RED)Error: Found the following Change Log fragments on $(OASIS_CORE_GIT_ORIGIN_REMOTE)/master branch:"; \
+	if ! CHANGELOG_FILES=`git ls-tree -r --name-only $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH) .changelog`; then \
+		$(ECHO_STDERR) "$(RED)Error: Could not obtain Change Log fragments for $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH) branch.$(OFF)"; \
+		exit 1; \
+	fi; \
+	if CHANGELOG_FRAGMENTS=`echo "$$CHANGELOG_FILES" | grep --invert-match --extended-regexp '(README.md|template.md.j2)'`; then \
+		$(ECHO_STDERR) "$(RED)Error: Found the following Change Log fragments on $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH) branch:"; \
 		$(ECHO_STDERR) "$${CHANGELOG_FRAGMENTS}$(OFF)"; \
 		exit 1; \
 	fi
 endef
 
-# Helper that ensures the origin/master's HEAD contains a Change Log section for the next release.
+# Helper that ensures the origin's release branch's HEAD contains a Change Log section for the next release.
 define ENSURE_NEXT_VERSION_IN_CHANGELOG =
-	if ! ( git show $(OASIS_CORE_GIT_ORIGIN_REMOTE)/master:CHANGELOG.md | \
-		   grep --quiet '^## $(NEXT_VERSION) (.*)' ); then \
-		$(ECHO_STDERR) "$(RED)Error: Could not locate Change Log section for release $(NEXT_VERSION).$(OFF)"; \
+	if ! ( git show $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH):CHANGELOG.md | \
+			grep --quiet '^## $(NEXT_VERSION) (.*)' ); then \
+		$(ECHO_STDERR) "$(RED)Error: Could not locate Change Log section for release $(NEXT_VERSION) on $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH) branch.$(OFF)"; \
 		exit 1; \
 	fi
 endef

--- a/common.mk
+++ b/common.mk
@@ -58,11 +58,14 @@ export VERSION
 #   - Passing current version as an CLI parameter.
 #   - Outputting the new version to stdout without making modifications to any
 #     files.
-_PUNCH_VERSION_FILE := $(shell mktemp /tmp/oasis-core.XXXXX.py)
+_PUNCH_VERSION_FILE_PATH_PREFIX := /tmp/oasis-core
 # NOTE: The "OUTPUT = $(eval OUTPUT := $$(shell some-comand))$(OUTPUT)" syntax
 # defers simple variable expansion so that it is only computed the first time it
 # is used. For more details, see:
 # http://make.mad-scientist.net/deferred-simple-variable-expansion/.
+_PUNCH_VERSION_FILE = $(eval _PUNCH_VERSION_FILE := $$(shell \
+	mktemp $(_PUNCH_VERSION_FILE_PATH_PREFIX).XXXXX.py \
+	))$(_PUNCH_VERSION_FILE)
 NEXT_VERSION ?= $(eval NEXT_VERSION := $$(shell \
 	set -e; \
 	echo "Fetching all tags from the $(OASIS_CORE_GIT_ORIGIN_REMOTE) remote..." 1>&2; \


### PR DESCRIPTION
This will allow back-porting fixes from an upcoming release and prepare a stable/bugfix release with versions of the form `YY.MINOR.MICRO`.

The workflow will look like (e.g. for a `20.1.1` release):
```
git checkout -b stable/20.1.x v20.1
git push -u origin stable/20.1.x
git checkout -b tjanez/stable/20.1.x/backport-foo
... backport foo change...
git push -u origin tjanez/stable/20.1.x/backport-foo
... create a pull request against the stable/20.1.x branch and merge it...
... create other pull requests and merge them (if necessary) ...
... once ready to prepare a minor release ...
git checkout -b tjanez/stable/20.1.x/changelog-20.1.1
RELEASE_BRANCH=stable/20.1.x NEXT_VERSION=20.1.1 make changelog
git push -u origin tjanez/stable/20.1.x/changelog-20.1.1
... create a pull request against the stable/20.1.x branch and merge it...
RELEASE_BRANCH=stable/20.1.x NEXT_VERSION=20.1.1 make tag-next-release
```

NOTE: Proper docs for this will come as part of #2457.