### PR TITLE
go tendermint: mux offset block height consistently

### DIFF
--- a/.changelog/2634.breaking.md
+++ b/.changelog/2634.breaking.md
@@ -1,0 +1,4 @@
+go tendermint: mux--Offset block height consistently.
+
+We've been using `blockHeight+1` for getting the epoch time except for on blockHeight=1.
+The hypothesis in this change is that we don't need that special case.


### PR DESCRIPTION
from https://github.com/oasislabs/oasis-core/pull/2625#discussion_r373370431

We've been using `blockHeight+1` for getting the epoch time except for on blockHeight=1. The hypothesis in this PR is that we don't need that special case.