### PR TITLE
go: Re-enable signature verification disabled for migration

### DIFF
--- a/.changelog/2615.bugfix.md
+++ b/.changelog/2615.bugfix.md
@@ -1,0 +1,5 @@
+go: Re-enable signature verification disabled for migration
+
+Now that the migration has hopefully been done, re-enable all of the
+signature verification that was disabled for the sake of allowing for
+migration.

--- a/go/consensus/tendermint/apps/registry/genesis.go
+++ b/go/consensus/tendermint/apps/registry/genesis.go
@@ -164,13 +164,6 @@ func (rq *registryQuerier) Genesis(ctx context.Context) (*registry.Genesis, erro
 		if n.HasRoles(node.RoleValidator) {
 			validatorNodes = append(validatorNodes, sn)
 		}
-
-		// We want to discard nodes that haven't bothered to re-register
-		// with the new multi-signed descriptor format.
-		if len(sn.MultiSigned.Signatures) < 2 {
-			// Too bad we can't log here.  Oh well.
-			continue
-		}
 	}
 
 	nodeStatuses, err := rq.state.NodeStatuses()

--- a/go/consensus/tendermint/apps/supplementarysanity/checks.go
+++ b/go/consensus/tendermint/apps/supplementarysanity/checks.go
@@ -59,23 +59,15 @@ func checkRegistry(state *iavl.MutableTree, now epochtime.EpochTime) error {
 		return fmt.Errorf("SanityCheckRuntimes: %w", err)
 	}
 
-	// We can't run this check till everyone transitions to the new
-	// descriptor format, since there's currently no way to distinguish
-	// between nodes registered at genesis (old signature format) and
-	// nodes registered at runtime (MUST be new signature format).
-
-	/*
-		// Check nodes.
-		nodes, err := st.SignedNodes()
-		if err != nil {
-			return fmt.Errorf("SignedNodes: %w", err)
-		}
-		err = registry.SanityCheckNodes(logger, params, nodes, seenEntities, runtimeLookup, false, now)
-		if err != nil {
-			return fmt.Errorf("SanityCheckNodes: %w", err)
-		}
-	*/
-	_, _ = seenEntities, runtimeLookup
+	// Check nodes.
+	nodes, err := st.SignedNodes()
+	if err != nil {
+		return fmt.Errorf("SignedNodes: %w", err)
+	}
+	err = registry.SanityCheckNodes(logger, params, nodes, seenEntities, runtimeLookup, false, now)
+	if err != nil {
+		return fmt.Errorf("SanityCheckNodes: %w", err)
+	}
 
 	return nil
 }

--- a/go/consensus/tendermint/seed.go
+++ b/go/consensus/tendermint/seed.go
@@ -12,7 +12,6 @@ import (
 	"github.com/tendermint/tendermint/types"
 	"github.com/tendermint/tendermint/version"
 
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/node"
@@ -163,14 +162,8 @@ func populateAddrBookFromGenesis(addrBook p2p.AddrBook, doc *genesis.Document, o
 	var addrs []*p2p.NetAddress
 	for _, v := range doc.Registry.Nodes {
 		var openedNode node.Node
-		if isOldNode(v) {
-			if err := cbor.Unmarshal(v.Blob, &openedNode); err != nil {
-				return errors.Wrap(err, "tendermint/seed: failed to unmarshal old-format validator")
-			}
-		} else {
-			if err := v.Open(registry.RegisterGenesisNodeSignatureContext, &openedNode); err != nil {
-				return errors.Wrap(err, "tendermint/seed: failed to verify validator")
-			}
+		if err := v.Open(registry.RegisterGenesisNodeSignatureContext, &openedNode); err != nil {
+			return errors.Wrap(err, "tendermint/seed: failed to verify validator")
 		}
 		// TODO: This should cross check that the entity is valid.
 		if !openedNode.HasRoles(node.RoleValidator) {

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -1029,12 +1029,6 @@ func (t *tendermintService) lazyInit() error {
 	return nil
 }
 
-func isOldNode(sigNode *node.MultiSignedNode) bool {
-	// Nodes signed before v20.3 are allowed in the genesis document,
-	// but they aren't validly signed by the current rules.
-	return len(sigNode.MultiSigned.Signatures) < 2
-}
-
 // genesisToTendermint converts the Oasis genesis block to Tendermint's format.
 func genesisToTendermint(d *genesisAPI.Document) (*tmtypes.GenesisDoc, error) {
 	// WARNING: The AppState MUST be encoded as JSON since its type is
@@ -1077,14 +1071,8 @@ func genesisToTendermint(d *genesisAPI.Document) (*tmtypes.GenesisDoc, error) {
 	var tmValidators []tmtypes.GenesisValidator
 	for _, v := range d.Registry.Nodes {
 		var openedNode node.Node
-		if isOldNode(v) {
-			if err := cbor.Unmarshal(v.Blob, &openedNode); err != nil {
-				return nil, fmt.Errorf("tendermint: failed to unmarshal old-format validator: %w", err)
-			}
-		} else {
-			if err := v.Open(registryAPI.RegisterGenesisNodeSignatureContext, &openedNode); err != nil {
-				return nil, fmt.Errorf("tendermint: failed to verify validator: %w", err)
-			}
+		if err := v.Open(registryAPI.RegisterGenesisNodeSignatureContext, &openedNode); err != nil {
+			return nil, fmt.Errorf("tendermint: failed to verify validator: %w", err)
 		}
 		// TODO: This should cross check that the entity is valid.
 		if !openedNode.HasRoles(node.RoleValidator) {


### PR DESCRIPTION
Now that the migration has hopefully been done, re-enable all of the
signature verification that was disabled for the sake of allowing for
migration.

Fixes #2615