### PR TITLE
go/tendermint/keymanager: error Status() if keymanager doesn't exist

### DIFF
--- a/.changelog/2628.bugfix.md
+++ b/.changelog/2628.bugfix.md
@@ -1,0 +1,4 @@
+go/tendermint/keymanager: error in Status() if keymanager doesn't exist
+
+This fixes panics in the key-manager client if keymanager for the specific
+runtime doesn't exist.

--- a/go/consensus/tendermint/apps/keymanager/state/state.go
+++ b/go/consensus/tendermint/apps/keymanager/state/state.go
@@ -60,7 +60,7 @@ func (st *ImmutableState) getStatusesRaw() ([][]byte, error) {
 func (st *ImmutableState) Status(id common.Namespace) (*api.Status, error) {
 	_, raw := st.Snapshot.Get(statusKeyFmt.Encode(&id))
 	if raw == nil {
-		return nil, nil
+		return nil, api.ErrNoSuchStatus
 	}
 
 	var status api.Status

--- a/go/keymanager/api/api.go
+++ b/go/keymanager/api/api.go
@@ -29,9 +29,9 @@ const (
 )
 
 var (
-	// ErrNoSuchKeyManager is the error returned when a key manager does not
+	// ErrNoSuchStatus is the error returned when a key manager status does not
 	// exist.
-	ErrNoSuchKeyManager = errors.New(ModuleName, 1, "keymanager: no such key manager")
+	ErrNoSuchStatus = errors.New(ModuleName, 1, "keymanager: no such status")
 
 	// TestPublicKey is the insecure hardcoded key manager public key, used
 	// in insecure builds when a RAK is unavailable.


### PR DESCRIPTION
This fixes panics in keymanager client if key manager doesn't exist.