### PR TITLE
go/consensus/tendermint: Don't use `UnsafeSigner`

### DIFF
--- a/.changelog/2670.internal.md
+++ b/.changelog/2670.internal.md
@@ -1,0 +1,1 @@
+go/consensus/tendermint: Don't use `UnsafeSigner`

--- a/go/common/crypto/signature/signer.go
+++ b/go/common/crypto/signature/signer.go
@@ -176,7 +176,8 @@ type Signer interface {
 	Reset()
 }
 
-// UnsafeSigner is a Signer that also supports access to the raw private key.
+// UnsafeSigner is a Signer that also supports access to the raw private key,
+// primarily for testing.
 type UnsafeSigner interface {
 	Signer
 

--- a/go/common/crypto/signature/signers/file/file_signer.go
+++ b/go/common/crypto/signature/signers/file/file_signer.go
@@ -201,12 +201,6 @@ func (s *Signer) Reset() {
 	}
 }
 
-// UnsafeBytes returns the byte representation of the private key.  This
-// MUST be removed for HSM support.
-func (s *Signer) UnsafeBytes() []byte {
-	return s.privateKey[:]
-}
-
 func (s *Signer) marshalPEM() ([]byte, error) {
 	return pem.Marshal(privateKeyPemType, s.privateKey[:])
 }

--- a/go/consensus/tendermint/crypto/signature_test.go
+++ b/go/consensus/tendermint/crypto/signature_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 	tmed "github.com/tendermint/tendermint/crypto/ed25519"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	memorySigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/memory"
 )
 
@@ -15,9 +14,7 @@ func TestSignatureConversions(t *testing.T) {
 	signer, err := memorySigner.NewSigner(rand.Reader)
 	require.NoError(t, err, "NewSigner()")
 
-	unsafeSigner := signer.(signature.UnsafeSigner)
-	tmSk := UnsafeSignerToTendermint(unsafeSigner)
-	require.Equal(t, unsafeSigner.UnsafeBytes(), tmSk[:], "Private key: ToTendermint")
+	tmSk := SignerToTendermint(signer)
 
 	pk := signer.Public()
 	tmPk := tmSk.PubKey().(tmed.PubKeyEd25519)

--- a/go/consensus/tendermint/seed.go
+++ b/go/consensus/tendermint/seed.go
@@ -12,7 +12,6 @@ import (
 	"github.com/tendermint/tendermint/types"
 	"github.com/tendermint/tendermint/version"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
@@ -101,11 +100,7 @@ func NewSeed(dataDir string, identity *identity.Identity, genesisProvider genesi
 	cfg.AddrBookStrict = !viper.GetBool(CfgDebugP2PAddrBookLenient)
 	// MaxNumInboundPeers/MaxNumOutboundPeers
 
-	unsafeNodeSigner, ok := identity.NodeSigner.(signature.UnsafeSigner)
-	if !ok {
-		return nil, errors.New("tendermint/seed: node signer does not allow private key access")
-	}
-	nodeKey := &p2p.NodeKey{PrivKey: crypto.UnsafeSignerToTendermint(unsafeNodeSigner)}
+	nodeKey := &p2p.NodeKey{PrivKey: crypto.SignerToTendermint(identity.NodeSigner)}
 
 	doc, err := genesisProvider.GetGenesisDocument()
 	if err != nil {

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -991,12 +991,6 @@ func (t *tendermintService) lazyInit() error {
 		return err
 	}
 
-	unsafeNodeSigner, ok := t.nodeSigner.(signature.UnsafeSigner)
-	if !ok {
-		t.Logger.Error("node signer does not allow private key access")
-		return fmt.Errorf("tendermint: node signer does not allow private key access")
-	}
-
 	// HACK: tmnode.NewNode() triggers block replay and or ABCI chain
 	// initialization, instead of t.node.Start().  This is a problem
 	// because at the time that lazyInit() is called, none of the ABCI
@@ -1007,8 +1001,7 @@ func (t *tendermintService) lazyInit() error {
 	t.startFn = func() error {
 		t.node, err = tmnode.NewNode(tenderConfig,
 			tendermintPV,
-			// TODO/hsm: This needs to use a separate key or something.
-			&tmp2p.NodeKey{PrivKey: crypto.UnsafeSignerToTendermint(unsafeNodeSigner)},
+			&tmp2p.NodeKey{PrivKey: crypto.SignerToTendermint(t.nodeSigner)},
 			tmproxy.NewLocalClientCreator(t.mux.Mux()),
 			tendermintGenesisProvider,
 			dbProvider,


### PR DESCRIPTION
No, that's German for "The UnsafeSigner, The"