### PR TITLE
go: Disable additional signature verification for migration

### DIFF
--- a/.changelog/2652.bugfix.md
+++ b/.changelog/2652.bugfix.md
@@ -1,0 +1,4 @@
+go: Disable additional signature verification for migration
+
+Some places were missed when signature verification was disabled for the
+purpose of migration.

--- a/go/consensus/tendermint/seed.go
+++ b/go/consensus/tendermint/seed.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tendermint/tendermint/types"
 	"github.com/tendermint/tendermint/version"
 
+	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/node"
@@ -162,8 +163,14 @@ func populateAddrBookFromGenesis(addrBook p2p.AddrBook, doc *genesis.Document, o
 	var addrs []*p2p.NetAddress
 	for _, v := range doc.Registry.Nodes {
 		var openedNode node.Node
-		if err := v.Open(registry.RegisterGenesisNodeSignatureContext, &openedNode); err != nil {
-			return errors.Wrap(err, "tendermint/seed: failed to verify validator")
+		if isOldNode(v) {
+			if err := cbor.Unmarshal(v.Blob, &openedNode); err != nil {
+				return errors.Wrap(err, "tendermint/seed: failed to unmarshal old-format validator")
+			}
+		} else {
+			if err := v.Open(registry.RegisterGenesisNodeSignatureContext, &openedNode); err != nil {
+				return errors.Wrap(err, "tendermint/seed: failed to verify validator")
+			}
 		}
 		// TODO: This should cross check that the entity is valid.
 		if !openedNode.HasRoles(node.RoleValidator) {

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -1029,6 +1029,12 @@ func (t *tendermintService) lazyInit() error {
 	return nil
 }
 
+func isOldNode(sigNode *node.MultiSignedNode) bool {
+	// Nodes signed before v20.3 are allowed in the genesis document,
+	// but they aren't validly signed by the current rules.
+	return len(sigNode.MultiSigned.Signatures) < 2
+}
+
 // genesisToTendermint converts the Oasis genesis block to Tendermint's format.
 func genesisToTendermint(d *genesisAPI.Document) (*tmtypes.GenesisDoc, error) {
 	// WARNING: The AppState MUST be encoded as JSON since its type is
@@ -1071,8 +1077,14 @@ func genesisToTendermint(d *genesisAPI.Document) (*tmtypes.GenesisDoc, error) {
 	var tmValidators []tmtypes.GenesisValidator
 	for _, v := range d.Registry.Nodes {
 		var openedNode node.Node
-		if err := v.Open(registryAPI.RegisterGenesisNodeSignatureContext, &openedNode); err != nil {
-			return nil, fmt.Errorf("tendermint: failed to verify validator: %w", err)
+		if isOldNode(v) {
+			if err := cbor.Unmarshal(v.Blob, &openedNode); err != nil {
+				return nil, fmt.Errorf("tendermint: failed to unmarshal old-format validator: %w", err)
+			}
+		} else {
+			if err := v.Open(registryAPI.RegisterGenesisNodeSignatureContext, &openedNode); err != nil {
+				return nil, fmt.Errorf("tendermint: failed to verify validator: %w", err)
+			}
 		}
 		// TODO: This should cross check that the entity is valid.
 		if !openedNode.HasRoles(node.RoleValidator) {

--- a/go/oasis-node/cmd/debug/fixgenesis/fixgenesis.go
+++ b/go/oasis-node/cmd/debug/fixgenesis/fixgenesis.go
@@ -179,7 +179,7 @@ func updateGenesisDoc(oldDoc *oldDocument) (*genesis.Document, error) {
 	}
 
 	// This currently is entirely registry genesis state changes.
-	oldReg, newReg := oldDoc.Registry, newDoc.Registry
+	oldReg, newReg := &oldDoc.Registry, &newDoc.Registry
 
 	// First copy the registry things that have not changed.
 	newReg.Parameters = oldReg.Parameters

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -601,11 +601,11 @@ func VerifyRegisterNodeArgs( // nolint: gocyclo
 		)
 		return nil, nil, err
 	}
-	certPub, err := verifyNodeCertificate(logger, &n)
-	if err != nil {
-		return nil, nil, err
-	}
 	if !isOldNode {
+		certPub, err := verifyNodeCertificate(logger, &n)
+		if err != nil {
+			return nil, nil, err
+		}
 		if !sigNode.MultiSigned.IsSignedBy(certPub) {
 			logger.Error("RegisterNode: not signed by TLS certificate key",
 				"signed_node", sigNode,
@@ -634,7 +634,7 @@ func VerifyRegisterNodeArgs( // nolint: gocyclo
 		expectedSigners = append(expectedSigners, n.P2P.ID)
 	}
 	p2pAddressRequired := n.HasRoles(P2PAddressRequiredRoles)
-	if err = verifyAddresses(params, p2pAddressRequired, n.P2P.Addresses); err != nil {
+	if err := verifyAddresses(params, p2pAddressRequired, n.P2P.Addresses); err != nil {
 		addrs, _ := json.Marshal(n.P2P.Addresses)
 		logger.Error("RegisterNode: missing/invald P2P addresses",
 			"node", n,


### PR DESCRIPTION
Some places were missed when signature verification was disabled for the
purpose of migration.