### PR TITLE
trivial: fix some comments, warnings

### DIFF
--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -409,8 +409,8 @@ func AppendRegistryState(doc *genesis.Document, entities, runtimes, nodes []stri
 	return nil
 }
 
-// AppendRootHashState appends the roothash genesis state given a vector
-// of exported roothash blocks.
+// AppendRootHashState appends the roothash genesis state given files with
+// exported runtime states.
 func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Logger) error {
 	rootSt := roothash.Genesis{
 		RuntimeStates: make(map[common.Namespace]*registry.RuntimeGenesis),
@@ -441,6 +441,7 @@ func AppendRootHashState(doc *genesis.Document, exports []string, l *logging.Log
 		}
 
 		for id, rtg := range rtStates {
+			// Each runtime state must be described exactly once!
 			if _, ok := rootSt.RuntimeStates[id]; ok {
 				l.Error("duplicate genesis roothash runtime state",
 					"runtime_id", id,
@@ -683,7 +684,7 @@ func init() {
 
 	initGenesisFlags.StringSlice(cfgRuntime, nil, "path to runtime registration file")
 	initGenesisFlags.StringSlice(cfgNode, nil, "path to node registration file")
-	initGenesisFlags.StringSlice(cfgRootHash, nil, "path to roothash genesis blocks file")
+	initGenesisFlags.StringSlice(cfgRootHash, nil, "path to roothash genesis runtime states file")
 	initGenesisFlags.String(cfgStaking, "", "path to staking genesis file")
 	initGenesisFlags.StringSlice(cfgKeyManager, nil, "path to key manager genesis status file")
 	initGenesisFlags.String(cfgKeyManagerOperator, "", "path to key manager operator entity registration file")

--- a/keymanager-runtime/src/main.rs
+++ b/keymanager-runtime/src/main.rs
@@ -11,7 +11,7 @@ extern crate tiny_keccak;
 extern crate x25519_dalek;
 extern crate zeroize;
 
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 mod context;
 mod kdf;
@@ -22,7 +22,7 @@ use failure::Fallible;
 
 use oasis_core_keymanager_api::*;
 use oasis_core_runtime::{
-    common::{runtime::RuntimeId, version::Version},
+    common::version::Version,
     rak::RAK,
     register_runtime_rpc_methods,
     rpc::{

--- a/runtime/src/common/roothash.rs
+++ b/runtime/src/common/roothash.rs
@@ -32,7 +32,9 @@ impl_bytes!(Namespace, 32, "Chain namespace.");
 
 /// Header type.
 ///
-/// NOTE: This should be kept in sync with go/roothash/api/block/header.go.
+/// # Note
+///
+/// This should be kept in sync with go/roothash/api/block/header.go.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize_repr, Deserialize_repr)]
 #[repr(u8)]
 pub enum HeaderType {


### PR DESCRIPTION
Trivial follow-up of https://github.com/oasislabs/oasis-runtime/pull/958:
* fixes comments in `runtime/common` and `genesis init` command for providing roothash runtime states file,
* fixes unused compilation warnings in keymanager-runtime.