### PR TITLE
go/storage/mkvs/urkel: fix invalid memory access when unmarshalling

### DIFF
--- a/.changelog/2611.bugfix.md
+++ b/.changelog/2611.bugfix.md
@@ -1,0 +1,1 @@
+go/storage: Fix invalid memory access crash in Urkel tree

--- a/go/storage/mkvs/urkel/node/node.go
+++ b/go/storage/mkvs/urkel/node/node.go
@@ -622,7 +622,8 @@ func (n *LeafNode) SizedUnmarshalBinary(data []byte) (int, error) {
 	valueSize := int(binary.LittleEndian.Uint32(data[pos : pos+ValueLengthSize]))
 	pos += ValueLengthSize
 
-	value := data[pos : pos+valueSize]
+	value := make([]byte, valueSize)
+	copy(value, data[pos:pos+valueSize])
 	pos += valueSize
 
 	n.Clean = true


### PR DESCRIPTION
PR for https://github.com/oasislabs/oasis-core/issues/2611:
- instead of storing a reference to external data, properly copy it to the node.