### PR TITLE
go/consensus/tendermint: Expose more P2P config params

### DIFF
--- a/.changelog/2646.breaking.md
+++ b/.changelog/2646.breaking.md
@@ -1,0 +1,9 @@
+Tendermint P2P configuration parameters.
+
+This allows configuring P2P parameters MaxNumInboundPeers, MaxNumOutboundPeers,
+SendRate and RecvRate through the CLI flags tendermint.p2p.max_num_inbound_peers,
+tendermint.p2p.max_num_outbound_peers, tendermint.p2p.send_rate, and
+tendermint.p2p.recv_rate, respectively.
+
+It also increases the default value of MaxNumOutboundPeers from 10 to 20 and moves
+all P2P parameters under the tendermint.p2p.* namespace.


### PR DESCRIPTION
Fixes #2597

TODO: Update sentry node config doc: https://docs.oasis.dev/operators/sentry-node.html#configuring-the-oasis-sentry-node