### PR TITLE
go/sentry: simplify tm sentry flags

### DIFF
--- a/.changelog/2362.breaking.md
+++ b/.changelog/2362.breaking.md
@@ -3,4 +3,7 @@ Simplify tendermint sentry node setup.
 Breaking configuration changes:
 - `worker.sentry.address` renamed to: `worker.registration.sentry.address`
 - `worker.sentry.cert_file` renamed to: `worker.registration.sentry.cert_file`
-TODO: more inc
+- `tendermint.private_peer_id` removed
+- added `tendermint.sentry.upstream_address` which should be set on sentry node
+and it will set `tendermint.private_peer_id` and `tendermint.peristent_peer` for
+the configured addresses

--- a/.changelog/2362.breaking.md
+++ b/.changelog/2362.breaking.md
@@ -1,0 +1,6 @@
+Simplify tendermint sentry node setup.
+
+Breaking configuration changes:
+- `worker.sentry.address` renamed to: `worker.registration.sentry.address`
+- `worker.sentry.cert_file` renamed to: `worker.registration.sentry.cert_file`
+TODO: more inc

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -325,7 +325,6 @@ func (n *Node) initWorkers(logger *logging.Logger) error {
 
 	// Initialize the sentry worker.
 	n.SentryWorker, err = workerSentry.New(
-		&workerCommonCfg,
 		n.Sentry,
 		n.Identity,
 	)

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -82,19 +82,10 @@ func (args *argBuilder) tendermintCoreListenAddress(port uint16) *argBuilder {
 	return args
 }
 
-func (args *argBuilder) tendermintPersistentPeer(peers []string) *argBuilder {
-	for _, peer := range peers {
+func (args *argBuilder) tendermintSentryUpstreamAddress(addrs []string) *argBuilder {
+	for _, addr := range addrs {
 		args.vec = append(args.vec, []string{
-			"--" + tendermint.CfgP2PPersistentPeer, peer,
-		}...)
-	}
-	return args
-}
-
-func (args *argBuilder) tendermintPrivatePeerID(peerIDs []string) *argBuilder {
-	for _, peerID := range peerIDs {
-		args.vec = append(args.vec, []string{
-			"--" + tendermint.CfgP2PPrivatePeerID, peerID,
+			"--" + tendermint.CfgSentryUpstreamAddress, addr,
 		}...)
 	}
 	return args
@@ -308,21 +299,12 @@ func (args *argBuilder) addSentries(sentries []*Sentry) *argBuilder {
 	return args
 }
 
-func (args *argBuilder) addSentriesAsPersistentPeers(sentries []*Sentry) *argBuilder {
-	var peers []string
-	for _, sentry := range sentries {
-		peers = append(peers, fmt.Sprintf("%s@127.0.0.1:%d", sentry.tmAddress, sentry.consensusPort))
-	}
-	args = args.tendermintPersistentPeer(peers)
-	return args
-}
-
-func (args *argBuilder) addValidatorsAsPrivatePeers(validators []*Validator) *argBuilder {
-	var peerIDs []string
+func (args *argBuilder) addValidatorsAsSentryUpstreams(validators []*Validator) *argBuilder {
+	var addrs []string
 	for _, val := range validators {
-		peerIDs = append(peerIDs, val.tmAddress)
+		addrs = append(addrs, fmt.Sprintf("%s@127.0.0.1:%d", val.tmAddress, val.consensusPort))
 	}
-	args = args.tendermintPrivatePeerID(peerIDs)
+	args = args.tendermintSentryUpstreamAddress(addrs)
 	return args
 }
 

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -160,19 +160,19 @@ func (args *argBuilder) workerClientPort(port uint16) *argBuilder {
 	return args
 }
 
-func (args *argBuilder) workerCommonSentryAddresses(addrs []string) *argBuilder {
+func (args *argBuilder) workerRegistrySentryAddresses(addrs []string) *argBuilder {
 	for _, addr := range addrs {
 		args.vec = append(args.vec, []string{
-			"--" + workerCommon.CfgSentryAddresses, addr,
+			"--" + registration.CfgSentryAddress, addr,
 		}...)
 	}
 	return args
 }
 
-func (args *argBuilder) workerCommonSentryCertFiles(certFiles []string) *argBuilder {
+func (args *argBuilder) workerRegistrySentryCertFiles(certFiles []string) *argBuilder {
 	for _, certFile := range certFiles {
 		args.vec = append(args.vec, []string{
-			"--" + workerCommon.CfgSentryCertFiles, certFile,
+			"--" + registration.CfgSentryCert, certFile,
 		}...)
 	}
 	return args
@@ -303,8 +303,8 @@ func (args *argBuilder) addSentries(sentries []*Sentry) *argBuilder {
 		addrs = append(addrs, fmt.Sprintf("127.0.0.1:%d", sentry.controlPort))
 		certFiles = append(certFiles, sentry.TLSCertPath())
 	}
-	args = args.workerCommonSentryAddresses(addrs)
-	args = args.workerCommonSentryCertFiles(certFiles)
+	args = args.workerRegistrySentryAddresses(addrs)
+	args = args.workerRegistrySentryCertFiles(certFiles)
 	return args
 }
 

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -318,8 +318,7 @@ func (args *argBuilder) appendSeedNodes(net *Network) *argBuilder {
 }
 
 func (args *argBuilder) appendNetwork(net *Network) *argBuilder {
-	args = args.grpcLogDebug().
-		appendSeedNodes(net)
+	args = args.grpcLogDebug()
 	return args
 }
 

--- a/go/oasis-test-runner/oasis/client.go
+++ b/go/oasis-test-runner/oasis/client.go
@@ -23,6 +23,7 @@ func (client *Client) startNode() error {
 		tendermintCoreListenAddress(client.consensusPort).
 		storageBackend(storageClient.BackendName).
 		appendNetwork(client.net).
+		appendSeedNodes(client.net).
 		runtimeTagIndexerBackend("bleve")
 	for _, v := range client.net.runtimes {
 		if v.kind != registry.KindCompute {

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -89,6 +89,7 @@ func (worker *Compute) startNode() error {
 		workerRuntimeLoader(worker.net.cfg.RuntimeLoaderBinary).
 		workerTxnschedulerCheckTxEnabled().
 		appendNetwork(worker.net).
+		appendSeedNodes(worker.net).
 		appendEntity(worker.entity)
 	for _, v := range worker.net.runtimes {
 		if v.kind != registry.KindCompute {

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -184,6 +184,7 @@ func (km *Keymanager) startNode() error {
 		workerKeymanagerRuntimeID(km.runtime.id).
 		workerKeymanagerMayGenerate().
 		appendNetwork(km.net).
+		appendSeedNodes(km.net).
 		appendEntity(km.entity)
 	if km.runtime.teeHardware != node.TEEHardwareInvalid {
 		args = args.workerKeymanagerTEEHardware(km.runtime.teeHardware)

--- a/go/oasis-test-runner/oasis/sentry.go
+++ b/go/oasis-test-runner/oasis/sentry.go
@@ -46,6 +46,7 @@ func (sentry *Sentry) startNode() error {
 		workerSentryControlPort(sentry.controlPort).
 		tendermintCoreListenAddress(sentry.consensusPort).
 		appendNetwork(sentry.net).
+		appendSeedNodes(sentry.net).
 		addValidatorsAsSentryUpstreams(validators)
 
 	if sentry.cmd, _, err = sentry.net.startOasisNode(sentry.dir, nil, args, sentry.Name, false, false); err != nil {

--- a/go/oasis-test-runner/oasis/sentry.go
+++ b/go/oasis-test-runner/oasis/sentry.go
@@ -46,7 +46,7 @@ func (sentry *Sentry) startNode() error {
 		workerSentryControlPort(sentry.controlPort).
 		tendermintCoreListenAddress(sentry.consensusPort).
 		appendNetwork(sentry.net).
-		addValidatorsAsPrivatePeers(validators)
+		addValidatorsAsSentryUpstreams(validators)
 
 	if sentry.cmd, _, err = sentry.net.startOasisNode(sentry.dir, nil, args, sentry.Name, false, false); err != nil {
 		return fmt.Errorf("oasis/sentry: failed to launch node %s: %w", sentry.Name, err)

--- a/go/oasis-test-runner/oasis/storage.go
+++ b/go/oasis-test-runner/oasis/storage.go
@@ -83,6 +83,7 @@ func (worker *Storage) startNode() error {
 		workerStorageEnabled().
 		workerStorageDebugIgnoreApplies(worker.ignoreApplies).
 		appendNetwork(worker.net).
+		appendSeedNodes(worker.net).
 		appendEntity(worker.entity)
 	for _, v := range worker.net.runtimes {
 		if v.kind != registry.KindCompute {

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -87,6 +87,8 @@ func (val *Validator) startNode() error {
 	if len(val.sentries) > 0 {
 		args = args.addSentries(val.sentries).
 			tendermintDisablePeerExchange()
+	} else {
+		args = args.appendSeedNodes(val.net)
 	}
 
 	if len(val.net.validators) >= 1 && val == val.net.validators[0] {

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -86,7 +86,6 @@ func (val *Validator) startNode() error {
 
 	if len(val.sentries) > 0 {
 		args = args.addSentries(val.sentries).
-			addSentriesAsPersistentPeers(val.sentries).
 			tendermintDisablePeerExchange()
 	}
 

--- a/go/worker/common/config.go
+++ b/go/worker/common/config.go
@@ -1,16 +1,12 @@
 package common
 
 import (
-	tlsPkg "crypto/tls"
-	"crypto/x509"
-	"fmt"
 	"time"
 
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/oasislabs/oasis-core/go/common"
-	"github.com/oasislabs/oasis-core/go/common/crypto/tls"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	runtimeRegistry "github.com/oasislabs/oasis-core/go/runtime/registry"
@@ -22,13 +18,6 @@ var (
 	CfgClientPort = "worker.client.port"
 
 	cfgClientAddresses = "worker.client.addresses"
-
-	// CfgSentryAddresses configures addresses of sentry nodes the worker
-	// should connect to.
-	CfgSentryAddresses = "worker.sentry.address"
-	// CfgSentryCertFiles configures paths to certificates of the sentry nodes
-	// the worker should connect to.
-	CfgSentryCertFiles = "worker.sentry.cert_file"
 
 	// CfgRuntimeBackend configures the runtime backend.
 	CfgRuntimeBackend = "worker.runtime.backend"
@@ -45,10 +34,8 @@ var (
 
 // Config contains common worker config.
 type Config struct { // nolint: maligned
-	ClientPort         uint16
-	ClientAddresses    []node.Address
-	SentryAddresses    []node.Address
-	SentryCertificates []*x509.Certificate
+	ClientPort      uint16
+	ClientAddresses []node.Address
 
 	// RuntimeHost contains configuration for a worker that hosts
 	// runtimes. It may be nil if the worker is not configured to
@@ -106,42 +93,9 @@ func newConfig() (*Config, error) {
 		return nil, err
 	}
 
-	// Parse sentry nodes' addresses.
-	sentryAddresses, err := configparser.ParseAddressList(viper.GetStringSlice(CfgSentryAddresses))
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse sentry address list: %w", err)
-	}
-	// Get sentry nodes' certificate files.
-	sentryCertFiles := viper.GetStringSlice(CfgSentryCertFiles)
-	// Check if number of sentry addresses corresponds to the number of sentry
-	// certificate files.
-	nSentryAddrs, nSentryCertFiles := len(sentryAddresses), len(sentryCertFiles)
-	if nSentryAddrs != nSentryCertFiles {
-		return nil, fmt.Errorf("worker/registration: configuration error: each sentry node address should have a corresponding certificate file")
-	}
-	sentryCerts := make([]*x509.Certificate, 0, nSentryCertFiles)
-	for _, certFile := range sentryCertFiles {
-		var tlsCert *tlsPkg.Certificate
-		tlsCert, err = tls.LoadCertificate(certFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load sentry certificate file %v: %w", certFile, err)
-		}
-		if len(tlsCert.Certificate) != 1 {
-			return nil, fmt.Errorf("sentry certificate file %v should contain exactly 1 certificate in the chain", certFile)
-		}
-		var x509Cert *x509.Certificate
-		x509Cert, err = x509.ParseCertificate(tlsCert.Certificate[0])
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse certificate file %v: %w", certFile, err)
-		}
-		sentryCerts = append(sentryCerts, x509Cert)
-	}
-
 	cfg := Config{
 		ClientPort:           uint16(viper.GetInt(CfgClientPort)),
 		ClientAddresses:      clientAddresses,
-		SentryAddresses:      sentryAddresses,
-		SentryCertificates:   sentryCerts,
 		StorageCommitTimeout: viper.GetDuration(cfgStorageCommitTimeout),
 		logger:               logging.GetLogger("worker/config"),
 	}
@@ -173,9 +127,6 @@ func newConfig() (*Config, error) {
 func init() {
 	Flags.Uint16(CfgClientPort, 9100, "Port to use for incoming gRPC client connections")
 	Flags.StringSlice(cfgClientAddresses, []string{}, "Address/port(s) to use for client connections when registering this node (if not set, all non-loopback local interfaces will be used)")
-
-	Flags.StringSlice(CfgSentryAddresses, []string{}, fmt.Sprintf("Address(es) of sentry node(s) to connect to (each address should have a corresponding certificate file set in %s)", CfgSentryCertFiles))
-	Flags.StringSlice(CfgSentryCertFiles, []string{}, fmt.Sprintf("Certificate file(s) of sentry node(s) to connect to (each certificate file should have a corresponding address set in %s)", CfgSentryAddresses))
 
 	Flags.String(CfgRuntimeBackend, "sandboxed", "Runtime worker host backend")
 	Flags.String(CfgRuntimeLoader, "", "Path to runtime loader binary")

--- a/go/worker/sentry/worker.go
+++ b/go/worker/sentry/worker.go
@@ -10,7 +10,6 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/sentry/api"
-	workerCommon "github.com/oasislabs/oasis-core/go/worker/common"
 )
 
 const (
@@ -32,8 +31,6 @@ func Enabled() bool {
 // enabling them to hide their real address(es).
 type Worker struct {
 	enabled bool
-
-	workerCommonCfg *workerCommon.Config
 
 	backend api.Backend
 
@@ -102,22 +99,16 @@ func (w *Worker) Cleanup() {
 }
 
 // New creates a new sentry worker.
-func New(workerCommonCfg *workerCommon.Config, backend api.Backend, identity *identity.Identity) (*Worker, error) {
+func New(backend api.Backend, identity *identity.Identity) (*Worker, error) {
 	w := &Worker{
-		enabled:         Enabled(),
-		workerCommonCfg: workerCommonCfg,
-		backend:         backend,
-		quitCh:          make(chan struct{}),
-		initCh:          make(chan struct{}),
-		logger:          logging.GetLogger("worker/sentry"),
+		enabled: Enabled(),
+		backend: backend,
+		quitCh:  make(chan struct{}),
+		initCh:  make(chan struct{}),
+		logger:  logging.GetLogger("worker/sentry"),
 	}
 
 	if w.enabled {
-		if len(w.workerCommonCfg.SentryAddresses) > 0 {
-			return nil, fmt.Errorf(
-				"worker/sentry: invalid configuration: sentry worker is enabled, but the node is configured to connect to sentry node(s)",
-			)
-		}
 		grpcServer, err := grpc.NewServer(&grpc.ServerConfig{
 			Name:        "sentry",
 			Port:        uint16(viper.GetInt(CfgControlPort)),


### PR DESCRIPTION
Fixes: #2362 

This changes the sentry configuration to:
- on sentry node:
  - single flag:  `--tendermint.sentry.upstream_address` 
- on upstream node:
  - `--worker.registration.sentry.address`, `--worker.registration.sentry.cert_fiile` (for querying addresses at registration time)
  -  `--tendermint.disable_peer_exchange` 

One regression to the previous sentry setup is that the upstream node no longer sets "tendermint.persistent_peers" to sentry nodes. I think this is fine, since in any real sentry node setup, the sentry nodes are the only nodes connecting to the upstream node, so not sure if setting persistent peers is/was really needed/useful. Let me know what others think.

Also updated the E2E tests so that nodes behind sentries do not connect to the seed node, since currently the sentry setup was not really properly tested as all nodes got addresses of upstream nodes through the seed node. In future should probably enhance the sentry E2E test further, by blocking all connections to the upstream nodes not originating from sentry nodes.