### PR TITLE
registry/api/sanitycheck: move genesis stateroot check into registration

### DIFF
--- a/.changelog/2643.bugfix.md
+++ b/.changelog/2643.bugfix.md
@@ -1,0 +1,4 @@
+registry/api/sanitycheck: move genesis stateroot check into registration.
+
+Runtime genesis check should only be done when registering, not during the
+sanity checks.

--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -506,6 +506,13 @@ func (app *registryApplication) registerRuntime(
 		return err
 	}
 
+	// Runtime with genesis stateroot only allowed in genesis.
+	if !ctx.IsInitChain() && !rt.Genesis.StateRoot.IsEmpty() {
+		ctx.Logger().Error("RegisterRuntime: runtime genesis state root not empty")
+		// TODO: Verify storage receipt for the state root, reject such registrations for now. See oasis-core#1686.
+		return registry.ErrInvalidArgument
+	}
+
 	if rt.Kind == registry.KindCompute {
 		if err = registry.VerifyRegisterComputeRuntimeArgs(ctx.Logger(), rt, state); err != nil {
 			return err

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -1126,10 +1126,6 @@ func VerifyRegisterRuntimeArgs(
 		return nil, fmt.Errorf("%w: test runtime not allowed", ErrInvalidArgument)
 	}
 
-	if !isGenesis && !rt.Genesis.StateRoot.IsEmpty() {
-		// TODO: Verify storage receipt for the state root, reject such registrations for now. See oasis-core#1686.
-		return nil, ErrInvalidArgument
-	}
 	if err := rt.Genesis.SanityCheck(isGenesis); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`rt.Genesis.StateRoot.IsEmpty` check should only be done when registering (otherwise `supplementarysanity` checks are failing)