### PR TITLE
Add markdownlint

### DIFF
--- a/.changelog/.markdownlint.yml
+++ b/.changelog/.markdownlint.yml
@@ -1,0 +1,22 @@
+# markdownlint configuration for Change Log fragments.
+
+# For more information, see:
+# https://github.com/DavidAnson/markdownlint#optionsconfig.
+
+# Extend project's main configuration.
+extends: ../.markdownlint.yml
+
+line-length:
+  # Line length checking is not strict by default.
+  strict: true
+  # Change Log fragments will be listed as bullets indented by 2 spaces so they
+  # should be 2 characters shorter than ordinary lines.
+  line_length: 78
+
+# Change Log fragments should not have a heading as the first line.
+first-line-heading: false
+
+ul-style:
+  # Enforce a uniform symbol for unordered lists across all Change Log
+  # fragments.
+  style: dash

--- a/.changelog/2406.breaking.md
+++ b/.changelog/2406.breaking.md
@@ -1,1 +1,1 @@
-go/registry: Enable non-genesis runtime registrations by default.
+go/registry: Enable non-genesis runtime registrations by default

--- a/.changelog/2572.internal.md
+++ b/.changelog/2572.internal.md
@@ -1,0 +1,4 @@
+github: Add new steps to ci-lint workflow
+
+Add _Lint Markdown files_ and _Lint Change Log fragments_ steps to ci-lint
+GitHub Actions workflow.

--- a/.changelog/2638.breaking.md
+++ b/.changelog/2638.breaking.md
@@ -1,1 +1,1 @@
-Optionally require a deposit for registering a runtime.
+Optionally require a deposit for registering a runtime

--- a/.changelog/2642.breaking.1.md
+++ b/.changelog/2642.breaking.1.md
@@ -1,1 +1,1 @@
-go/registry: Add explicit EntityID field to Runtime descriptors.
+go/registry: Add explicit EntityID field to Runtime descriptors

--- a/.changelog/2642.breaking.2.md
+++ b/.changelog/2642.breaking.2.md
@@ -1,9 +1,12 @@
 go/staking: Add stateful stake accumulator.
 
-Previously there was no central place to account for all the parts that need to claim some part of
-an entity's stake which required approximations all around.
+Previously there was no central place to account for all the parts that need
+to claim some part of an entity's stake which required approximations all
+around.
 
-This is now changed and a stateful stake accumulator is added to each escrow account. The stake
-accumulator is used to track stake claims from different apps (currently only the registry).
+This is now changed and a stateful stake accumulator is added to each escrow
+account. The stake accumulator is used to track stake claims from different
+apps (currently only the registry).
 
-This change also means that node registration will now always require the correct amount of stake.
+This change also means that node registration will now always require the
+correct amount of stake.

--- a/.changelog/2642.breaking.2.md
+++ b/.changelog/2642.breaking.2.md
@@ -1,4 +1,4 @@
-go/staking: Add stateful stake accumulator.
+go/staking: Add stateful stake accumulator
 
 Previously there was no central place to account for all the parts that need
 to claim some part of an entity's stake which required approximations all

--- a/.changelog/2647.breaking.md
+++ b/.changelog/2647.breaking.md
@@ -1,4 +1,4 @@
 staking: More reward for more signatures.
 
-We're adjusting fee distribution and the block proposing staking reward to incentivize proposers
-to create blocks with more signatures.
+We're adjusting fee distribution and the block proposing staking reward to
+incentivize proposers to create blocks with more signatures.

--- a/.changelog/2647.breaking.md
+++ b/.changelog/2647.breaking.md
@@ -1,4 +1,4 @@
-staking: More reward for more signatures.
+staking: More reward for more signatures
 
 We're adjusting fee distribution and the block proposing staking reward to
 incentivize proposers to create blocks with more signatures.

--- a/.changelog/2662.internal.1.md
+++ b/.changelog/2662.internal.1.md
@@ -1,0 +1,7 @@
+Make: Add lint targets
+
+Add a general `lint` target that depends on the following lint targets:
+
+- `lint-go`: Lint Go code,
+- `lint-md`: Lint Markdown files (except Change Log fragments),
+- `lint-changelog`: Lint Change Log fragments.

--- a/.changelog/2662.internal.2.md
+++ b/.changelog/2662.internal.2.md
@@ -1,0 +1,4 @@
+changelog: Use Git commit message style for Change Log fragments
+
+For more details, see the description in [Change Log fragments](
+.changelog/README.md).

--- a/.changelog/README.md
+++ b/.changelog/README.md
@@ -1,14 +1,14 @@
 # Change Log fragments
 
 This directory collects Change Log fragments:
-short files that each contain a snippet of MarkDown formatted text that will be
-assembled using [towncrier] to form the [Change Log] section for the next
+short files that each contain a snippet of MarkDown formatted text that will
+be assembled using [towncrier] to form the [Change Log] section for the next
 release.
 
 ## Description
 
-A Change Log fragment should be a description of aspects of the change (if any)
-that are relevant to users.
+A Change Log fragment should be a description of aspects of the change (if
+any) that are relevant to users.
 
 _NOTE: This could be very different from the commit message and pull request
 description, which are a description of the change as relevant to the people
@@ -24,13 +24,13 @@ The description could use one of the following two formats:
   ```text
   Remove staking-related roothash messages.
 
-  There is no longer a plan to support direct manipulation of the staking accounts
-  from the runtimes in order to isolate the runtimes from corrupting the
-  consensus layer.
+  There is no longer a plan to support direct manipulation of the staking
+  accounts from the runtimes in order to isolate the runtimes from corrupting
+  the consensus layer.
 
-  To reduce complexity, the staking-related roothash messages were removed. The
-  general roothash message mechanism stayed as-is since it may be useful in the
-  future, but any commits with non-empty messages are rejected for now.
+  To reduce complexity, the staking-related roothash messages were removed.
+  The general roothash message mechanism stayed as-is since it may be useful
+  in the future, but any commits with non-empty messages are rejected for now.
   ```
 
 - Shorter multi-line change description.
@@ -42,8 +42,8 @@ The description could use one of the following two formats:
   freshly provisioned state, preserving any key material if it exists.
   ```
 
-_NOTE: Don't put links to issue(s)/pull request in your text as the [towncrier]
-tool will add them automatically._
+_NOTE: Don't put links to issue(s)/pull request in your text as the
+[towncrier] tool will add them automatically._
 
 ## File name
 
@@ -60,9 +60,9 @@ where:
 
   If your pull request closes an issue, use that number here.
 
-  If there is no issue for the change you've implemented, then after you submit
-  the pull request and get your pull request number, amend your commit(s) with an
-  appropriately named Change Log fragment.
+  If there is no issue for the change you've implemented, then after you
+  submit the pull request and get your pull request number, amend your
+  commit(s) with an appropriately named Change Log fragment.
 
 - `<TYPE>` is one of:
 
@@ -76,9 +76,9 @@ where:
   - `trivial`: a trivial change that is _not_ included in the Change Log.
 
 - `.<COUNTER>` part is optional and can be used when a single issue or pull
-  request needs multiple Change Log fragments. For example, when a pull request
-  contains multiple bug fixes and each bug fix deserves a separate Change Log
-  fragment describing what it fixes.
+  request needs multiple Change Log fragments. For example, when a pull
+  request contains multiple bug fixes and each bug fix deserves a separate
+  Change Log fragment describing what it fixes.
 
 Example file names:
 

--- a/.changelog/README.md
+++ b/.changelog/README.md
@@ -1,7 +1,7 @@
 # Change Log fragments
 
 This directory collects Change Log fragments:
-short files that each contain a snippet of MarkDown formatted text that will
+short files that each contain a snippet of Markdown formatted text that will
 be assembled using [towncrier] to form the [Change Log] section for the next
 release.
 
@@ -14,36 +14,32 @@ _NOTE: This could be very different from the commit message and pull request
 description, which are a description of the change as relevant to the people
 working on the code itself._
 
-The description could use one of the following two formats:
+The description should follow the familiar [style of Git commit messages],
+i.e. a separate subject line giving the change's summary, followed by a more
+detailed explanation in the body.
 
-- One line change summary followed by an empty line and a more detailed
-  explanation in the body.
+In case of simpler descriptions, one can omit the description's body.
 
-  For example:
+_NOTE: Lines should be wrapped at 78 characters because Change Log fragments
+will be listed as bullets indented by 2 spaces so they should be 2 characters
+shorter than ordinary lines._
 
-  ```text
-  Remove staking-related roothash messages.
+An example:
 
-  There is no longer a plan to support direct manipulation of the staking
-  accounts from the runtimes in order to isolate the runtimes from corrupting
-  the consensus layer.
+```text
+Remove staking-related roothash messages
 
-  To reduce complexity, the staking-related roothash messages were removed.
-  The general roothash message mechanism stayed as-is since it may be useful
-  in the future, but any commits with non-empty messages are rejected for now.
-  ```
+There is no longer a plan to support direct manipulation of the staking
+accounts from the runtimes in order to isolate the runtimes from corrupting
+the consensus layer.
 
-- Shorter multi-line change description.
+To reduce complexity, the staking-related roothash messages were removed.
+The general roothash message mechanism stayed as-is since it may be useful in
+the future, but any commits with non-empty messages are rejected for now.
+```
 
-  For example:
-
-  ```text
-  Add `oasis-node unsafe-reset` sub-command which resets the node back to a
-  freshly provisioned state, preserving any key material if it exists.
-  ```
-
-_NOTE: Don't put links to issue(s)/pull request in your text as the
-[towncrier] tool will add them automatically._
+_NOTE: The [towncrier] tool will automatically augment each subject line with
+a link to an appropriate issue/pull request._
 
 ## File name
 
@@ -113,3 +109,4 @@ _NOTE: You can use any version for the preview, it doesn't really matter._
 [Change Log]: ../CHANGELOG.md
 [towncrier]: https://github.com/hawkowl/towncrier
 [Oasis Labs' towncrier fork]: https://github.com/oasislabs/towncrier
+[style of Git commit messages]: ../CONTRIBUTING.md#git-commit-messages

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -26,9 +26,15 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up Python 3
         uses: actions/setup-python@v1
+      - name: Set up Node.js 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
       - name: Install prerequisites
         run: |
-          python -m pip install https://github.com/oasislabs/towncrier/archive/oasis-master.tar.gz
+          python -m pip install \
+            https://github.com/oasislabs/towncrier/archive/oasis-master.tar.gz \
+            gitlint
       - name: Check for presence of a Change Log fragment (only pull requests)
         run: |
           # Fetch the pull request' base branch so towncrier will be able to
@@ -39,3 +45,13 @@ jobs:
         env:
           BASE_BRANCH: ${{ github.base_ref }}
         if: github.event_name == 'pull_request'
+      - name: Lint Markdown files
+        run: |
+          make lint-md
+        # Always run this step so that all linting errors can be seen at once.
+        if: always()
+      - name: Lint Change Log fragments
+        run: |
+          make lint-changelog
+        # Always run this step so that all linting errors can be seen at once.
+        if: always()

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,18 @@
+# markdownlint configuration.
+
+# For more information, see:
+# https://github.com/DavidAnson/markdownlint#optionsconfig.
+
+# Enable all rules.
+default: true
+
+line-length:
+  # Line length checking is not strict by default.
+  strict: true
+  line_length: 80
+  # Allow longer lines for code blocks.
+  code_block_line_length: 100
+
+# Do not always require language specifiers with fenced code blocks since they
+# are not part of the Markdown spec.
+fenced-code-language: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is inspired by [Keep a Changelog].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 
+<!-- markdownlint-disable no-duplicate-heading -->
+
 <!-- NOTE: towncrier will not alter content above the TOWNCRIER line below. -->
 
 <!-- TOWNCRIER -->
@@ -262,8 +264,7 @@ The format is inspired by [Keep a Changelog].
 
   Add `-buildid=` back to `ldflags` to make builds reproducible again.
 
-  As noted in [60641ce](
-  https://github.com/oasislabs/oasis-core/commit/60641ce41a9c2402f1b539375e1dd4e0eb45272d),
+  As noted in [60641ce](https://github.com/oasislabs/oasis-core/commit/60641ce),
   this should be no longer necessary with Go 1.13.4+, but there appears to be a
   [specific issue with GoReleaser's build handling](
   https://github.com/oasislabs/goreleaser/issues/1).
@@ -347,12 +348,11 @@ The format is inspired by [Keep a Changelog].
   This makes it easier to write unit tests for functions that require ABCI
   state.
 
-
 ## 20.2 (2020-01-21)
 
 ### Removals and Breaking changes
 
-- go node: Unite compute, merge, and transaction scheduler roles.
+- go node: Unite compute, merge, and transaction scheduler roles
   ([#2107](https://github.com/oasislabs/oasis-core/issues/2107))
 
   We're removing the separation among registering nodes for the compute, merge,
@@ -367,12 +367,12 @@ The format is inspired by [Keep a Changelog].
   - `worker.sentry.address` renamed to: `worker.registration.sentry.address`
   - `worker.sentry.cert_file` renamed to: `worker.registration.sentry.cert_file`
   - `tendermint.private_peer_id` removed
-  - added `tendermint.sentry.upstream_address` which should be set on sentry node
-  and it will set `tendermint.private_peer_id` and `tendermint.peristent_peer` for
-  the configured addresses
+  - added `tendermint.sentry.upstream_address` which should be set on sentry
+    node and it will set `tendermint.private_peer_id` and
+    `tendermint.peristent_peer` for the configured addresses
 
 - Charge gas for runtime transactions and suspend runtimes which do not pay
-  periodic maintenance fees.
+  periodic maintenance fees
   ([#2504](https://github.com/oasislabs/oasis-core/issues/2504))
 
   This introduces gas fees for submitting roothash commitments from runtime
@@ -384,7 +384,7 @@ The format is inspired by [Keep a Changelog].
   If the maintenance fees are not paid, the runtime gets suspended (so periodic
   work is not needed) and must be resumed by registering nodes.
 
-- go: Rename compute -> executor.
+- go: Rename compute -> executor
   ([#2525](https://github.com/oasislabs/oasis-core/issues/2525))
 
   It was proposed that we rename the "compute" phase (of the txnscheduler,
@@ -400,10 +400,12 @@ The format is inspired by [Keep a Changelog].
   So among things that are renamed are fields of the on-chain state and command
   line flags.
 
-- `RuntimeID` is not hardcoded anymore in the enclave, but is passed when
-  dispatching the runtime. This enables the same runtime binary to be registered
-  and executed multiple times with different `RuntimeID`.
+- `RuntimeID` is not hard-coded in the enclave anymore
   ([#2529](https://github.com/oasislabs/oasis-core/issues/2529))
+
+  It is passed when dispatching the runtime. This enables the same runtime
+  binary to be registered and executed multiple times with different
+  `RuntimeID`.
 
 ### Features
 
@@ -424,7 +426,7 @@ The format is inspired by [Keep a Changelog].
     fee would ever go over this limit, the transaction will not be submitted and
     an error will be returned instead.
 
-- Optimize registry runtime lookups during node registration.
+- Optimize registry runtime lookups during node registration
   ([#2538](https://github.com/oasislabs/oasis-core/issues/2538))
 
   A performance optimization to avoid loading a list of all registered runtimes
@@ -432,13 +434,13 @@ The format is inspired by [Keep a Changelog].
 
 ### Bug Fixes
 
-- Don't allow duplicate P2P connections from the same IP by default.
+- Don't allow duplicate P2P connections from the same IP by default
   ([#2558](https://github.com/oasislabs/oasis-core/issues/2558))
 
 - go/extra/stats: handle nil-votes and non-registered nodes
   ([#2566](https://github.com/oasislabs/oasis-core/issues/2566))
 
-- go/oasis-node: Include account ID in `stake list -v` subcommand.
+- go/oasis-node: Include account ID in `stake list -v` subcommand
   ([#2567](https://github.com/oasislabs/oasis-core/issues/2567))
 
   Changes `stake list -v` subcommand to return a map of IDs to accounts.
@@ -467,7 +469,6 @@ The format is inspired by [Keep a Changelog].
 
   See [Release process](./docs/release-process.md).
 
-
 ## 20.1 (2020-01-14)
 
 ### Features
@@ -482,15 +483,15 @@ The format is inspired by [Keep a Changelog].
 
 ### Bug Fixes
 
-- go/runtime/client: Return empty sequences instead of nil.
+- go/runtime/client: Return empty sequences instead of nil
   ([#2542](https://github.com/oasislabs/oasis-core/issues/2542))
 
-  The runtime client endpoint should return empty sequences instead of `nil` as serde doesn't know how
-  to decode a `NULL` when the expected type is a sequence.
+  The runtime client endpoint should return empty sequences instead of `nil` as
+  serde doesn't know how to decode a `NULL` when the expected type is a
+  sequence.
 
 - Temporarily disable consensus address checks at genesis
   ([#2552](https://github.com/oasislabs/oasis-core/issues/2552))
-
 
 ## 20.0 (2020-01-10)
 
@@ -504,81 +505,84 @@ The format is inspired by [Keep a Changelog].
   forbid registering runtimes that have test runtime IDs unless the
   appropriate consensus flag is set.
 
-- Remove staking-related roothash messages.
+- Remove staking-related roothash messages
   ([#2377](https://github.com/oasislabs/oasis-core/issues/2377))
 
-  There is no longer a plan to support direct manipulation of the staking accounts
-  from the runtimes in order to isolate the runtimes from corrupting the
-  consensus layer.
+  There is no longer a plan to support direct manipulation of the staking
+  accounts from the runtimes in order to isolate the runtimes from corrupting
+  the consensus layer.
 
   To reduce complexity, the staking-related roothash messages were removed. The
   general roothash message mechanism stayed as-is since it may be useful in the
   future, but any commits with non-empty messages are rejected for now.
 
-- Refactoring of roothash genesis block for runtime.
+- Refactoring of roothash genesis block for runtime
   ([#2426](https://github.com/oasislabs/oasis-core/issues/2426))
 
   - `RuntimeGenesis.Round` field was added to the roothash block for the runtime
-  which can be set by `--runtime.genesis.round` flag.
-  - The `RuntimeGenesis.StorageReceipt` field was replaced by `StorageReceipts` list,
-  one for each storage node.
+    which can be set by `--runtime.genesis.round` flag.
+  - The `RuntimeGenesis.StorageReceipt` field was replaced by `StorageReceipts`
+    list, one for each storage node.
   - Support for `base64` encoding/decoding of `Bytes` was added in rust.
 
 - When registering a new runtime, require that the given key manager ID points
-  to a valid key manager in the registry.
+  to a valid key manager in the registry
   ([#2459](https://github.com/oasislabs/oasis-core/issues/2459))
 
-- Remove `oasis-node debug dummy` sub-commands.
+- Remove `oasis-node debug dummy` sub-commands
   ([#2492](https://github.com/oasislabs/oasis-core/issues/2492))
 
   These are only useful for testing, and our test harness has a internal Go API
   that removes the need to have this functionality exposed as a sub-command.
 
-- Make storage per-runtime.
+- Make storage per-runtime
   ([#2494](https://github.com/oasislabs/oasis-core/issues/2494))
 
-  Previously there was a single storage backend used by `oasis-node` which required that a single
-  database supported multiple namespaces for the case when multiple runtimes were being used in a
-  single node.
+  Previously there was a single storage backend used by `oasis-node` which
+  required that a single database supported multiple namespaces for the case
+  when multiple runtimes were being used in a single node.
 
-  This change simplifies the storage database backends by removing the need for backends to implement
-  multi-namespace support, reducing overhead and cleanly separating per-runtime state.
+  This change simplifies the storage database backends by removing the need for
+  backends to implement multi-namespace support, reducing overhead and cleanly
+  separating per-runtime state.
 
-  Due to this changing the internal database format, this breaks previous (compute node) deployments
-  with no way to do an automatic migration.
+  Due to this changing the internal database format, this breaks previous
+  (compute node) deployments with no way to do an automatic migration.
 
 ### Features
 
-- Add `oasis-node debug storage export` sub-command.
+- Add `oasis-node debug storage export` sub-command
   ([#1845](https://github.com/oasislabs/oasis-core/issues/1845))
 
-- Add fuzzing for consensus methods.
+- Add fuzzing for consensus methods
   ([#2245](https://github.com/oasislabs/oasis-core/issues/2245))
 
   Initial support for fuzzing was added, along with an implementation of
   it for some of the consensus methods. The implementation uses
   oasis-core's demultiplexing and method dispatch mechanisms.
 
-- Add storage backend fuzzing.
+- Add storage backend fuzzing
   ([#2246](https://github.com/oasislabs/oasis-core/issues/2246))
 
   Based on the work done for consensus fuzzing, support was added to run fuzzing
   jobs on the storage api backend.
 
 - Add `oasis-node unsafe-reset` sub-command which resets the node back to a
-  freshly provisioned state, preserving any key material if it exists.
+  freshly provisioned state, preserving any key material if it exists
   ([#2435](https://github.com/oasislabs/oasis-core/issues/2435))
 
-- Add txsource.
+- Add txsource
   ([#2478](https://github.com/oasislabs/oasis-core/issues/2478))
 
-  The so-called "txsource" utility introduced in this PR is a starting point for something like a client that sends
-  transactions for a long period of time, for the purpose of creating long-running tests.
+  The so-called "txsource" utility introduced in this PR is a starting point for
+  something like a client that sends transactions for a long period of time, for
+  the purpose of creating long-running tests.
 
-  With this change is a preliminary sample "workload"--a DRBG-backed schedule of transactions--which transfers staking
-  tokens around among a set of test accounts.
+  With this change is a preliminary sample "workload"--a DRBG-backed schedule of
+  transactions--which transfers staking tokens around among a set of test
+  accounts.
 
-- Add consensus block and transaction metadata accessors.
+- Add consensus block and transaction metadata accessors
   ([#2482](https://github.com/oasislabs/oasis-core/issues/2482))
 
   In order to enable people to build "network explorers", we exposed some
@@ -588,23 +592,26 @@ The format is inspired by [Keep a Changelog].
   - Access to raw consensus transactions within a block.
   - Stream of consensus blocks as they are finalized.
 
-- Make maximum in-memory cache size for runtime storage configurable.
+- Make maximum in-memory cache size for runtime storage configurable
   ([#2494](https://github.com/oasislabs/oasis-core/issues/2494))
 
-  Previously the value of 64mb was always used as the size of the in-memory storage cache. This adds a
-  new configuration parameter/command-line flag `--storage.max_cache_size` which configures the
-  maximum size of the in-memory runtime storage cache.
+  Previously the value of 64mb was always used as the size of the in-memory
+  storage cache. This adds a new configuration parameter/command-line flag
+  `--storage.max_cache_size` which configures the maximum size of the in-memory
+  runtime storage cache.
 
-- Undisable transfers for some senders.
+- Undisable transfers for some senders
   ([#2498](https://github.com/oasislabs/oasis-core/issues/2498))
 
-  Ostensibly for faucet purposes while we run the rest of the network with transfers disabled,
-  this lets us identify a whitelist of accounts from which we allow transfers when otherwise transfers are disabled.
+  Ostensibly for faucet purposes while we run the rest of the network with
+  transfers disabled, this lets us identify a whitelist of accounts from which
+  we allow transfers when otherwise transfers are disabled.
 
-  Configure this with a map of allowed senders' public keys -> `true` in the new `undisable_transfers_from` field in the
-  staking consensus parameters object along with `"disable_transfers": true`.
+  Configure this with a map of allowed senders' public keys -> `true` in the
+  new `undisable_transfers_from` field in the staking consensus parameters
+  object along with `"disable_transfers": true`.
 
-- Entity block signatures count tool.
+- Entity block signatures count tool
   ([#2500](https://github.com/oasislabs/oasis-core/issues/2500))
 
   The tool uses node consensus and registry API endpoints and computes the per
@@ -612,12 +619,11 @@ The format is inspired by [Keep a Changelog].
 
 ### Bug Fixes
 
-- Reduce Badger in-memory cache sizes.
+- Reduce Badger in-memory cache sizes
   ([#2484](https://github.com/oasislabs/oasis-core/issues/2484))
 
   The default is 1 GiB per badger instance and we use a few instances so this
   resulted in some nice memory usage.
-
 
 ## 19.0 (2019-12-18)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 Oasis Labs is building the next generation blockchain technology for scalable,
 privacy-preserving, and distributed applications/services.
 
-Thank you for your interest in contributing to Oasis Core! There are many ways to
-contribute, and this document should not be considered encompassing.
+Thank you for your interest in contributing to Oasis Core! There are many ways
+to contribute, and this document should not be considered encompassing.
 
 If you have a general question on how to use and deploy our software, please
 read our [Operator Docs](https://docs.oasis.dev/) or join our
@@ -13,13 +13,16 @@ read our [Operator Docs](https://docs.oasis.dev/) or join our
 For concrete feature requests and/or bug reports, please file an issue in this
 repository as described below.
 
+<!-- markdownlint-disable heading-increment -->
 #### Table of Contents
+<!-- markdownlint-enable heading-increment -->
 
 [Feature Requests](#feature-requests)
 
 [Bug Reports](#bug-reports)
 
 [Development](#development)
+
 * [Building](#building)
 * [Contributing Code](#contributing-code)
 * [Contributing Documentation](#contributing-documentation)
@@ -36,8 +39,8 @@ most effective at receiving input and making progress.
 If the feature is **small** - a change to a single piece of functionality, or an
 addition that can be expressed clearly and succinctly in a few sentences, then
 the most appropriate place to propose it is as a [new Feature request](
-https://github.com/oasislabs/oasis-core/issues/new?template=feature_request.md) in
-this repository.
+https://github.com/oasislabs/oasis-core/issues/new?template=feature_request.md)
+in this repository.
 Such issues will typically receive `p:3` priority in their initial triage.
 
 If the feature is **more complicated**, involves protocol changes, or has
@@ -86,13 +89,18 @@ https://github.com/oasislabs/oasis-core/blob/master/README.md).
   there.
   * Good habit: regularly rebase to the `HEAD` of `master` branch of the main
     repository to make sure you prevent nasty conflicts:
+
     ```bash
     git rebase <main-repo>/master
     ```
-  * Push your branch to GitHub regularly so others can see what you are working on:
+
+  * Push your branch to GitHub regularly so others can see what you are working
+    on:
+
     ```bash
     git push -u <main-repo-or-your-fork> <branch-name>
     ```
+
     _Note that you are allowed to force push into your development branches._
 
 * **Use draft pull requests for work-in-progress:**
@@ -187,6 +195,7 @@ Go code should use the standard `gofmt` formatting style. Be sure to run
 
 `gofmt` also does not check import order/grouping, so please ensure that you
 use the following convention:
+
 ```golang
 package foo
 
@@ -211,6 +220,7 @@ code.
 
 Similar as above for Go, `rustfmt` does not check import order/grouping, so
 please ensure that you use the following convention:
+
 ```rust
 // External crates.
 extern crate foo;

--- a/README.md
+++ b/README.md
@@ -1,17 +1,38 @@
 # Oasis Core
 
-[![Build status](https://badge.buildkite.com/15a8faccee0d5b5ab1af7e75eb6f9daf2d493c543fbc67dce5.svg?branch=master)](https://buildkite.com/oasislabs/oasis-core-ci)
-[![CI lint status](https://github.com/oasislabs/oasis-core/workflows/ci-lint/badge.svg)](https://github.com/oasislabs/oasis-core/actions?query=workflow:ci-lint)
-[![CI reproducibility status](https://github.com/oasislabs/oasis-core/workflows/ci-reproducibility/badge.svg)](https://github.com/oasislabs/oasis-core/actions?query=workflow:ci-reproducibility)
-[![Release status](https://github.com/oasislabs/oasis-core/workflows/release/badge.svg)](https://github.com/oasislabs/oasis-core/actions?query=workflow:release)
-[![Coverage Status](https://coveralls.io/repos/github/oasislabs/oasis-core/badge.svg?t=HsLWgi)](https://coveralls.io/github/oasislabs/oasis-core) Rust
-[![codecov](https://codecov.io/gh/oasislabs/oasis-core/branch/master/graph/badge.svg?token=DqjRsufMqf)](https://codecov.io/gh/oasislabs/oasis-core) Go
-[![GoDoc](https://godoc.org/github.com/oasislabs/oasis-core?status.svg)](https://godoc.org/github.com/oasislabs/oasis-core)
+[![Build status][buildkite-badge]][buildkite-link]
+[![CI lint status][github-ci-lint-badge]][github-ci-lint-link]
+[![CI reproducibility status][github-ci-repr-badge]][github-ci-repr-link]
+[![Release status][github-release-badge]][github-release-link]
+[![GoDoc][godoc-badge]][godoc-link]
+
+<!-- NOTE: Markdown doesn't support tables without headers, so we need to
+work around that and make the second (non-header) row also bold. -->
+| Go            | [![Go coverage][codecov-badge]][codecov-link]       |
+|:-------------:|:---------------------------------------------------:|
+| **Rust**      | [![Rust coverage][coveralls-badge]][coveralls-link] |
+
+<!-- markdownlint-disable line-length -->
+[buildkite-badge]: https://badge.buildkite.com/15a8faccee0d5b5ab1af7e75eb6f9daf2d493c543fbc67dce5.svg?branch=master
+[buildkite-link]: https://buildkite.com/oasislabs/oasis-core-ci
+[github-ci-lint-badge]: https://github.com/oasislabs/oasis-core/workflows/ci-lint/badge.svg
+[github-ci-lint-link]: https://github.com/oasislabs/oasis-core/actions?query=workflow:ci-lint
+[github-ci-repr-badge]: https://github.com/oasislabs/oasis-core/workflows/ci-reproducibility/badge.svg
+[github-ci-repr-link]: https://github.com/oasislabs/oasis-core/actions?query=workflow:ci-reproducibility
+[github-release-badge]: https://github.com/oasislabs/oasis-core/workflows/release/badge.svg
+[github-release-link]: https://github.com/oasislabs/oasis-core/actions?query=workflow:release
+[codecov-badge]: https://codecov.io/gh/oasislabs/oasis-core/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/oasislabs/oasis-core
+[coveralls-badge]: https://coveralls.io/repos/github/oasislabs/oasis-core/badge.svg
+[coveralls-link]: https://coveralls.io/github/oasislabs/oasis-core
+[godoc-badge]: https://godoc.org/github.com/oasislabs/oasis-core?status.svg
+[godoc-link]: https://godoc.org/github.com/oasislabs/oasis-core
+<!-- markdownlint-enable line-length -->
 
 ## Note
 
-* **Oasis Core is in active development so all APIs, protocols and data structures
-  are subject to change.**
+* **Oasis Core is in active development so all APIs, protocols and data
+  structures are subject to change.**
 * **The code has not yet been fully audited. For security issues and other
   security-related topics, see [Security](#security).**
 
@@ -43,10 +64,16 @@ Prerequisites:
   * [libseccomp](https://github.com/seccomp/libseccomp) development package.
 
   On Fedora 29+, you can install all the above with:
+
+  <!-- markdownlint-disable line-length -->
   ```
   sudo dnf install bubblewrap gcc gcc-c++ protobuf-compiler make cmake openssl-devel libseccomp-devel
   ```
-  On Ubuntu 18.10+ (18.04 LTS provides overly-old `bubblewrap`), you can install all the above with:
+  <!-- markdownlint-enable line-length -->
+
+  On Ubuntu 18.10+ (18.04 LTS provides overly-old `bubblewrap`), you can install
+  all the above with:
+
   ```
   sudo apt install bubblewrap gcc g++ protobuf-compiler make cmake libssl-dev libseccomp-dev
   ```
@@ -61,12 +88,15 @@ Prerequisites:
     https://tip.golang.org/doc/code.html#GOPATH),
   * [install the desired version of Go](
     https://golang.org/doc/install#extra_versions), e.g. 1.13, with:
+
     ```
     go get golang.org/dl/go1.13
     go1.13 download
     ```
-  * instruct the build system to use this particular version of Go by setting the
-    `OASIS_GO` environment variable in your `~/.bashrc`:
+
+  * instruct the build system to use this particular version of Go by setting
+    the `OASIS_GO` environment variable in your `~/.bashrc`:
+
     ```
     export OASIS_GO=go1.13
     ```
@@ -75,10 +105,13 @@ Prerequisites:
 
   Once you have [`rustup` installed](https://www.rust-lang.org/tools/install),
   install the nightly with:
+
   ```
   rustup install nightly
   ```
+
   Then make it the default version with:
+
   ```
   rustup default nightly
   ```
@@ -86,10 +119,13 @@ Prerequisites:
 * [Fortanix Rust SGX](https://edp.fortanix.com) target.
 
   Install it by running:
+
   ```
   rustup target add x86_64-fortanix-unknown-sgx
   ```
+
   Install its utilities by running:
+
   ```
   cargo install fortanix-sgx-tools sgxs-tools
   ```
@@ -97,12 +133,14 @@ Prerequisites:
 * (**OPTIONAL**) [protoc-gen-go](https://github.com/golang/protobuf).
 
   Download and install it with:
+
   ```
   ${OASIS_GO:-go} get github.com/golang/protobuf/protoc-gen-go
   ```
 
   _NOTE: If you didn't/can't add `$GOPATH/bin` to your `PATH`, you can install
   `protoc-gen-go` to `/usr/local/bin` (which is in `$PATH`) with:_
+
   ```
   sudo GOBIN=/usr/local/bin ${OASIS_GO:-go} install github.com/golang/protobuf/protoc-gen-go
   ```
@@ -116,18 +154,21 @@ where the code has been checked out.
 
 ### Using the development Docker image
 
-If for some reason you don't want or can't install the specified prerequisites on the
-host system, you can use our development Docker image. This requires that you have a
-[recent version of Docker installed](https://docs.docker.com/install/).
+If for some reason you don't want or can't install the specified prerequisites
+on the host system, you can use our development Docker image. This requires that
+you have a [recent version of Docker installed](
+https://docs.docker.com/install/).
 
-Oasis development environment with all the dependencies preinstalled is available
-in the `oasislabs/development:0.3.0` image. To run a container do something like the
-following in the top-level directory:
+Oasis development environment with all the dependencies preinstalled is
+available in the `oasislabs/development:0.3.0` image.
+To run a container, do the following in the top-level directory:
+
 ```bash
 make docker-shell
 ```
 
-if you are curious, this target will internally run the following command:
+If you are curious, this target will internally run the following command:
+
 ```
 docker run -t -i \
   --name oasis-core \
@@ -147,6 +188,7 @@ containers.
 
 To build everything required for running an Oasis node locally, simply execute
 in the top-level directory:
+
 ```
 export OASIS_UNSAFE_SKIP_AVR_VERIFY="1"
 export OASIS_UNSAFE_SKIP_KM_POLICY="1"
@@ -159,8 +201,10 @@ are supported on production SGX systems only and these features must be disabled
 in our environment.
 
 Next we specify how to run a simple network for development purposes. To start a
-simple Oasis network as defined by [the default network fixture](go/oasis-net-runner/fixtures/default.go)
-running the `simple-keyvalue` test runtime, do:
+simple Oasis network as defined by [the default network fixture](
+go/oasis-net-runner/fixtures/default.go) running the `simple-keyvalue` test
+runtime, do:
+
 ```
 ./go/oasis-net-runner/oasis-net-runner \
   --net.node.binary go/oasis-node/oasis-node \
@@ -169,12 +213,15 @@ running the `simple-keyvalue` test runtime, do:
   --net.keymanager.binary target/debug/oasis-core-keymanager-runtime
 ```
 
-Wait for the network to start, there should be messages about nodes being started
-and at the end the following message should appear:
+Wait for the network to start, there should be messages about nodes being
+started and at the end the following message should appear:
+
+<!-- markdownlint-disable line-length -->
 ```
 level=info module=oasis/net-runner caller=oasis.go:319 ts=2019-10-03T10:47:30.776566482Z msg="network started"
 level=info module=net-runner caller=root.go:145 ts=2019-10-03T10:47:30.77662061Z msg="client node socket available" path=/tmp/oasis-net-runner530668299/net-runner/network/client-0/internal.sock
 ```
+<!-- markdownlint-enable line-length -->
 
 The `simple-keyvalue` runtime implements a key-value hash map in the enclave
 and supports reading, writing, and fetching string values associated with the
@@ -184,8 +231,9 @@ example [here](tests/runtimes/simple-keyvalue).
 Finally, to test Oasis node, we will run a test client written specifically
 for the `simple-keyvalue` runtime. The client sends a few keys with associated
 values and fetches them back over RPC defined in the runtime's API. Execute the
-client as follows (substituting the socket path from your log output) in a different
-terminal:
+client as follows (substituting the socket path from your log output) in a
+different terminal:
+
 ```
 ./target/debug/simple-keyvalue-client \
   --runtime-id 0000000000000000000000000000000000000000000000000000000000000000 \
@@ -199,8 +247,9 @@ make any progress. For more information on writing your own client, see the
 
 ## SGX environment: Building and Running an Oasis node
 
-Compilation procedure under SGX environment is similiar to the non-SGX with
+Compilation procedure under SGX environment is similar to the non-SGX with
 slightly different environmental variables set:
+
 ```
 export OASIS_UNSAFE_SKIP_AVR_VERIFY="1"
 export OASIS_UNSAFE_KM_POLICY_KEYS="1"
@@ -216,6 +265,7 @@ policy of the node. TEE hardware flag denotes the trusted execution environment
 engine for running the Oasis node and the tests below.
 
 To run an Oasis node under SGX make sure:
+
 * Your hardware has SGX support.
 * You either explicitly enabled SGX in BIOS or made a
   `sgx_cap_enable_device()` system call, if SGX is in software controlled state.
@@ -223,6 +273,7 @@ To run an Oasis node under SGX make sure:
 * You have the AESM daemon running. The easiest way is to just run it in a
   Docker container by doing (this will keep the container running and it will
   be automatically started on boot):
+
   ```
   docker run \
     --detach \
@@ -238,6 +289,8 @@ configured correctly.
 
 Finally, to run an Oasis node under SGX follow the same steps as for non-SGX,
 except the `oasis-net-runner` invocation:
+
+<!-- markdownlint-disable line-length -->
 ```
 ./go/oasis-net-runner/oasis-net-runner \
   --net.node.binary go/oasis-node/oasis-node \
@@ -245,22 +298,26 @@ except the `oasis-net-runner` invocation:
   --net.runtime.loader target/debug/oasis-core-runtime-loader \
   --net.keymanager.binary target/x86_64-fortanix-unknown-sgx/debug/oasis-core-keymanager-runtime.sgxs
 ```
+<!-- markdownlint-enable line-length -->
 
 ## Running tests and benchmarks
 
 After you built everything, you can use the following commands to run tests.
 
 To run all unit tests:
+
 ```
 make test-unit
 ```
 
 To run end-to-end tests locally:
+
 ```
 make test-e2e
 ```
 
 To run all tests:
+
 ```
 make test
 ```
@@ -270,10 +327,15 @@ execute tests under SGX.
 
 ### Troubleshooting
 
-Check the console output for mentions of a path of the form `/tmp/oasis-test-runnerXXXXXXXXX` (where each `X` is a digit). That's the log directory. Start with coarsest-level debug output in `console.log` files:
+Check the console output for mentions of a path of the form
+`/tmp/oasis-test-runnerXXXXXXXXX` (where each `X` is a digit).
+That's the log directory. Start with coarsest-level debug output in
+`console.log` files:
+
 ```
 cat $(find /tmp/oasis-test-runnerXXXXXXXXX -name console.log) | less
 ```
+
 For even more output, check the other `*.log` files.
 
 ## Directories
@@ -283,7 +345,8 @@ For even more output, check the other `*.log` files.
 * `go`: Oasis node.
 * `keymanager-client`: Client crate for the key manager.
 * `keymanager-runtime`: (INSECURE) key manager implementation.
-* `runtime`: The runtime library that simplifies writing SGX and non-SGX runtimes.
+* `runtime`: The runtime library that simplifies writing SGX and non-SGX
+  runtimes.
 * `runtime-loader`: The SGX and non-SGX runtime loader process.
 * `scripts`: Bash scripts for development.
 * `tests`: Runtimes, clients and resources used for E2E tests.

--- a/common.mk
+++ b/common.mk
@@ -166,3 +166,6 @@ _RELEASE_NOTES_FILE := $(shell mktemp /tmp/oasis-core.XXXXX)
 _ := $(shell printf "$(subst ",\",$(subst $(newline),\n,$(RELEASE_TEXT)))" > $(_RELEASE_NOTES_FILE))
 GORELEASER_ARGS = release --release-notes $(_RELEASE_NOTES_FILE)
 endif
+
+# List of non-trivial Change Log fragments.
+CHANGELOG_FRAGMENTS_NON_TRIVIAL := $(filter-out $(wildcard .changelog/*trivial*.md),$(wildcard .changelog/[0-9]*.md))

--- a/docs/bigint.md
+++ b/docs/bigint.md
@@ -1,6 +1,7 @@
 # Big Integer Quantities
 
-Arbitrary-precision positive integer quantities are represented by the `quantity.Quantity` type.
+Arbitrary-precision positive integer quantities are represented by the
+`quantity.Quantity` type.
 
 ## Encoding
 

--- a/docs/consensus/staking.md
+++ b/docs/consensus/staking.md
@@ -1,17 +1,19 @@
 # Staking
 
-The staking component is responsible for managing the staking ledger in the consensus layer. It
-enables operations like transfering tokens between accounts and escrowing tokens for specific
-needs (e.g., operating nodes).
+The staking component is responsible for managing the staking ledger in the
+consensus layer. It enables operations like transfering tokens between accounts
+and escrowing tokens for specific needs (e.g., operating nodes).
 
 Links:
+
 * [API definition](../../go/staking/api).
 
-### Test Vectors
+## Test Vectors
 
 To generate test vectors for various staking transactions, run:
+
 ```bash
-$ make -C go test-vectors/staking
+make -C go test-vectors/staking
 ```
 
 ## Accounts
@@ -34,14 +36,17 @@ Each staking method takes a method-specific body as an argument.
 
 ### Transfer
 
-Transfer enables token transfer between different accounts in the staking ledger.
+Transfer enables token transfer between different accounts in the staking
+ledger.
 
 Method name:
+
 ```
 staking.Transfer
 ```
 
 Body:
+
 ```golang
 type Transfer struct {
     To     signature.PublicKey `json:"xfer_to"`
@@ -52,6 +57,7 @@ type Transfer struct {
 The transaction signer implicitly specifies the source account.
 
 Fields:
+
 * `xfer_to` specifies the destination account.
 * `xfer_tokens` specifies the amount of tokens to transfer.
 
@@ -60,11 +66,13 @@ Fields:
 Burn destroys some tokens in the caller's account.
 
 Method name:
+
 ```
 staking.Burn
 ```
 
 Body:
+
 ```golang
 type Burn struct {
     Tokens quantity.Quantity `json:"burn_tokens"`
@@ -74,21 +82,25 @@ type Burn struct {
 The transaction signer implicitly specifies the caller's account.
 
 Fields:
+
 * `burn_tokens` specifies the amount of tokens to burn.
 
 ### Add Escrow
 
-Escrow transfers tokens into an escrow account. Escrow accounts are used to keep the funds needed
-for specific consensus-layer operations (e.g., registering and running nodes). To simplify
-accounting, each escrow results in the source account being issued shares which can be converted
-back into staking tokens during the reclaim escrow operation.
+Escrow transfers tokens into an escrow account. Escrow accounts are used to keep
+the funds needed for specific consensus-layer operations (e.g., registering and
+running nodes). To simplify accounting, each escrow results in the source
+account being issued shares which can be converted back into staking tokens
+during the reclaim escrow operation.
 
 Method name:
+
 ```
 staking.AddEscrow
 ```
 
 Body:
+
 ```golang
 type Escrow struct {
     Account signature.PublicKey `json:"escrow_account"`
@@ -99,20 +111,24 @@ type Escrow struct {
 The transaction signer implicitly specifies the source account.
 
 Fields:
+
 * `escrow_account` specifies the destination escrow account.
 * `escrow_tokens` specifies the amount of tokens to transfer.
 
 ### Reclaim Escrow
 
-Reclaim escrow starts the escrow reclamation process. The process does not complete immediately but
-may be subject to a debonding period during which the tokens still remain escrowed.
+Reclaim escrow starts the escrow reclamation process. The process does not
+complete immediately but may be subject to a debonding period during which the
+tokens still remain escrowed.
 
 Method name:
+
 ```
 staking.ReclaimEscrow
 ```
 
 Body:
+
 ```golang
 type ReclaimEscrow struct {
     Account signature.PublicKey `json:"escrow_account"`
@@ -123,17 +139,20 @@ type ReclaimEscrow struct {
 The transaction signer implicitly specifies the destination account.
 
 Fields:
+
 * `escrow_account` specifies the source escrow account.
 * `reclaim_shares` specifies the amount of shares to reclaim.
 
 ### Amend Commission Schedule
 
 Method name:
+
 ```
 staking.AmendCommissionSchedule
 ```
 
 Body:
+
 ```golang
 type AmendCommissionSchedule struct {
     Amendment CommissionSchedule `json:"amendment"`
@@ -143,8 +162,9 @@ type AmendCommissionSchedule struct {
 The transaction signer implicitly specifies the escrow account.
 
 Fields:
+
 * `amendment` defines the amended commission schedule.
 
 ## Events
 
-_TODO_
+_TODO: Say something about how events work._

--- a/docs/consensus/transactions.md
+++ b/docs/consensus/transactions.md
@@ -4,7 +4,8 @@ The consensus layer uses a common transaction format for all transactions.
 
 ## Format
 
-Each (unsigned) transaction is represented by the following [encoded](../encoding.md) structure:
+Each (unsigned) transaction is represented by the following [encoded] structure:
+
 ```golang
 type Transaction struct {
     Nonce uint64 `json:"nonce"`
@@ -16,45 +17,55 @@ type Transaction struct {
 ```
 
 Fields:
-* `nonce` is the current caller nonce to prevent replays.
-* `fee` is an optional fee that the caller commits to paying to execute the transaction.
-* `method` is the called method name. Method names are composed of two parts, the component name
-  and the method name, joined by a separator (`.`). For example `staking.Transfer` is the method
-  name of the staking component's `Transfer` method.
+
+* `nonce` is the current caller's nonce to prevent replays.
+* `fee` is an optional fee that the caller commits to paying to execute the
+  transaction.
+* `method` is the called method name. Method names are composed of two parts,
+  the component name and the method name, joined by a separator (`.`).
+  For example, `staking.Transfer` is the method name of the staking component's
+  `Transfer` method.
 * `body` is the method-specific body.
 
-The actual transaction that is submitted to the consensus layer must be signed which means that it
-is wrapped into a [signed envelope](../crypto.md#signed-envelope).
+The actual transaction that is submitted to the consensus layer must be signed
+which means that it is wrapped into a [signed envelope].
 
-Domain separation context (+ [chain domain separation](../crypto.md#chain-domain-separation)):
+Domain separation context (+ [chain domain separation]):
+
 ```
 oasis-core/consensus: tx
 ```
 
+[encoded]: ../encoding.md
+[signed envelope]: ../crypto.md#signed-envelope
+[chain domain separation]: ../crypto.md#chain-domain-separation
+
 ## Fees
 
-As the consensus operations require resources to process, the consensus layer charges fees to
-perform operations.
+As the consensus operations require resources to process, the consensus layer
+charges fees to perform operations.
 
 ### Gas
 
 Gas is an unsigned 64-bit integer denominated in _gas units_.
 
-Different operations cost different amounts of gas as defined by the consensus parameters of the
-consensus component that implements the operation.
+Different operations cost different amounts of gas as defined by the consensus
+parameters of the consensus component that implements the operation.
 
-Transactions that require fees to process will include a `fee` field to declare how much the caller
-is willing to pay for fees. Specifying an `amount` (in tokens) and `gas` (in gas units) implicitly
-defines a _gas price_ (price of one gas unit) as `amount / gas`. Consensus validators may refuse
-to process operations with a gas price that is too low.
+Transactions that require fees to process will include a `fee` field to declare
+how much the caller is willing to pay for fees.
+Specifying an `amount` (in tokens) and `gas` (in gas units) implicitly defines a
+_gas price_ (price of one gas unit) as `amount / gas`.
+Consensus validators may refuse to process operations with a gas price that is
+too low.
 
-The `gas` field defines the maximum amount of gas that can be used by an operation for which the
-fee has been included. In case an operation uses more gas, processing will be aborted and no state
-changes will take place.
+The `gas` field defines the maximum amount of gas that can be used by an
+operation for which the fee has been included. In case an operation uses more
+gas, processing will be aborted and no state changes will take place.
 
-Signing a transaction which includes a fee structure implicitly grants permission to withdraw the
-given amount of tokens from the signer's account. In case there is not enough balance in the account
-the operation will fail.
+Signing a transaction which includes a fee structure implicitly grants
+permission to withdraw the given amount of tokens from the signer's account.
+In case there is not enough balance in the account, the operation will fail.
 
 ```golang
 type Fee struct {
@@ -66,5 +77,6 @@ type Fee struct {
 Fees are not refunded.
 
 Fields:
+
 * `amount` is the total fee amount to be paid.
 * `gas` is the maximum gas that an operation can use.

--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -3,5 +3,6 @@
 All messages exchanged by different components in Oasis Core are encoded using
 [canonical CBOR as defined by RFC 7049](https://tools.ietf.org/html/rfc7049).
 
-When describing different messages in the documentation, we use Go structs with field annotations
-that specify how different fields translate to their encoded form.
+When describing different messages in the documentation, we use Go structs with
+field annotations that specify how different fields translate to their encoded
+form.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -23,12 +23,14 @@ pip3 install https://github.com/oasislabs/towncrier/archive/oasis-master.tar.gz 
 You might want to install the packages to a [Python virtual environment] or
 via so-called [User install] (i.e. isolated to the current user).
 
+<!-- markdownlint-disable line-length -->
 [Python]: https://www.python.org/
 [Oasis Labs' towncrier fork]: https://github.com/oasislabs/towncrier
 [Punch]: https://github.com/lgiordani/punch
 [pip]: https://pip.pypa.io/en/stable/
 [Python virtual environment]: https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments
 [User install]: https://pip.pypa.io/en/stable/user_guide/#user-installs
+<!-- markdownlint-enable line-length -->
 
 ## Tooling
 

--- a/docs/runtime-id.md
+++ b/docs/runtime-id.md
@@ -8,9 +8,9 @@ of the runtime, the last 192 bits are used as the runtime identifier.
 Currently the following flags are defined (bit positions assume the flags
 vector is interpreted as an unsigned 64 bit big endian integer):
 
- * Bit 63: The runtime is a test runtime and not for production networks.
- * Bit 62: The runtime is a key manager runtime.
- * Bits 61-0: Reserved for future expansion and MUST be set to 0.
+* Bit 63: The runtime is a test runtime and not for production networks.
+* Bit 62: The runtime is a key manager runtime.
+* Bits 61-0: Reserved for future expansion and MUST be set to 0.
 
 Note: Unless the registry consensus parameter `DebugAllowTestRuntimes` is
 set, attempts to register a test runtime will be rejected.

--- a/go/extra/README.md
+++ b/go/extra/README.md
@@ -1,4 +1,4 @@
-## Extra
+# Extra
 
 This directory contains packages depending on (but not directly part of)
 oasis-core.

--- a/go/extra/stats/README.md
+++ b/go/extra/stats/README.md
@@ -1,4 +1,4 @@
-## Stats
+# Stats
 
 Queries a node for network stats. Currently implemented per entity block
 signature counts.
@@ -6,7 +6,7 @@ signature counts.
 ## Usage
 
 ```
-stats/stats entity-signatures \
+$ stats/stats entity-signatures \
     --address unix:<node_dir>/internal.sock \
     --start-block 0 \
     --end-block 100 \

--- a/tests/fixture-data/txsource/README.md
+++ b/tests/fixture-data/txsource/README.md
@@ -1,5 +1,8 @@
 # Fixture data for txsource
-This data is parameterized for the default seed `seeeeeeeeeeeeeeeeeeeeeeeeeeeeeed` (UTF-8).
+
+This data is parameterized for the default see
+`seeeeeeeeeeeeeeeeeeeeeeeeeeeeeed` (UTF-8).
 
 ## Inventory of configurations
+
 - Funded accounts for the transfer workload


### PR DESCRIPTION
Closes #2572.

TODO:
- [x] Use `gitlint` to lint the Change Log fragments.