### PR TITLE
go/oasis-node/cmd/debug/fixgenesis: Support migrating Node.Roles

### DIFF
--- a/.changelog/2620.feature.md
+++ b/.changelog/2620.feature.md
@@ -1,0 +1,7 @@
+go/oasis-node/cmd/debug/fixgenesis: Support migrating Node.Roles
+
+The node.RolesMask bit definitons have changed since the last major
+release deployed to the wild, so support migrating things by rewriting
+the node descriptor.
+
+Note: This assumes that signature validation in InitChain is disabled.


### PR DESCRIPTION
The node.RolesMask bit definitons have changed since the last major
release deployed to the wild, so support migrating things by rewriting
the node descriptor.

Note: This assumes that signature validation in InitChain is disabled.