### PR TITLE
go/oasis-node: Include account ID in `stake list -v` cmd

### DIFF
--- a/.changelog/2567.bugfix.md
+++ b/.changelog/2567.bugfix.md
@@ -1,0 +1,3 @@
+go/oasis-node: Include account ID in `stake list -v` subcommand.
+
+Changes `stake list -v` subcommand to return a map of IDs to accounts.

--- a/go/oasis-node/cmd/stake/stake.go
+++ b/go/oasis-node/cmd/stake/stake.go
@@ -150,15 +150,17 @@ func doList(cmd *cobra.Command, args []string) {
 		return err
 	})
 
-	for _, v := range ids {
-		if !cmdFlags.Verbose() {
-			fmt.Printf("%v\n", v)
-			continue
+	if cmdFlags.Verbose() {
+		accts := make(map[signature.PublicKey]*api.Account)
+		for _, v := range ids {
+			accts[v] = getAccountInfo(ctx, cmd, v, client)
 		}
-
-		ai := getAccountInfo(ctx, cmd, v, client)
-		b, _ := json.Marshal(ai)
+		b, _ := json.Marshal(accts)
 		fmt.Printf("%v\n", string(b))
+	} else {
+		for _, v := range ids {
+			fmt.Printf("%v\n", v)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #2557 