### PR TITLE
go/registry: Disallow entity signed node registrations

### DIFF
--- a/.changelog/2594.breaking.md
+++ b/.changelog/2594.breaking.md
@@ -1,0 +1,8 @@
+registry: Disallow entity signed node registrations
+
+This feature is mostly useful for testing and should not be used in
+production, basically ever.  Additionally when provisioning node
+descriptors, `--node.is_self_signed` is now the default.
+
+Note: Breaking if anyone happens to use said feature, but enabling said
+feature is already feature-gated, so this is unlikely.

--- a/go/consensus/tendermint/tests/genesis/genesis.go
+++ b/go/consensus/tendermint/tests/genesis/genesis.go
@@ -50,11 +50,12 @@ func NewTestNodeGenesisProvider(identity *identity.Identity) (genesis.Provider, 
 		},
 		Registry: registry.Genesis{
 			Parameters: registry.ConsensusParameters{
-				KeyManagerOperator:            identity.NodeSigner.Public(),
-				DebugAllowUnroutableAddresses: true,
-				DebugAllowRuntimeRegistration: true,
-				DebugAllowTestRuntimes:        true,
-				DebugBypassStake:              true,
+				KeyManagerOperator:                     identity.NodeSigner.Public(),
+				DebugAllowUnroutableAddresses:          true,
+				DebugAllowRuntimeRegistration:          true,
+				DebugAllowTestRuntimes:                 true,
+				DebugAllowEntitySignedNodeRegistration: true,
+				DebugBypassStake:                       true,
 			},
 		},
 		Scheduler: scheduler.Genesis{

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -52,11 +52,12 @@ const (
 	cfgHaltEpoch          = "halt.epoch"
 
 	// Registry config flags.
-	CfgRegistryMaxNodeExpiration             = "registry.max_node_expiration"
-	cfgRegistryDebugAllowUnroutableAddresses = "registry.debug.allow_unroutable_addresses"
-	CfgRegistryDebugAllowRuntimeRegistration = "registry.debug.allow_runtime_registration"
-	CfgRegistryDebugAllowTestRuntimes        = "registry.debug.allow_test_runtimes"
-	cfgRegistryDebugBypassStake              = "registry.debug.bypass_stake" // nolint: gosec
+	CfgRegistryMaxNodeExpiration                      = "registry.max_node_expiration"
+	cfgRegistryDebugAllowUnroutableAddresses          = "registry.debug.allow_unroutable_addresses"
+	CfgRegistryDebugAllowRuntimeRegistration          = "registry.debug.allow_runtime_registration"
+	CfgRegistryDebugAllowTestRuntimes                 = "registry.debug.allow_test_runtimes"
+	cfgRegistryDebugAllowEntitySignedNodeRegistration = "registry.debug.allow_entity_signed_registration"
+	cfgRegistryDebugBypassStake                       = "registry.debug.bypass_stake" // nolint: gosec
 
 	// Scheduler config flags.
 	cfgSchedulerMinValidators          = "scheduler.min_validators"
@@ -244,12 +245,13 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []string, l *logging.Logger) error {
 	regSt := registry.Genesis{
 		Parameters: registry.ConsensusParameters{
-			DebugAllowUnroutableAddresses: viper.GetBool(cfgRegistryDebugAllowUnroutableAddresses),
-			DebugAllowRuntimeRegistration: viper.GetBool(CfgRegistryDebugAllowRuntimeRegistration),
-			DebugAllowTestRuntimes:        viper.GetBool(CfgRegistryDebugAllowTestRuntimes),
-			DebugBypassStake:              viper.GetBool(cfgRegistryDebugBypassStake),
-			GasCosts:                      registry.DefaultGasCosts, // TODO: Make these configurable.
-			MaxNodeExpiration:             viper.GetUint64(CfgRegistryMaxNodeExpiration),
+			DebugAllowUnroutableAddresses:          viper.GetBool(cfgRegistryDebugAllowUnroutableAddresses),
+			DebugAllowRuntimeRegistration:          viper.GetBool(CfgRegistryDebugAllowRuntimeRegistration),
+			DebugAllowTestRuntimes:                 viper.GetBool(CfgRegistryDebugAllowTestRuntimes),
+			DebugAllowEntitySignedNodeRegistration: viper.GetBool(cfgRegistryDebugAllowEntitySignedNodeRegistration),
+			DebugBypassStake:                       viper.GetBool(cfgRegistryDebugBypassStake),
+			GasCosts:                               registry.DefaultGasCosts, // TODO: Make these configurable.
+			MaxNodeExpiration:                      viper.GetUint64(CfgRegistryMaxNodeExpiration),
 		},
 		Entities: make([]*entity.SignedEntity, 0, len(entities)),
 		Runtimes: make([]*registry.SignedRuntime, 0, len(runtimes)),
@@ -693,10 +695,12 @@ func init() {
 	initGenesisFlags.Bool(cfgRegistryDebugAllowUnroutableAddresses, false, "allow unroutable addreses (UNSAFE)")
 	initGenesisFlags.Bool(CfgRegistryDebugAllowRuntimeRegistration, false, "enable non-genesis runtime registration (UNSAFE)")
 	initGenesisFlags.Bool(CfgRegistryDebugAllowTestRuntimes, false, "enable test runtime registration")
+	initGenesisFlags.Bool(cfgRegistryDebugAllowEntitySignedNodeRegistration, false, "allow entity signed node registration (UNSAFE)")
 	initGenesisFlags.Bool(cfgRegistryDebugBypassStake, false, "bypass all stake checks and operations (UNSAFE)")
 	_ = initGenesisFlags.MarkHidden(cfgRegistryDebugAllowUnroutableAddresses)
 	_ = initGenesisFlags.MarkHidden(CfgRegistryDebugAllowRuntimeRegistration)
 	_ = initGenesisFlags.MarkHidden(CfgRegistryDebugAllowTestRuntimes)
+	_ = initGenesisFlags.MarkHidden(cfgRegistryDebugAllowEntitySignedNodeRegistration)
 	_ = initGenesisFlags.MarkHidden(cfgRegistryDebugBypassStake)
 
 	// Scheduler config flags.

--- a/go/oasis-node/cmd/registry/node/node.go
+++ b/go/oasis-node/cmd/registry/node/node.go
@@ -140,6 +140,10 @@ func doInit(cmd *cobra.Command, args []string) {
 		if viper.GetBool(CfgSelfSigned) {
 			isSelfSigned = true
 		}
+		if !cmdFlags.DebugDontBlameOasis() && !isSelfSigned {
+			logger.Error("entity signed node descriptors are prohibited")
+			os.Exit(1)
+		}
 		defer entitySigner.Reset()
 	}
 
@@ -356,7 +360,7 @@ func init() {
 	flags.StringSlice(CfgP2PAddress, nil, "Address(es) the node can be reached over the P2P transport")
 	flags.StringSlice(CfgConsensusAddress, nil, "Address(es) the node can be reached as a consensus member of the form [ID@]ip:port (where the ID@ part is optional and ID represents the node's public key)")
 	flags.StringSlice(CfgRole, nil, "Role(s) of the node.  Supported values are \"compute-worker\", \"storage-worker\", \"transaction-scheduler\", \"key-manager\", \"merge-worker\", and \"validator\"")
-	flags.Bool(CfgSelfSigned, false, "Node registration should be self-signed")
+	flags.Bool(CfgSelfSigned, true, "Node registration should be self-signed")
 	flags.StringSlice(CfgNodeRuntimeID, nil, "Hex Encoded Runtime ID(s) of the node.")
 
 	_ = viper.BindPFlags(flags)

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -411,7 +411,6 @@ func (args *argBuilder) appendEntity(ent *Entity) *argBuilder {
 		dir := ent.dir.String()
 		args.vec = append(args.vec, []string{
 			"--" + registration.CfgRegistrationEntity, filepath.Join(dir, "entity.json"),
-			"--" + registration.CfgRegistrationPrivateKey, filepath.Join(dir, "entity.pem"),
 		}...)
 	} else if ent.isDebugTestEntity {
 		args.vec = append(args.vec, "--"+flags.CfgDebugTestEntity)

--- a/go/oasis-test-runner/oasis/entity.go
+++ b/go/oasis-test-runner/oasis/entity.go
@@ -29,17 +29,15 @@ type Entity struct {
 	entity       *entity.Entity
 	entitySigner signature.Signer
 
-	isDebugTestEntity      bool
-	allowEntitySignedNodes bool
+	isDebugTestEntity bool
 
 	nodes []signature.PublicKey
 }
 
 // EntityCfg is the Oasis entity provisioning configuration.
 type EntityCfg struct {
-	IsDebugTestEntity      bool
-	AllowEntitySignedNodes bool
-	Restore                bool
+	IsDebugTestEntity bool
+	Restore           bool
 }
 
 // Inner returns the actual Oasis entity and it's signer.
@@ -114,9 +112,6 @@ func (ent *Entity) update() error {
 }
 
 func (ent *Entity) addNode(id signature.PublicKey) error {
-	if ent.allowEntitySignedNodes {
-		return nil
-	}
 	ent.nodes = append(ent.nodes, id)
 	return ent.update()
 }
@@ -146,9 +141,6 @@ func (net *Network) NewEntity(cfg *EntityCfg) (*Entity, error) {
 				"--" + flags.CfgSigner, fileSigner.SignerName,
 				"--" + flags.CfgSignerDir, entityDir.String(),
 			}
-			if cfg.AllowEntitySignedNodes {
-				args = append(args, "--entity.debug.allow_entity_signed_nodes")
-			}
 
 			var w io.WriteCloser
 			w, err = entityDir.NewLogWriter("provision.log")
@@ -167,9 +159,8 @@ func (net *Network) NewEntity(cfg *EntityCfg) (*Entity, error) {
 		}
 
 		ent = &Entity{
-			net:                    net,
-			dir:                    entityDir,
-			allowEntitySignedNodes: cfg.AllowEntitySignedNodes,
+			net: net,
+			dir: entityDir,
 		}
 		signerFactory := fileSigner.NewFactory(entityDir.String(), signature.SignerEntity)
 		ent.entity, ent.entitySigner, err = entity.Load(entityDir.String(), signerFactory)

--- a/go/registry/api/sanity_check.go
+++ b/go/registry/api/sanity_check.go
@@ -19,7 +19,7 @@ func (g *Genesis) SanityCheck(baseEpoch epochtime.EpochTime) error {
 	logger := logging.GetLogger("genesis/sanity-check")
 
 	if !flags.DebugDontBlameOasis() {
-		if g.Parameters.DebugAllowUnroutableAddresses || g.Parameters.DebugAllowRuntimeRegistration || g.Parameters.DebugBypassStake {
+		if g.Parameters.DebugAllowUnroutableAddresses || g.Parameters.DebugAllowRuntimeRegistration || g.Parameters.DebugBypassStake || g.Parameters.DebugAllowEntitySignedNodeRegistration {
 			return fmt.Errorf("registry: sanity check failed: one or more unsafe debug flags set")
 		}
 		if g.Parameters.MaxNodeExpiration == 0 {

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -35,8 +35,8 @@ const (
 
 	// CfgRegistrationEntity configures the registration worker entity.
 	CfgRegistrationEntity = "worker.registration.entity"
-	// CfgRegistrationPrivateKey configures the registration worker private key.
-	CfgRegistrationPrivateKey = "worker.registration.private_key"
+	// CfgDebugRegistrationPrivateKey configures the registration worker private key.
+	CfgDebugRegistrationPrivateKey = "worker.registration.debug.private_key"
 	// CfgRegistrationForceRegister overrides a previously saved deregistration
 	// request.
 	CfgRegistrationForceRegister = "worker.registration.force_register"
@@ -658,6 +658,10 @@ func GetRegistrationSigner(logger *logging.Logger, dataDir string, identity *ide
 		}
 	}
 
+	if !flags.DebugDontBlameOasis() {
+		return defaultPk, nil, fmt.Errorf("worker/registration: entity signed nodes disallowed by node config")
+	}
+
 	// At this point, the entity allows entity-signed registrations,
 	// and the node is not in the entity's list of allowed
 	// node-signed nodes.
@@ -668,7 +672,7 @@ func GetRegistrationSigner(logger *logging.Logger, dataDir string, identity *ide
 	// given a entity ID.
 
 	// The entity allows self-signed nodes, try to load the entity private key.
-	f = viper.GetString(CfgRegistrationPrivateKey)
+	f = viper.GetString(CfgDebugRegistrationPrivateKey)
 	if f == "" {
 		// If the private key is not provided, try using a node-signed
 		// registration, the local copy of the entity descriptor may
@@ -812,9 +816,10 @@ func (w *Worker) Cleanup() {
 }
 
 func init() {
-	Flags.String(CfgRegistrationEntity, "", "Entity to use as the node owner in registrations")
-	Flags.String(CfgRegistrationPrivateKey, "", "Private key to use to sign node registrations")
-	Flags.Bool(CfgRegistrationForceRegister, false, "Override a previously saved deregistration request")
+	Flags.String(CfgRegistrationEntity, "", "entity to use as the node owner in registrations")
+	Flags.String(CfgDebugRegistrationPrivateKey, "", "private key to use to sign node registrations")
+	Flags.Bool(CfgRegistrationForceRegister, false, "override a previously saved deregistration request")
+	_ = Flags.MarkHidden(CfgDebugRegistrationPrivateKey)
 
 	_ = viper.BindPFlags(Flags)
 }


### PR DESCRIPTION
This feature is mostly useful for testing and should not be used in
production, basically ever.

Note: Breaking if anyone happens to use said feature.

Fixes #2594