### PR TITLE
send expected epoch along when calling SubmitTx

### DIFF
--- a/.changelog/2650.breaking.md
+++ b/.changelog/2650.breaking.md
@@ -1,0 +1,8 @@
+Send and check expected epoch number during transaction execution
+
+Stress tests revealed some race conditions during transaction execution when
+there is an epoch transition. Runtime client now sends `expectedEpochNumber`
+parameter in `SubmitTx` call. The transaction scheduler checks whether the
+expected epoch matches its local one. Additionally, if state transition occurs
+during transaction execution, Executor and Merge committee correctly abort the
+transaction.

--- a/.changelog/2650.internal.1.md
+++ b/.changelog/2650.internal.1.md
@@ -1,0 +1,12 @@
+Replace redundant fields with `Consensus` accessors
+
+`Backend` in `go/consensus/api` contains among others accessors for
+`Beacon`, `EpochTime`, `Registry`, `RootHash`, `Scheduler`, and
+`KeyManager`. Use those instead of direct references. The following
+structs were affected:
+
+- `Node` in `go/cmd/node`,
+- `Node` in `go/common/commmittee`,
+- `Worker` in `go/common`,
+- `clientCommon` in `go/runtime/client`,
+- `Group` in `go/worker/common/committee`.

--- a/.changelog/2650.internal.2.md
+++ b/.changelog/2650.internal.2.md
@@ -1,0 +1,1 @@
+e2e/multiple-runtimes: Enable `EpochtimeMock`, add `numComputeWorkers`

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -62,7 +62,7 @@ var (
 
 	// CommitteeProtocol versions the P2P protocol used by the
 	// committee members.
-	CommitteeProtocol = Version{Major: 0, Minor: 7, Patch: 0}
+	CommitteeProtocol = Version{Major: 0, Minor: 8, Patch: 0}
 
 	// ConsensusProtocol versions all data structures and processing used by
 	// the epochtime, beacon, registry, roothash, etc. modules that are

--- a/go/control/debug.go
+++ b/go/control/debug.go
@@ -2,6 +2,7 @@ package control
 
 import (
 	"context"
+	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
 
 	"github.com/oasislabs/oasis-core/go/control/api"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
@@ -62,9 +63,9 @@ Loop:
 }
 
 // New creates a new oasis-node debug controller.
-func NewDebug(timeSource epochtime.Backend, registry registry.Backend) api.DebugController {
+func NewDebug(consensus consensus.Backend) api.DebugController {
 	return &debugController{
-		timeSource: timeSource,
-		registry:   registry,
+		timeSource: consensus.EpochTime(),
+		registry:   consensus.Registry(),
 	}
 }

--- a/go/epochtime/api/api.go
+++ b/go/epochtime/api/api.go
@@ -18,10 +18,10 @@ const EpochInvalid EpochTime = 0xffffffffffffffff // ~50 quadrillion years away.
 
 // Backend is a timekeeping implementation.
 type Backend interface {
-	// GetBaseEPoch returns the base epoch.
+	// GetBaseEpoch returns the base epoch.
 	GetBaseEpoch(context.Context) (EpochTime, error)
 
-	// GetEpoch returns the epoch at the specified block height.
+	// GetEpoch returns the epoch number at the specified block height.
 	// Calling this method with height `0`, should return the
 	// epoch of latest known block.
 	GetEpoch(context.Context, int64) (EpochTime, error)

--- a/go/worker/common/worker.go
+++ b/go/worker/common/worker.go
@@ -13,10 +13,7 @@ import (
 	genesis "github.com/oasislabs/oasis-core/go/genesis/api"
 	ias "github.com/oasislabs/oasis-core/go/ias/api"
 	keymanagerApi "github.com/oasislabs/oasis-core/go/keymanager/api"
-	registry "github.com/oasislabs/oasis-core/go/registry/api"
-	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
 	runtimeRegistry "github.com/oasislabs/oasis-core/go/runtime/registry"
-	scheduler "github.com/oasislabs/oasis-core/go/scheduler/api"
 	"github.com/oasislabs/oasis-core/go/worker/common/committee"
 	"github.com/oasislabs/oasis-core/go/worker/common/p2p"
 )
@@ -27,9 +24,6 @@ type Worker struct {
 	cfg     Config
 
 	Identity          *identity.Identity
-	Roothash          roothash.Backend
-	Registry          registry.Backend
-	Scheduler         scheduler.Backend
 	Consensus         consensus.Backend
 	Grpc              *grpc.Server
 	GrpcPolicyWatcher policyAPI.PolicyWatcher
@@ -186,9 +180,6 @@ func (w *Worker) NewUnmanagedCommitteeNode(runtime runtimeRegistry.Runtime, enab
 		runtime,
 		w.Identity,
 		w.KeyManager,
-		w.Roothash,
-		w.Registry,
-		w.Scheduler,
 		w.Consensus,
 		p2p,
 	)
@@ -217,9 +208,6 @@ func newWorker(
 	dataDir string,
 	enabled bool,
 	identity *identity.Identity,
-	roothash roothash.Backend,
-	registryInst registry.Backend,
-	scheduler scheduler.Backend,
 	consensus consensus.Backend,
 	grpc *grpc.Server,
 	grpcPolicyWatcher policyAPI.PolicyWatcher,
@@ -234,9 +222,6 @@ func newWorker(
 		enabled:           enabled,
 		cfg:               cfg,
 		Identity:          identity,
-		Roothash:          roothash,
-		Registry:          registryInst,
-		Scheduler:         scheduler,
 		Consensus:         consensus,
 		Grpc:              grpc,
 		GrpcPolicyWatcher: grpcPolicyWatcher,
@@ -268,9 +253,6 @@ func New(
 	dataDir string,
 	enabled bool,
 	identity *identity.Identity,
-	roothash roothash.Backend,
-	registry registry.Backend,
-	scheduler scheduler.Backend,
 	consensus consensus.Backend,
 	p2p *p2p.P2P,
 	ias ias.Endpoint,
@@ -301,9 +283,6 @@ func New(
 		dataDir,
 		enabled,
 		identity,
-		roothash,
-		registry,
-		scheduler,
 		consensus,
 		grpc,
 		grpcPolicyWatcher,

--- a/go/worker/compute/txnscheduler/api/api.go
+++ b/go/worker/compute/txnscheduler/api/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/errors"
+	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 )
 
 // ModuleName is the transaction scheduler module name.
@@ -26,6 +27,9 @@ var (
 
 	// ErrCheckTxFailed is the error returned when CheckTx fails.
 	ErrCheckTxFailed = errors.New(ModuleName, 4, "txnscheduler: CheckTx failed")
+
+	// ErrEpochNumberMismatch is the error returned when epoch of client and compute node mismatch.
+	ErrEpochNumberMismatch = errors.New(ModuleName, 5, "txnscheduler: epoch number mismatch")
 )
 
 // TransactionScheduler is the transaction scheduler API interface.
@@ -41,8 +45,9 @@ type TransactionScheduler interface {
 
 // SubmitTxRequest is a SubmitTx request.
 type SubmitTxRequest struct {
-	RuntimeID common.Namespace `json:"runtime_id"`
-	Data      []byte           `json:"data"`
+	RuntimeID           common.Namespace    `json:"runtime_id"`
+	ExpectedEpochNumber epochtime.EpochTime `json:"expected_epoch_number"`
+	Data                []byte              `json:"data"`
 }
 
 // SubmitTxResponse is a SubmitTx response.

--- a/go/worker/compute/txnscheduler/service.go
+++ b/go/worker/compute/txnscheduler/service.go
@@ -15,7 +15,7 @@ func (w *Worker) SubmitTx(ctx context.Context, rq *api.SubmitTxRequest) (*api.Su
 		return nil, api.ErrUnknownRuntime
 	}
 
-	if err := runtime.QueueCall(ctx, rq.Data); err != nil {
+	if err := runtime.QueueCall(ctx, rq.ExpectedEpochNumber, rq.Data); err != nil {
 		return nil, err
 	}
 	return &api.SubmitTxResponse{}, nil

--- a/go/worker/compute/txnscheduler/tests/tester.go
+++ b/go/worker/compute/txnscheduler/tests/tester.go
@@ -95,7 +95,8 @@ func testQueueCall(
 
 	// Queue a test call.
 	testCall := []byte("hello world")
-	err = rtNode.QueueCall(context.Background(), testCall)
+	testEpochNumber := epochtime.EpochTime(2)
+	err = rtNode.QueueCall(context.Background(), testEpochNumber, testCall)
 	require.NoError(t, err, "QueueCall")
 
 	// Node should transition to WaitingForFinalize state.

--- a/go/worker/keymanager/worker.go
+++ b/go/worker/keymanager/worker.go
@@ -360,7 +360,7 @@ func (w *Worker) worker() { // nolint: gocyclo
 	// are using us as a key manager.
 	clientRuntimes := make(map[common.Namespace]*clientRuntimeWatcher)
 	clientRuntimesQuitCh := make(chan *clientRuntimeWatcher)
-	rtCh, rtSub, err := w.commonWorker.Registry.WatchRuntimes(w.ctx)
+	rtCh, rtSub, err := w.commonWorker.Consensus.Registry().WatchRuntimes(w.ctx)
 	if err != nil {
 		w.logger.Error("failed to watch runtimes",
 			"err", err,
@@ -564,7 +564,7 @@ func (crw *clientRuntimeWatcher) updateExternalServicePolicyLocked(snapshot *com
 		var kmNodes []*node.Node
 
 		for _, pk := range status.Nodes {
-			n, err := crw.node.Registry.GetNode(crw.w.ctx, &registry.IDQuery{ID: pk, Height: height})
+			n, err := crw.node.Consensus.Registry().GetNode(crw.w.ctx, &registry.IDQuery{ID: pk, Height: height})
 			if err != nil {
 				crw.w.logger.Error("worker/keymanager: unable to get KM node info", "err", err)
 			} else {

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -226,7 +226,7 @@ func NewNode(
 	copy(ns[:], runtimeID[:])
 
 	// Create a new storage client that will be used for remote sync.
-	scl, err := client.New(node.ctx, ns, node.commonNode.Identity, node.commonNode.Scheduler, node.commonNode.Registry)
+	scl, err := client.New(node.ctx, ns, node.commonNode.Identity, node.commonNode.Consensus.Scheduler(), node.commonNode.Consensus.Registry())
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +300,7 @@ func (n *Node) updateExternalServicePolicyLocked(snapshot *committee.EpochSnapsh
 	}
 	// TODO: Query registry only for storage nodes after
 	// https://github.com/oasislabs/oasis-core/issues/1923 is implemented.
-	nodes, err := n.commonNode.Registry.GetNodes(context.Background(), snapshot.GetGroupVersion())
+	nodes, err := n.commonNode.Consensus.Registry().GetNodes(context.Background(), snapshot.GetGroupVersion())
 	if nodes != nil {
 		storageNodesPolicy.AddRulesForNodeRoles(&policy, nodes, node.RoleStorageWorker)
 	} else {
@@ -364,7 +364,7 @@ func (n *Node) ForceFinalize(ctx context.Context, round uint64) error {
 	var err error
 
 	if round == RoundLatest {
-		block, err = n.commonNode.Roothash.GetLatestBlock(ctx, n.commonNode.Runtime.ID(), consensus.HeightLatest)
+		block, err = n.commonNode.Consensus.RootHash().GetLatestBlock(ctx, n.commonNode.Runtime.ID(), consensus.HeightLatest)
 	} else {
 		block, err = n.commonNode.Runtime.History().GetBlock(ctx, round)
 	}
@@ -478,7 +478,7 @@ func (n *Node) worker() { // nolint: gocyclo
 
 	n.logger.Info("starting committee node")
 
-	genesisBlock, err := n.commonNode.Roothash.GetGenesisBlock(n.ctx, n.commonNode.Runtime.ID(), consensus.HeightLatest)
+	genesisBlock, err := n.commonNode.Consensus.RootHash().GetGenesisBlock(n.ctx, n.commonNode.Runtime.ID(), consensus.HeightLatest)
 	if err != nil {
 		n.logger.Error("can't retrieve genesis block", "err", err)
 		return


### PR DESCRIPTION
PR for #1062: 
- runtime/client: add expectedEpochNumber parameter to SubmitTx call,
- txnscheduler/committee/node: check whether expectedEpochNumber matches the local one,
- executor/node, merge/node: abort, if state change detected,
- e2e/multiple-runtimes:
  - reduce all group sizes to 1 with no backups,
  - use epochTime mock,
  - add new numComputeWorkers parameter,
- cmd/node/node.go, common/commmittee/node.go, common/worker.go, runtime/client/client.go, worker/common/committee/group.go: access `RootHash`, `Scheduler`, `Beacon`, `KeyManager`, `EpochTime`, and `Registry` fields indirectly using `consensus` member.