### PR TITLE
go/registry: Enable non-genesis runtime registrations by default

### DIFF
--- a/.changelog/2406.breaking.md
+++ b/.changelog/2406.breaking.md
@@ -1,0 +1,1 @@
+go/registry: Enable non-genesis runtime registrations by default.

--- a/go/consensus/tendermint/apps/registry/genesis.go
+++ b/go/consensus/tendermint/apps/registry/genesis.go
@@ -29,18 +29,6 @@ func (app *registryApplication) InitChain(ctx *abci.Context, request types.Reque
 	state := registryState.NewMutableState(ctx.State())
 	state.SetConsensusParameters(&st.Parameters)
 
-	if st.Parameters.KeyManagerOperator.IsValid() {
-		ctx.Logger().Debug("InitChain: Registering key manager operator",
-			"id", st.Parameters.KeyManagerOperator,
-		)
-	} else {
-		// This is informational for now since there are configurations
-		// that do not have a key manager.
-		ctx.Logger().Warn("InitChain: Invalid key manager operator, key manager will not work",
-			"id", st.Parameters.KeyManagerOperator,
-		)
-	}
-
 	for _, v := range st.Entities {
 		ctx.Logger().Debug("InitChain: Registering genesis entity",
 			"entity", v.Signature.PublicKey,

--- a/go/consensus/tendermint/apps/registry/registry.go
+++ b/go/consensus/tendermint/apps/registry/registry.go
@@ -94,17 +94,6 @@ func (app *registryApplication) ExecuteTx(ctx *abci.Context, tx *transaction.Tra
 			return err
 		}
 
-		params, err := state.ConsensusParameters()
-		if err != nil {
-			ctx.Logger().Error("RegisterRuntime: failed to fetch consensus parameters",
-				"err", err,
-			)
-			return err
-		}
-
-		if !params.DebugAllowRuntimeRegistration {
-			return registry.ErrForbidden
-		}
 		return app.registerRuntime(ctx, state, &sigRt)
 	default:
 		return registry.ErrInvalidArgument

--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -512,7 +512,7 @@ func (app *registryApplication) unfreezeNode(
 	return nil
 }
 
-func (app *registryApplication) registerRuntime(
+func (app *registryApplication) registerRuntime( // nolint: gocyclo
 	ctx *abci.Context,
 	state *registryState.MutableState,
 	sigRt *registry.SignedRuntime,
@@ -525,9 +525,17 @@ func (app *registryApplication) registerRuntime(
 		return err
 	}
 
+	if params.DisableRuntimeRegistration {
+		return registry.ErrForbidden
+	}
+
 	rt, err := registry.VerifyRegisterRuntimeArgs(params, ctx.Logger(), sigRt, ctx.IsInitChain())
 	if err != nil {
 		return err
+	}
+
+	if rt.Kind == registry.KindKeyManager && params.DisableKeyManagerRuntimeRegistration {
+		return registry.ErrForbidden
 	}
 
 	// Runtime with genesis stateroot only allowed in genesis.

--- a/go/consensus/tendermint/tests/genesis/genesis.go
+++ b/go/consensus/tendermint/tests/genesis/genesis.go
@@ -50,9 +50,7 @@ func NewTestNodeGenesisProvider(identity *identity.Identity) (genesis.Provider, 
 		},
 		Registry: registry.Genesis{
 			Parameters: registry.ConsensusParameters{
-				KeyManagerOperator:                     identity.NodeSigner.Public(),
 				DebugAllowUnroutableAddresses:          true,
-				DebugAllowRuntimeRegistration:          true,
 				DebugAllowTestRuntimes:                 true,
 				DebugAllowEntitySignedNodeRegistration: true,
 				DebugBypassStake:                       true,

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -47,7 +47,6 @@ var testDoc = &genesis.Document{
 	Registry: registry.Genesis{
 		Parameters: registry.ConsensusParameters{
 			DebugAllowUnroutableAddresses:          true,
-			DebugAllowRuntimeRegistration:          true,
 			DebugBypassStake:                       true,
 			DebugAllowEntitySignedNodeRegistration: true,
 		},
@@ -131,7 +130,7 @@ func TestGenesisChainContext(t *testing.T) {
 	//       on each run.
 	stableDoc.Staking = staking.Genesis{}
 
-	require.Equal(t, "c0c1cdc46bc6eba60b4971ab9f25d1188d0829be01b33f13d6a1929d551cc900", stableDoc.ChainContext())
+	require.Equal(t, "ce29f2d2241e7eaaa9bd96d20aa075fe18cd8b178e4f9d05b7dacd8b538eabcc", stableDoc.ChainContext())
 }
 
 func TestGenesisSanityCheck(t *testing.T) {
@@ -252,10 +251,6 @@ func TestGenesisSanityCheck(t *testing.T) {
 	}
 	signedTestNode := signNodeOrDie(nodeSigners, testNode)
 	entitySignedTestNode := signNodeOrDie(append([]signature.Signer{signer}, nodeSigners...), testNode)
-
-	testDocCopy := *testDoc
-	testDoc := &testDocCopy
-	testDoc.Registry.Parameters.KeyManagerOperator = signer.Public()
 
 	// Test genesis document should pass sanity check.
 	require.NoError(testDoc.SanityCheck(), "test genesis document should be valid")

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -176,7 +176,6 @@ func (km *Keymanager) provisionGenesis() error {
 func (km *Keymanager) toGenesisArgs() []string {
 	return []string{
 		"--keymanager", filepath.Join(km.dir.String(), kmStatusFile),
-		"--keymanager.operator", filepath.Join(km.entity.dir.String(), "entity_genesis.json"),
 	}
 }
 

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -195,9 +195,6 @@ type NetworkCfg struct { // nolint: maligned
 	// StakingGenesis is the name of a file with a staking genesis document to use if GenesisFile isn't set.
 	StakingGenesis string `json:"staking_genesis"`
 
-	// RegistryDebugAllowRuntimeRegistration enables runtime registration.
-	RegistryDebugAllowRuntimeRegistration bool `json:"registry_debug_allow_runtime_registration"`
-
 	// A set of log watcher handler factories used by default on all nodes
 	// created in this test network.
 	DefaultLogWatcherHandlerFactories []log.WatcherHandlerFactory `json:"-"`
@@ -654,9 +651,6 @@ func (net *Network) makeGenesis() error {
 	}
 	if net.cfg.StakingGenesis != "" {
 		args = append(args, "--staking", net.cfg.StakingGenesis)
-	}
-	if net.cfg.RegistryDebugAllowRuntimeRegistration {
-		args = append(args, "--"+genesis.CfgRegistryDebugAllowRuntimeRegistration)
 	}
 	if len(net.byzantine) > 0 {
 		// If the byzantine node is in use, disable max node expiration

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -52,9 +52,6 @@ func (r *registryCLIImpl) Fixture() (*oasis.NetworkFixture, error) {
 	// We will mock epochs for reclaiming the escrow.
 	f.Network.EpochtimeMock = true
 
-	// Allow runtime registration.
-	f.Network.RegistryDebugAllowRuntimeRegistration = true
-
 	return f, nil
 }
 

--- a/go/oasis-test-runner/scenario/e2e/runtime_dynamic.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime_dynamic.go
@@ -48,9 +48,6 @@ func (sc *runtimeDynamicImpl) Fixture() (*oasis.NetworkFixture, error) {
 	f.Network.IASUseRegistry = true
 	// Avoid unexpected blocks.
 	f.Network.EpochtimeMock = true
-	// We need runtime registration to be enabled.
-	// TODO: This should not be needed once this is the default (no longer debug).
-	f.Network.RegistryDebugAllowRuntimeRegistration = true
 	// Exclude all runtimes from genesis as we will register those dynamically.
 	for i, rt := range f.Runtimes {
 		// TODO: This should not be needed once dynamic keymanager policy document registration

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -553,17 +553,6 @@ func VerifyRegisterNodeArgs( // nolint: gocyclo
 		return nil, nil, err
 	}
 
-	// If node is a key manager, ensure that it is owned by the key manager
-	// operator.
-	if n.HasRoles(node.RoleKeyManager) {
-		if !n.EntityID.Equal(params.KeyManagerOperator) {
-			logger.Error("RegisterNode: key manager not owned by key manager operator",
-				"node", n,
-			)
-			return nil, nil, fmt.Errorf("%w: keymanager entity not operator", ErrInvalidArgument)
-		}
-	}
-
 	// Validate CommitteeInfo.
 	// Verify that certificate is well-formed.
 	if _, err := n.Committee.ParseCertificate(); err != nil {
@@ -1233,17 +1222,9 @@ type Genesis struct {
 
 // ConsensusParameters are the registry consensus parameters.
 type ConsensusParameters struct {
-	// KeyManagerOperator is the ID of the entity that is allowed to operate
-	// key manager nodes.
-	KeyManagerOperator signature.PublicKey `json:"km_operator"`
-
 	// DebugAllowUnroutableAddresses is true iff node registration should
 	// allow unroutable addreses.
 	DebugAllowUnroutableAddresses bool `json:"debug_allow_unroutable_addresses,omitempty"`
-
-	// DebugAllowRuntimeRegistration is true iff runtime registration should be
-	// allowed outside of the genesis block.
-	DebugAllowRuntimeRegistration bool `json:"debug_allow_runtime_registration,omitempty"`
 
 	// DebugAllowTestRuntimes is true iff test runtimes should be allowed to
 	// be registered.
@@ -1256,6 +1237,14 @@ type ConsensusParameters struct {
 	// DebugBypassStake is true iff the registry should bypass all of the staking
 	// related checks and operations.
 	DebugBypassStake bool `json:"debug_bypass_stake,omitempty"`
+
+	// DisableRuntimeRegistration is true iff runtime registration should be
+	// disabled outside of the genesis block.
+	DisableRuntimeRegistration bool `json:"disable_runtime_registration,omitempty"`
+
+	// DisableRuntimeRegistration is true iff key manager runtime registration should be
+	// disabled outside of the genesis block.
+	DisableKeyManagerRuntimeRegistration bool `json:"disable_km_runtime_registration,omitempty"`
 
 	// GasCosts are the registry transaction gas costs.
 	GasCosts transaction.Costs `json:"gas_costs,omitempty"`

--- a/go/registry/api/sanity_check.go
+++ b/go/registry/api/sanity_check.go
@@ -19,16 +19,13 @@ func (g *Genesis) SanityCheck(baseEpoch epochtime.EpochTime) error {
 	logger := logging.GetLogger("genesis/sanity-check")
 
 	if !flags.DebugDontBlameOasis() {
-		if g.Parameters.DebugAllowUnroutableAddresses || g.Parameters.DebugAllowRuntimeRegistration || g.Parameters.DebugBypassStake || g.Parameters.DebugAllowEntitySignedNodeRegistration {
+		if g.Parameters.DebugAllowUnroutableAddresses || g.Parameters.DebugBypassStake || g.Parameters.DebugAllowEntitySignedNodeRegistration {
 			return fmt.Errorf("registry: sanity check failed: one or more unsafe debug flags set")
 		}
 		if g.Parameters.MaxNodeExpiration == 0 {
 			return fmt.Errorf("registry: sanity check failed: maximum node expiration not specified")
 		}
 	}
-
-	// This could check KeyManagerOperator, but some configurations don't
-	// use a key manager, so the parameter is optional.
 
 	// Check entities.
 	seenEntities, err := SanityCheckEntities(logger, g.Entities)


### PR DESCRIPTION
See #2406 
Fixes #2445 (together with #2642)
