### PR TITLE
.buildkite/pipeline: require large agents for coverage step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -271,5 +271,7 @@ steps:
     artifact_paths:
       - merged-coverage.txt
     soft_fail: true
+    agents:
+      buildkite_agent_size: large
     plugins:
       <<: *docker_plugin


### PR DESCRIPTION
temoporary, until: https://github.com/oasislabs/oasis-core/issues/2644