### PR TITLE
go/cmd: add explicit --wait flag, prepend unix: if user forgets it

### DIFF
--- a/.changelog/2438.trivial.md
+++ b/.changelog/2438.trivial.md
@@ -1,0 +1,7 @@
+go/cmd: Improve gRPC address passing.
+
+Introduced new `--wait` switch for oasis-node which explicitly enables waiting
+for gRPC address, if it's not available yet.
+
+Additionally, if a user forgets to prepend `unix:` for an existing unix socket
+filename, it is automatically prepended and a warning is shown.

--- a/go/oasis-node/cmd/common/grpc/grpc.go
+++ b/go/oasis-node/cmd/common/grpc/grpc.go
@@ -4,6 +4,8 @@ package grpc
 import (
 	"crypto/tls"
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -12,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 
 	cmnGrpc "github.com/oasislabs/oasis-core/go/common/grpc"
+	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
 )
 
@@ -20,6 +23,8 @@ const (
 	CfgServerPort = "grpc.port"
 	// CfgDebugPort configures the remote address.
 	CfgAddress = "address"
+	// CfgWait waits for the remote address to become available.
+	CfgWait = "wait"
 
 	defaultAddress      = "unix:" + localSocketFilename
 	localSocketFilename = "internal.sock"
@@ -32,6 +37,8 @@ var (
 	ServerLocalFlags = flag.NewFlagSet("", flag.ContinueOnError)
 	// ClientFlags has the flags for a gRPC client.
 	ClientFlags = flag.NewFlagSet("", flag.ContinueOnError)
+
+	logger = logging.GetLogger("cmd/grpc")
 )
 
 // NewServerTCP constructs a new gRPC server service listening on
@@ -73,10 +80,19 @@ func NewServerLocal(installWrapper bool) (*cmnGrpc.Server, error) {
 func NewClient(cmd *cobra.Command) (*grpc.ClientConn, error) {
 	addr, _ := cmd.Flags().GetString(CfgAddress)
 
+	if _, err := os.Stat(addr); err == nil {
+		logger.Warn(fmt.Sprintf("'%s' is a file name. Assuming 'unix:%s'.", addr, addr))
+		addr = "unix:" + addr
+	}
+
+	opts := []grpc.DialOption{grpc.WithInsecure()}
+	if viper.GetBool(CfgWait) {
+		opts = append(opts, grpc.WithDefaultCallOptions(grpc.WaitForReady(true)))
+	}
+
 	conn, err := cmnGrpc.Dial(
 		addr,
-		grpc.WithInsecure(),
-		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
+		opts...,
 	)
 	if err != nil {
 		return nil, err
@@ -93,5 +109,6 @@ func init() {
 	ServerLocalFlags.AddFlagSet(cmnGrpc.Flags)
 
 	ClientFlags.StringP(CfgAddress, "a", defaultAddress, "remote gRPC address")
+	ClientFlags.Bool(CfgWait, false, "wait for gRPC address to become available")
 	_ = viper.BindPFlags(ClientFlags)
 }

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -57,6 +57,13 @@ func (args *argBuilder) grpcServerPort(port uint16) *argBuilder {
 	return args
 }
 
+func (args *argBuilder) grpcWait() *argBuilder {
+	args.vec = append(args.vec, []string{
+		"--" + grpc.CfgWait,
+	}...)
+	return args
+}
+
 func (args *argBuilder) grpcLogDebug() *argBuilder {
 	args.vec = append(args.vec, "--"+commonGrpc.CfgLogDebug)
 	return args

--- a/go/oasis-test-runner/oasis/ias.go
+++ b/go/oasis-test-runner/oasis/ias.go
@@ -30,6 +30,7 @@ func (ias *iasProxy) startNode() error {
 		debugDontBlameOasis().
 		debugAllowTestKeys().
 		grpcServerPort(ias.grpcPort).
+		grpcWait().
 		iasDebugMock().
 		iasSPID(mockSPID)
 	if ias.useRegistry {

--- a/go/oasis-test-runner/scenario/e2e/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/txsource.go
@@ -60,6 +60,11 @@ func (sc *txSourceImpl) Run(childEnv *env.Env) error {
 		return fmt.Errorf("scenario net Start: %w", err)
 	}
 
+	// Wait for all nodes to be synced before we proceed.
+	if err := sc.waitNodesSynced(); err != nil {
+		return err
+	}
+
 	logFmt := logging.FmtJSON
 	logLevel := logging.LevelDebug
 	cmd, err := startClient(childEnv, sc.net, "scripts/txsource-wrapper.sh", append([]string{


### PR DESCRIPTION
PR for https://github.com/oasislabs/oasis-core/issues/2438:
* introduces new `--wait` flag which explicitly waits for gRPC address to become available,
* automatically prepends a `unix:` prefix, if the address is a local file name and prints a warning message.