### PR TITLE
go/consensus/tendermint: Always accept own transactions

### DIFF
--- a/.changelog/2586.bugfix.md
+++ b/.changelog/2586.bugfix.md
@@ -1,0 +1,4 @@
+go/consensus/tendermint: Always accept own transactions.
+
+A validator node should always accept own transactions (signed by the node's identity key)
+regardless of the configured gas price.

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -65,6 +65,9 @@ type ApplicationConfig struct {
 	Pruning         PruneConfig
 	HaltEpochHeight epochtime.EpochTime
 	MinGasPrice     uint64
+
+	// OwnTxSigner is the transaction signer identity of the local node.
+	OwnTxSigner signature.PublicKey
 }
 
 // TransactionAuthHandler is the interface for ABCI applications that handle
@@ -947,6 +950,7 @@ type ApplicationState struct {
 	haltEpochHeight epochtime.EpochTime
 
 	minGasPrice quantity.Quantity
+	ownTxSigner signature.PublicKey
 
 	metricsCloseCh  chan struct{}
 	metricsClosedCh chan struct{}
@@ -1074,6 +1078,11 @@ func (s *ApplicationState) Genesis() *genesis.Document {
 // MinGasPrice returns the configured minimum gas price.
 func (s *ApplicationState) MinGasPrice() *quantity.Quantity {
 	return &s.minGasPrice
+}
+
+// OwnTxSigner returns the transaction signer identity of the local node.
+func (s *ApplicationState) OwnTxSigner() signature.PublicKey {
+	return s.ownTxSigner
 }
 
 func (s *ApplicationState) doCommit(now time.Time) error {
@@ -1216,6 +1225,7 @@ func newApplicationState(ctx context.Context, cfg *ApplicationConfig) (*Applicat
 		blockHeight:     blockHeight,
 		haltEpochHeight: cfg.HaltEpochHeight,
 		minGasPrice:     minGasPrice,
+		ownTxSigner:     cfg.OwnTxSigner,
 		metricsCloseCh:  make(chan struct{}),
 		metricsClosedCh: make(chan struct{}),
 	}

--- a/go/consensus/tendermint/apps/staking/state/gas.go
+++ b/go/consensus/tendermint/apps/staking/state/gas.go
@@ -69,12 +69,14 @@ func AuthenticateAndPayFees(
 			return transaction.ErrInsufficientFeeBalance
 		}
 
-		// Check fee against minimum gas price if in CheckTx.
+		// Check fee against minimum gas price if in CheckTx. Always accept own transactions.
 		// NOTE: This is non-deterministic as it is derived from the local validator
 		//       configuration, but as long as it is only done in CheckTx, this is ok.
-		callerGasPrice := fee.GasPrice()
-		if fee.Gas > 0 && callerGasPrice.Cmp(ctx.AppState().MinGasPrice()) < 0 {
-			return transaction.ErrGasPriceTooLow
+		if !ctx.AppState().OwnTxSigner().Equal(id) {
+			callerGasPrice := fee.GasPrice()
+			if fee.Gas > 0 && callerGasPrice.Cmp(ctx.AppState().MinGasPrice()) < 0 {
+				return transaction.ErrGasPriceTooLow
+			}
 		}
 
 		return nil

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -878,6 +878,7 @@ func (t *tendermintService) lazyInit() error {
 		Pruning:         pruneCfg,
 		HaltEpochHeight: t.genesis.HaltEpoch,
 		MinGasPrice:     viper.GetUint64(CfgConsensusMinGasPrice),
+		OwnTxSigner:     t.nodeSigner.Public(),
 	}
 	t.mux, err = abci.NewApplicationServer(t.ctx, appConfig)
 	if err != nil {


### PR DESCRIPTION
A validator node should always accept own transactions (signed by the node's
identity key) regardless of the configured gas price.