### PR TITLE
go staking: add per-account lockup

### DIFF
--- a/.changelog/2672.breaking.md
+++ b/.changelog/2672.breaking.md
@@ -1,0 +1,6 @@
+go staking: Add per-account lockup
+
+With this, we'll be able to set up special accounts in the genesis
+document where they're not permitted to transfer staking tokens until
+a the specified epoch time.
+They can still delegate during that time.

--- a/go/consensus/tendermint/apps/staking/transactions_test.go
+++ b/go/consensus/tendermint/apps/staking/transactions_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	staking "github.com/oasislabs/oasis-core/go/staking/api"
 )
 
@@ -14,12 +15,16 @@ func TestIsTransferPermitted(t *testing.T) {
 		msg       string
 		params    *staking.ConsensusParameters
 		fromID    signature.PublicKey
+		from      *staking.Account
+		epoch     epochtime.EpochTime
 		permitted bool
 	}{
 		{
 			"no disablement",
 			&staking.ConsensusParameters{},
 			signature.PublicKey{},
+			&staking.Account{},
+			0,
 			true,
 		},
 		{
@@ -28,6 +33,8 @@ func TestIsTransferPermitted(t *testing.T) {
 				DisableTransfers: true,
 			},
 			signature.PublicKey{},
+			&staking.Account{},
+			0,
 			false,
 		},
 		{
@@ -39,6 +46,8 @@ func TestIsTransferPermitted(t *testing.T) {
 				},
 			},
 			signature.PublicKey{},
+			&staking.Account{},
+			0,
 			false,
 		},
 		{
@@ -50,9 +59,48 @@ func TestIsTransferPermitted(t *testing.T) {
 				},
 			},
 			signature.PublicKey{},
+			&staking.Account{},
+			0,
 			true,
 		},
+		{
+			"before allowed",
+			&staking.ConsensusParameters{},
+			signature.PublicKey{},
+			&staking.Account{
+				General: staking.GeneralAccount{
+					TransfersNotBefore: 1,
+				},
+			},
+			0,
+			false,
+		},
+		{
+			"after allowed",
+			&staking.ConsensusParameters{},
+			signature.PublicKey{},
+			&staking.Account{},
+			1,
+			true,
+		},
+		{
+			"whitelisted before allowed ",
+			&staking.ConsensusParameters{
+				DisableTransfers: true,
+				UndisableTransfersFrom: map[signature.PublicKey]bool{
+					signature.PublicKey{}: true,
+				},
+			},
+			signature.PublicKey{},
+			&staking.Account{
+				General: staking.GeneralAccount{
+					TransfersNotBefore: 1,
+				},
+			},
+			0,
+			false,
+		},
 	} {
-		require.Equal(t, tt.permitted, isTransferPermitted(tt.params, tt.fromID), tt.msg)
+		require.Equal(t, tt.permitted, isTransferPermitted(tt.params, tt.fromID, tt.from, tt.epoch), tt.msg)
 	}
 }

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -414,8 +414,9 @@ func (sa *StakeAccumulator) TotalClaims(thresholds map[ThresholdKind]quantity.Qu
 
 // GeneralAccount is a general-purpose account.
 type GeneralAccount struct {
-	Balance quantity.Quantity `json:"balance"`
-	Nonce   uint64            `json:"nonce"`
+	Balance            quantity.Quantity   `json:"balance"`
+	Nonce              uint64              `json:"nonce"`
+	TransfersNotBefore epochtime.EpochTime `json:"transfers_not_before,omitempty"`
 }
 
 // EscrowAccount is an escrow account the balance of which is subject to


### PR DESCRIPTION
With this, we'll be able to set up special accounts in the genesis document where they're not permitted to transfer staking tokens until a the specified epoch time. They can still delegate during that time.