### PR TITLE
go/cmd/registry/runtime: fix provisioning a runtime without keymanager

### DIFF
--- a/.changelog/2639.bugfix.md
+++ b/.changelog/2639.bugfix.md
@@ -1,0 +1,1 @@
+go/cmd/registry/runtime: fix provisioning a runtime without keymanager

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -266,7 +266,7 @@ func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) {
 	}
 	switch kind {
 	case registry.KindCompute:
-		if viper.IsSet(CfgKeyManager) {
+		if viper.GetString(CfgKeyManager) != "" {
 			var tmpKmID common.Namespace
 			if err = tmpKmID.UnmarshalHex(viper.GetString(CfgKeyManager)); err != nil {
 				logger.Error("failed to parse key manager ID",


### PR DESCRIPTION
`vipper.IsSet` always returns true if key was bound to a PFlag. Also did check, and this is the only place where we're using `viper.IsSet`.

Apparently could also use:
```
flag := cmd.Flags().Lookup("flag-name")
if flag == nil || !flag.Changed {
    continue
}
```
but this seems clearer?