### PR TITLE
go oasis-node: use references to update genesis doc

### DIFF
--- a/go/oasis-node/cmd/debug/fixgenesis/fixgenesis.go
+++ b/go/oasis-node/cmd/debug/fixgenesis/fixgenesis.go
@@ -179,7 +179,7 @@ func updateGenesisDoc(oldDoc *oldDocument) (*genesis.Document, error) {
 	}
 
 	// This currently is entirely registry genesis state changes.
-	oldReg, newReg := oldDoc.Registry, newDoc.Registry
+	oldReg, newReg := &oldDoc.Registry, &newDoc.Registry
 
 	// First copy the registry things that have not changed.
 	newReg.Parameters = oldReg.Parameters


### PR DESCRIPTION
registry doc was coming out empty due to this