### PR TITLE
go/registry: Add `ConsensusParams.MaxNodeExpiration`

### DIFF
--- a/.changelog/2580.breaking.md
+++ b/.changelog/2580.breaking.md
@@ -1,0 +1,12 @@
+go/registry: Add `ConsensusParams.MaxNodeExpiration`
+
+Node expirations being unbound is likely a bad idea.  This adds a
+consensus parameter that limits the maximum lifespan of a node
+registration, to a pre-defined number of epochs (default 5).
+
+Additionally the genesis document sanity checker is now capable of
+detecting if genesis node descriptors have invalid expirations.
+
+Note: Existing deployments will need to alter the state dump to
+configure the maximun node expiration manually before a restore
+will succeed.

--- a/go/consensus/tendermint/apps/supplementarysanity/checks.go
+++ b/go/consensus/tendermint/apps/supplementarysanity/checks.go
@@ -56,7 +56,11 @@ func checkRegistry(state *iavl.MutableTree, now epochtime.EpochTime) error {
 	if err != nil {
 		return fmt.Errorf("SignedNodes: %w", err)
 	}
-	err = registry.SanityCheckNodes(nodes, seenEntities, seenRuntimes)
+	params, err := st.ConsensusParameters()
+	if err != nil {
+		return fmt.Errorf("ConsensusParameters: %w", err)
+	}
+	err = registry.SanityCheckNodes(nodes, seenEntities, seenRuntimes, false, now, params.MaxNodeExpiration)
 	if err != nil {
 		return fmt.Errorf("SanityCheckNodes: %w", err)
 	}

--- a/go/genesis/api/api.go
+++ b/go/genesis/api/api.go
@@ -110,7 +110,7 @@ func (d *Document) SanityCheck() error {
 	if err = d.EpochTime.SanityCheck(); err != nil {
 		return err
 	}
-	if err = d.Registry.SanityCheck(); err != nil {
+	if err = d.Registry.SanityCheck(d.EpochTime.Base); err != nil {
 		return err
 	}
 	if err = d.RootHash.SanityCheck(); err != nil {

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -52,6 +52,7 @@ const (
 	cfgHaltEpoch          = "halt.epoch"
 
 	// Registry config flags.
+	CfgRegistryMaxNodeExpiration             = "registry.max_node_expiration"
 	cfgRegistryDebugAllowUnroutableAddresses = "registry.debug.allow_unroutable_addresses"
 	CfgRegistryDebugAllowRuntimeRegistration = "registry.debug.allow_runtime_registration"
 	CfgRegistryDebugAllowTestRuntimes        = "registry.debug.allow_test_runtimes"
@@ -247,9 +248,8 @@ func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []stri
 			DebugAllowRuntimeRegistration: viper.GetBool(CfgRegistryDebugAllowRuntimeRegistration),
 			DebugAllowTestRuntimes:        viper.GetBool(CfgRegistryDebugAllowTestRuntimes),
 			DebugBypassStake:              viper.GetBool(cfgRegistryDebugBypassStake),
-
-			// TODO: Make these configurable.
-			GasCosts: registry.DefaultGasCosts,
+			GasCosts:                      registry.DefaultGasCosts, // TODO: Make these configurable.
+			MaxNodeExpiration:             viper.GetUint64(CfgRegistryMaxNodeExpiration),
 		},
 		Entities: make([]*entity.SignedEntity, 0, len(entities)),
 		Runtimes: make([]*registry.SignedRuntime, 0, len(runtimes)),
@@ -689,6 +689,7 @@ func init() {
 	initGenesisFlags.Uint64(cfgHaltEpoch, math.MaxUint64, "genesis halt epoch height")
 
 	// Registry config flags.
+	initGenesisFlags.Uint64(CfgRegistryMaxNodeExpiration, 5, "maximum node registration lifespan in epochs")
 	initGenesisFlags.Bool(cfgRegistryDebugAllowUnroutableAddresses, false, "allow unroutable addreses (UNSAFE)")
 	initGenesisFlags.Bool(CfgRegistryDebugAllowRuntimeRegistration, false, "enable non-genesis runtime registration (UNSAFE)")
 	initGenesisFlags.Bool(CfgRegistryDebugAllowTestRuntimes, false, "enable test runtime registration")

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -663,6 +663,13 @@ func (net *Network) makeGenesis() error {
 	if net.cfg.RegistryDebugAllowRuntimeRegistration {
 		args = append(args, "--"+genesis.CfgRegistryDebugAllowRuntimeRegistration)
 	}
+	if len(net.byzantine) > 0 {
+		// If the byzantine node is in use, disable max node expiration
+		// enforcement, because it wants to register for 1000 epochs.
+		args = append(args, []string{
+			"--" + genesis.CfgRegistryMaxNodeExpiration, "0",
+		}...)
+	}
 
 	w, err := net.baseDir.NewLogWriter("genesis_provision.log")
 	if err != nil {


### PR DESCRIPTION
Node expirations being unbound is likely a bad idea.  This adds a
consensus parameter that limits the maximum lifespan of a node
registration, to a pre-defined number of epochs (default 5).

Additionally the genesis document sanity checker is now capable of
detecting if genesis node descriptors have invalid expirations.

Fixes #2580