### PR TITLE
Make node TLS certificates totally ephemeral

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -203,7 +203,7 @@ steps:
   ###############
   - label: E2E tests
     parallelism: 7
-    timeout_in_minutes: 11
+    timeout_in_minutes: 12
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       - .buildkite/scripts/test_e2e.sh

--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -203,7 +203,7 @@ steps:
   ###############
   - label: E2E tests
     parallelism: 7
-    timeout_in_minutes: 12
+    timeout_in_minutes: 9
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       - .buildkite/scripts/test_e2e.sh

--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -203,7 +203,7 @@ steps:
   ###############
   - label: E2E tests
     parallelism: 7
-    timeout_in_minutes: 9
+    timeout_in_minutes: 11
     command:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       - .buildkite/scripts/test_e2e.sh

--- a/.changelog/2098.breaking.md
+++ b/.changelog/2098.breaking.md
@@ -1,0 +1,5 @@
+Sentry nodes no longer require TLS certificate file of the upstream node
+
+The `worker.sentry.grpc.upstream.cert` option has been removed.
+Instead, use `worker.sentry.grpc.upstream.id` to specify the
+upstream node's ID.

--- a/.changelog/2098.feature.md
+++ b/.changelog/2098.feature.md
@@ -1,0 +1,6 @@
+node: Add automatic TLS certificate rotation support
+
+It is now possible to automatically rotate the node's TLS
+certificates every N epochs by passing the command-line flag
+`worker.registration.rotate_certs`.
+Do not use this if you use sentry nodes or IAS proxies.

--- a/.changelog/2098.feature.md
+++ b/.changelog/2098.feature.md
@@ -3,4 +3,4 @@ node: Add automatic TLS certificate rotation support
 It is now possible to automatically rotate the node's TLS
 certificates every N epochs by passing the command-line flag
 `worker.registration.rotate_certs`.
-Do not use this if you use sentry nodes or IAS proxies.
+Do not use this option on sentry nodes or IAS proxies.

--- a/go/common/accessctl/accessctl_test.go
+++ b/go/common/accessctl/accessctl_test.go
@@ -49,11 +49,11 @@ func TestSubjectFromCertificate(t *testing.T) {
 	require.NoError(err, "Failed to create a temporary directory")
 	defer os.RemoveAll(dataDir)
 
-	ident, err := identity.LoadOrGenerate(dataDir, memorySigner.NewFactory())
+	ident, err := identity.LoadOrGenerate(dataDir, memorySigner.NewFactory(), false)
 	require.NoError(err, "Failed to generate a new identity")
-	require.Len(ident.TLSCertificate.Certificate, 1, "The generated identity contains more than 1 certificate in the chain")
+	require.Len(ident.GetTLSCertificate().Certificate, 1, "The generated identity contains more than 1 certificate in the chain")
 
-	x509Cert, err := x509.ParseCertificate(ident.TLSCertificate.Certificate[0])
+	x509Cert, err := x509.ParseCertificate(ident.GetTLSCertificate().Certificate[0])
 	require.NoError(err, "Failed to parse X.509 certificate from TLS certificate")
 
 	sub := SubjectFromX509Certificate(x509Cert)

--- a/go/common/grpc/policy/policy_test.go
+++ b/go/common/grpc/policy/policy_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/grpc/policy"
 	"github.com/oasislabs/oasis-core/go/common/grpc/policy/api"
 	cmnTesting "github.com/oasislabs/oasis-core/go/common/grpc/testing"
+	"github.com/oasislabs/oasis-core/go/common/identity"
 )
 
 var testNs = common.NewTestNamespaceFromSeed([]byte("oasis common grpc policy test ns"), 0)
@@ -60,9 +61,10 @@ func TestAccessPolicy(t *testing.T) {
 	serverConfig := &cmnGrpc.ServerConfig{
 		Name:          host,
 		Port:          port,
-		Certificate:   serverTLSCert,
+		Identity:      &identity.Identity{},
 		CustomOptions: []grpc.ServerOption{grpc.CustomCodec(&cmnGrpc.CBORCodec{})},
 	}
+	serverConfig.Identity.SetTLSCertificate(serverTLSCert)
 	grpcServer, err := cmnGrpc.NewServer(serverConfig)
 	require.NoErrorf(err, "Failed to create a new gRPC server: %v", err)
 

--- a/go/common/grpc/proxy/proxy.go
+++ b/go/common/grpc/proxy/proxy.go
@@ -17,21 +17,29 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/logging"
 )
 
-// Handler returns a grpc StreamHandler than can be used
-// to proxy requests to provided client.
-// XXX: potentially the connection should be established in this package,
-// with some sensible defaults e.g. KeepAlive set.
-// We might also want to establish a pool of connections to the upstream.
-func Handler(conn *grpc.ClientConn) grpc.StreamHandler {
+// Dialer should return a gRPC ClientConn that will be used
+// to forward calls to.
+type Dialer func(ctx context.Context) (*grpc.ClientConn, error)
+
+// Handler returns a gRPC StreamHandler than can be used
+// to proxy requests to the client returned by the proxy dialer.
+func Handler(dialer Dialer) grpc.StreamHandler {
 	proxy := &proxy{
 		logger:       logging.GetLogger("grpc/proxy"),
-		upstreamConn: conn,
+		dialer:       dialer,
+		upstreamConn: nil, // Will be dialed on-demand.
 	}
 
 	return grpc.StreamHandler(proxy.handler)
 }
 
 type proxy struct {
+	// This is the dialer callback we use to make new connections to the
+	// upstream server if the connection drops, etc.
+	dialer Dialer
+
+	// This is a cached client connection to the upstream server, so we
+	// don't have to re-dial it on every call.
 	upstreamConn *grpc.ClientConn
 
 	logger *logging.Logger
@@ -66,6 +74,15 @@ func (p *proxy) handler(srv interface{}, stream grpc.ServerStream) error {
 	// Pass subject header upstream.
 	upstreamCtx = metadata.AppendToOutgoingContext(upstreamCtx, policy.ForwardedSubjectMD, sub)
 
+	// Dial upstream if necessary.
+	if p.upstreamConn == nil {
+		var grr error
+		p.upstreamConn, grr = p.dialer(stream.Context())
+		if grr != nil {
+			return grr
+		}
+	}
+
 	upstreamStream, err := grpc.NewClientStream(
 		upstreamCtx,
 		desc,
@@ -92,7 +109,7 @@ func (p *proxy) handler(srv interface{}, stream grpc.ServerStream) error {
 				// can still be in progress.
 				p.logger.Debug("downstream EOF")
 				if err = upstreamStream.CloseSend(); err != nil {
-					p.logger.Error("failrue closing upstream stream",
+					p.logger.Error("failure closing upstream stream",
 						"err", err,
 					)
 				}
@@ -154,6 +171,7 @@ func (p *proxy) proxyUpstream(downstream grpc.ServerStream, upstream grpc.Client
 func (p *proxy) proxyDownstream(upstream grpc.ClientStream, downstream grpc.ServerStream) <-chan error {
 	errCh := make(chan error, 1)
 	var headerSent bool
+
 	go func() {
 		for {
 			// Wait for stream msg (from upstream).

--- a/go/common/grpc/testing/ping.go
+++ b/go/common/grpc/testing/ping.go
@@ -64,14 +64,14 @@ func CreateCertificate(t *testing.T) (*tls.Certificate, *x509.Certificate) {
 	require.NoError(err, "Failed to create a temporary directory")
 	defer os.RemoveAll(dataDir)
 
-	ident, err := identity.LoadOrGenerate(dataDir, memorySigner.NewFactory())
+	ident, err := identity.LoadOrGenerate(dataDir, memorySigner.NewFactory(), false)
 	require.NoError(err, "Failed to generate a new identity")
-	require.Len(ident.TLSCertificate.Certificate, 1, "The generated identity contains more than 1 TLS certificate in the chain")
+	require.Len(ident.GetTLSCertificate().Certificate, 1, "The generated identity contains more than 1 TLS certificate in the chain")
 
-	x509Cert, err := x509.ParseCertificate(ident.TLSCertificate.Certificate[0])
+	x509Cert, err := x509.ParseCertificate(ident.GetTLSCertificate().Certificate[0])
 	require.NoError(err, "Failed to parse X.509 certificate from TLS certificate")
 
-	return ident.TLSCertificate, x509Cert
+	return ident.GetTLSCertificate(), x509Cert
 }
 
 // PingQuery is the PingServer query.

--- a/go/common/identity/identity.go
+++ b/go/common/identity/identity.go
@@ -6,10 +6,12 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"path/filepath"
+	"sync"
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/memory"
 	tlsCert "github.com/oasislabs/oasis-core/go/common/crypto/tls"
+	"github.com/oasislabs/oasis-core/go/common/errors"
 )
 
 const (
@@ -30,31 +32,124 @@ const (
 	tlsCertFilename = "tls_identity_cert.pem"
 )
 
+// ErrCertificateRotationForbidden is returned by RotateCertificates if
+// TLS certificate rotation is forbidden.  This happens when rotation is
+// enabled and an existing TLS certificate was successfully loaded
+// (or a new one was generated and persisted to disk).
+var ErrCertificateRotationForbidden = errors.New("identity", 1, "identity: TLS certificate rotation forbidden")
+
 // Identity is a node identity.
 type Identity struct {
+	sync.RWMutex
+
 	// NodeSigner is a node identity key signer.
 	NodeSigner signature.Signer
 	// P2PSigner is a node P2P link key signer.
 	P2PSigner signature.Signer
 	// ConsensusSigner is a node consensus key signer.
 	ConsensusSigner signature.Signer
-	// TLSSigner is a node TLS certificate signer.
-	TLSSigner signature.Signer
-	// TLSCertificate is a certificate that can be used for TLS.
-	TLSCertificate *tls.Certificate
+	// tlsSigner is a node TLS certificate signer.
+	tlsSigner signature.Signer
+	// tlsCertificate is a certificate that can be used for TLS.
+	tlsCertificate *tls.Certificate
+	// nextTLSCertificate is a certificate that can be used for TLS in the next rotation.
+	nextTLSCertificate *tls.Certificate
+	// DoNotRotateTLS flag is true if we mustn't rotate the TLS certificates.
+	DoNotRotateTLS bool
+}
+
+// RotateCertificates rotates the identity's TLS certificates.
+// This is called from worker/registration/worker.go every
+// CfgRegistrationRotateCerts epochs (if it's non-zero).
+func (i *Identity) RotateCertificates() error {
+	if i.DoNotRotateTLS {
+		// If we loaded an existing certificate or persisted a generated one
+		// to disk, certificate rotation must be disabled.
+		// This behaviour is required for sentry nodes to work.
+		return ErrCertificateRotationForbidden
+	}
+
+	i.Lock()
+	defer i.Unlock()
+
+	if i.tlsCertificate != nil {
+		// Use the prepared certificate.
+		if i.nextTLSCertificate != nil {
+			i.tlsCertificate = i.nextTLSCertificate
+			i.tlsSigner = memory.NewFromRuntime(i.tlsCertificate.PrivateKey.(ed25519.PrivateKey))
+		}
+
+		// Generate a new TLS certificate to be used in the next rotation.
+		var err error
+		i.nextTLSCertificate, err = tlsCert.Generate(CommonName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// GetTLSSigner returns the current TLS signer.
+func (i *Identity) GetTLSSigner() signature.Signer {
+	i.RLock()
+	defer i.RUnlock()
+
+	return i.tlsSigner
+}
+
+// SetTLSSigner sets the current TLS signer.
+func (i *Identity) SetTLSSigner(s signature.Signer) {
+	i.Lock()
+	defer i.Unlock()
+
+	i.tlsSigner = s
+}
+
+// GetTLSCertificate returns the current TLS certificate.
+func (i *Identity) GetTLSCertificate() *tls.Certificate {
+	i.RLock()
+	defer i.RUnlock()
+
+	return i.tlsCertificate
+}
+
+// SetTLSCertificate sets the current TLS certificate.
+func (i *Identity) SetTLSCertificate(cert *tls.Certificate) {
+	i.Lock()
+	defer i.Unlock()
+
+	i.tlsCertificate = cert
+}
+
+// GetNextTLSCertificate returns the next TLS certificate.
+func (i *Identity) GetNextTLSCertificate() *tls.Certificate {
+	i.RLock()
+	defer i.RUnlock()
+
+	return i.nextTLSCertificate
+}
+
+// SetNextTLSCertificate sets the next TLS certificate.
+func (i *Identity) SetNextTLSCertificate(nextCert *tls.Certificate) {
+	i.Lock()
+	defer i.Unlock()
+
+	i.nextTLSCertificate = nextCert
 }
 
 // Load loads an identity.
 func Load(dataDir string, signerFactory signature.SignerFactory) (*Identity, error) {
-	return doLoadOrGenerate(dataDir, signerFactory, false)
+	return doLoadOrGenerate(dataDir, signerFactory, false, false)
 }
 
 // LoadOrGenerate loads or generates an identity.
-func LoadOrGenerate(dataDir string, signerFactory signature.SignerFactory) (*Identity, error) {
-	return doLoadOrGenerate(dataDir, signerFactory, true)
+// If persistTLS is true, it saves the generated TLS certificates to disk.
+func LoadOrGenerate(dataDir string, signerFactory signature.SignerFactory, persistTLS bool) (*Identity, error) {
+	return doLoadOrGenerate(dataDir, signerFactory, true, persistTLS)
 }
 
-func doLoadOrGenerate(dataDir string, signerFactory signature.SignerFactory, shouldGenerate bool) (*Identity, error) {
+func doLoadOrGenerate(dataDir string, signerFactory signature.SignerFactory, shouldGenerate bool, persistTLS bool) (*Identity, error) {
 	var signers []signature.Signer
 	for _, v := range []struct {
 		role  signature.SignerRole
@@ -86,30 +181,51 @@ func doLoadOrGenerate(dataDir string, signerFactory signature.SignerFactory, sho
 		signers = append(signers, signer)
 	}
 
-	// TLS certificate.
-	//
-	// TODO: The key and cert could probably be made totally ephemeral, as long
-	// as the registry update takes effect immediately.
 	var (
-		cert *tls.Certificate
-		err  error
+		nextCert *tls.Certificate
+		dnr      bool
 	)
+
+	// First, check if we can load the TLS certificate from disk.
 	tlsCertPath, tlsKeyPath := TLSCertPaths(dataDir)
-	if shouldGenerate {
-		cert, err = tlsCert.LoadOrGenerate(tlsCertPath, tlsKeyPath, CommonName)
+	cert, err := tlsCert.Load(tlsCertPath, tlsKeyPath)
+	if err == nil {
+		// Load successful, ensure that we won't ever rotate the certificates.
+		dnr = true
 	} else {
-		cert, err = tlsCert.Load(tlsCertPath, tlsKeyPath)
-	}
-	if err != nil {
-		return nil, err
+		// Freshly generate TLS certificates.
+		cert, err = tlsCert.Generate(CommonName)
+		if err != nil {
+			return nil, err
+		}
+
+		if persistTLS {
+			// Save generated TLS certificate to disk.
+			err = tlsCert.Save(tlsCertPath, tlsKeyPath, cert)
+			if err != nil {
+				return nil, err
+			}
+
+			// Disable TLS rotation if we're persisting TLS certificates.
+			dnr = true
+		} else {
+			// Not persisting TLS certificate to disk, generate a new
+			// certificate to be used in the next rotation.
+			nextCert, err = tlsCert.Generate(CommonName)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return &Identity{
-		NodeSigner:      signers[0],
-		P2PSigner:       signers[1],
-		ConsensusSigner: signers[2],
-		TLSSigner:       memory.NewFromRuntime(cert.PrivateKey.(ed25519.PrivateKey)),
-		TLSCertificate:  cert,
+		NodeSigner:         signers[0],
+		P2PSigner:          signers[1],
+		ConsensusSigner:    signers[2],
+		tlsSigner:          memory.NewFromRuntime(cert.PrivateKey.(ed25519.PrivateKey)),
+		tlsCertificate:     cert,
+		nextTLSCertificate: nextCert,
+		DoNotRotateTLS:     dnr,
 	}, nil
 }
 

--- a/go/common/identity/identity_test.go
+++ b/go/common/identity/identity_test.go
@@ -20,16 +20,36 @@ func TestLoadOrGenerate(t *testing.T) {
 	require.NoError(t, err, "NewFactory")
 
 	// Generate a new identity.
-	identity, err := LoadOrGenerate(dataDir, factory)
+	identity, err := LoadOrGenerate(dataDir, factory, true)
 	require.NoError(t, err, "LoadOrGenerate")
 
 	// Load an existing identity.
-	identity2, err := LoadOrGenerate(dataDir, factory)
+	identity2, err := LoadOrGenerate(dataDir, factory, false)
 	require.NoError(t, err, "LoadOrGenerate (2)")
 	require.EqualValues(t, identity.NodeSigner, identity2.NodeSigner)
 	require.EqualValues(t, identity.P2PSigner, identity2.P2PSigner)
 	require.EqualValues(t, identity.ConsensusSigner, identity2.ConsensusSigner)
-	require.EqualValues(t, identity.TLSSigner, identity2.TLSSigner)
-	// TODO: Check that it always generates a fresh certificate once oasis-core#1541 is done.
-	require.EqualValues(t, identity.TLSCertificate, identity2.TLSCertificate)
+	require.EqualValues(t, identity.GetTLSSigner(), identity2.GetTLSSigner())
+	require.EqualValues(t, identity.GetTLSCertificate(), identity2.GetTLSCertificate())
+
+	dataDir2, err := ioutil.TempDir("", "oasis-identity-test2_")
+	require.NoError(t, err, "create data dir (2)")
+	defer os.RemoveAll(dataDir2)
+
+	// Generate a new identity again, this time without persisting TLS certs.
+	identity3, err := LoadOrGenerate(dataDir2, factory, false)
+	require.NoError(t, err, "LoadOrGenerate (3)")
+
+	// Load it back.
+	identity4, err := LoadOrGenerate(dataDir2, factory, false)
+	require.NoError(t, err, "LoadOrGenerate (4)")
+	require.EqualValues(t, identity3.NodeSigner, identity4.NodeSigner)
+	require.EqualValues(t, identity3.P2PSigner, identity4.P2PSigner)
+	require.EqualValues(t, identity3.ConsensusSigner, identity4.ConsensusSigner)
+	require.NotEqual(t, identity.GetTLSSigner(), identity3.GetTLSSigner())
+	require.NotEqual(t, identity2.GetTLSSigner(), identity3.GetTLSSigner())
+	require.NotEqual(t, identity3.GetTLSSigner(), identity4.GetTLSSigner())
+	require.NotEqual(t, identity.GetTLSCertificate(), identity3.GetTLSCertificate())
+	require.NotEqual(t, identity2.GetTLSCertificate(), identity3.GetTLSCertificate())
+	require.NotEqual(t, identity3.GetTLSCertificate(), identity4.GetTLSCertificate())
 }

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -174,14 +174,21 @@ type CommitteeInfo struct {
 	// Certificate is the certificate for establishing TLS connections.
 	Certificate []byte `json:"certificate"`
 
+	// NextCertificate is the certificate that will be used for establishing
+	// TLS connections after certificate rotation (if enabled).
+	NextCertificate []byte `json:"next_certificate,omitempty"`
+
 	// Addresses is the list of committee addresses at which the node can be reached.
 	Addresses []CommitteeAddress `json:"addresses"`
 }
 
 // Equal compares vs another CommitteeInfo for equality.
 func (c *CommitteeInfo) Equal(other *CommitteeInfo) bool {
-	// XXX: Why is this top-level certificate even needed?
 	if !bytes.Equal(c.Certificate, other.Certificate) {
+		return false
+	}
+
+	if !bytes.Equal(c.NextCertificate, other.NextCertificate) {
 		return false
 	}
 
@@ -200,6 +207,11 @@ func (c *CommitteeInfo) Equal(other *CommitteeInfo) bool {
 // ParseCertificate returns the parsed x509 certificate.
 func (c *CommitteeInfo) ParseCertificate() (*x509.Certificate, error) {
 	return x509.ParseCertificate(c.Certificate)
+}
+
+// ParseCertificate returns the parsed x509 next certificate.
+func (c *CommitteeInfo) ParseNextCertificate() (*x509.Certificate, error) {
+	return x509.ParseCertificate(c.NextCertificate)
 }
 
 // P2PInfo contains information for connecting to this node via P2P transport.

--- a/go/ias/proxy/client/client.go
+++ b/go/ias/proxy/client/client.go
@@ -119,9 +119,11 @@ func New(identity *identity.Identity, proxyAddr, tlsCertFile string) (api.Endpoi
 		certPool := x509.NewCertPool()
 		certPool.AddCert(parsedCert)
 		creds := credentials.NewTLS(&tls.Config{
-			Certificates: []tls.Certificate{*identity.TLSCertificate},
-			RootCAs:      certPool,
-			ServerName:   proxy.CommonName,
+			RootCAs:    certPool,
+			ServerName: proxy.CommonName,
+			GetClientCertificate: func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				return identity.GetTLSCertificate(), nil
+			},
 		})
 
 		conn, err := cmnGrpc.Dial(

--- a/go/oasis-node/cmd/common/grpc/grpc.go
+++ b/go/oasis-node/cmd/common/grpc/grpc.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 
 	cmnGrpc "github.com/oasislabs/oasis-core/go/common/grpc"
+	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
 )
@@ -50,9 +51,10 @@ func NewServerTCP(cert *tls.Certificate, installWrapper bool) (*cmnGrpc.Server, 
 	config := &cmnGrpc.ServerConfig{
 		Name:           "internal",
 		Port:           uint16(viper.GetInt(CfgServerPort)),
-		Certificate:    cert,
+		Identity:       &identity.Identity{},
 		InstallWrapper: installWrapper,
 	}
+	config.Identity.SetTLSCertificate(cert)
 	return cmnGrpc.NewServer(config)
 }
 

--- a/go/oasis-node/cmd/debug/byzantine/registry.go
+++ b/go/oasis-node/cmd/debug/byzantine/registry.go
@@ -37,7 +37,7 @@ func registryRegisterNode(svc service.TendermintService, id *identity.Identity, 
 	var committeeAddresses []node.CommitteeAddress
 	for _, addr := range addresses {
 		committeeAddresses = append(committeeAddresses, node.CommitteeAddress{
-			Certificate: id.TLSCertificate.Certificate[0],
+			Certificate: id.GetTLSCertificate().Certificate[0],
 			Address:     addr,
 		})
 	}
@@ -47,7 +47,7 @@ func registryRegisterNode(svc service.TendermintService, id *identity.Identity, 
 		EntityID:   entityID,
 		Expiration: 1000,
 		Committee: node.CommitteeInfo{
-			Certificate: id.TLSCertificate.Certificate[0],
+			Certificate: id.GetTLSCertificate().Certificate[0],
 			Addresses:   committeeAddresses,
 		},
 		P2P: node.P2PInfo{
@@ -68,7 +68,7 @@ func registryRegisterNode(svc service.TendermintService, id *identity.Identity, 
 			registrationSigner,
 			id.P2PSigner,
 			id.ConsensusSigner,
-			id.TLSSigner,
+			id.GetTLSSigner(),
 		},
 		registry.RegisterGenesisNodeSignatureContext,
 		nodeDesc,

--- a/go/oasis-node/cmd/debug/byzantine/steps.go
+++ b/go/oasis-node/cmd/debug/byzantine/steps.go
@@ -42,7 +42,7 @@ func initDefaultIdentity(dataDir string) (*identity.Identity, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "identity NewFactory")
 	}
-	id, err := identity.LoadOrGenerate(dataDir, signerFactory)
+	id, err := identity.LoadOrGenerate(dataDir, signerFactory, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "identity LoadOrGenerate")
 	}

--- a/go/oasis-node/cmd/debug/byzantine/storage.go
+++ b/go/oasis-node/cmd/debug/byzantine/storage.go
@@ -69,7 +69,7 @@ func dialNode(node *node.Node, opts grpc.DialOption) (*grpc.ClientConn, func(), 
 }
 
 func newHonestNodeStorage(id *identity.Identity, node *node.Node) (*honestNodeStorage, error) {
-	opts, err := dialOptionForNode([]tls.Certificate{*id.TLSCertificate}, node)
+	opts, err := dialOptionForNode([]tls.Certificate{*id.GetTLSCertificate()}, node)
 	if err != nil {
 		return nil, errors.Wrap(err, "storage client DialOptionForNode")
 	}

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -99,10 +99,10 @@ func getNodeDesc(rng *rand.Rand, nodeIdentity *identity.Identity, entityID signa
 		Expiration: 0,
 		Roles:      availableRoles[rng.Intn(len(availableRoles))],
 		Committee: node.CommitteeInfo{
-			Certificate: nodeIdentity.TLSCertificate.Certificate[0],
+			Certificate: nodeIdentity.GetTLSCertificate().Certificate[0],
 			Addresses: []node.CommitteeAddress{
 				{
-					Certificate: nodeIdentity.TLSCertificate.Certificate[0],
+					Certificate: nodeIdentity.GetTLSCertificate().Certificate[0],
 					Address:     nodeAddr,
 				},
 			},
@@ -136,7 +136,7 @@ func signNode(identity *identity.Identity, nodeDesc *node.Node) (*node.MultiSign
 		identity.NodeSigner,
 		identity.P2PSigner,
 		identity.ConsensusSigner,
-		identity.TLSSigner,
+		identity.GetTLSSigner(),
 	}
 
 	sigNode, err := node.MultiSignNode(nodeSigners, registry.RegisterNodeSignatureContext, nodeDesc)
@@ -213,7 +213,7 @@ func (r *registration) Run( // nolint: gocyclo
 			if err != nil {
 				return fmt.Errorf("failed to create a temporary directory: %w", err)
 			}
-			ident, err := identity.LoadOrGenerate(dataDir, memorySigner.NewFactory())
+			ident, err := identity.LoadOrGenerate(dataDir, memorySigner.NewFactory(), false)
 			if err != nil {
 				return fmt.Errorf("failed generating account node identity: %w", err)
 			}

--- a/go/oasis-node/cmd/identity/identity.go
+++ b/go/oasis-node/cmd/identity/identity.go
@@ -50,7 +50,7 @@ func doNodeInit(cmd *cobra.Command, args []string) {
 		)
 		os.Exit(1)
 	}
-	if _, err = identity.LoadOrGenerate(dataDir, nodeSignerFactory); err != nil {
+	if _, err = identity.LoadOrGenerate(dataDir, nodeSignerFactory, true); err != nil {
 		logger.Error("failed to load or generate node identity",
 			"err", err,
 		)

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -372,13 +372,13 @@ func (n *Node) startWorkers(logger *logging.Logger) error {
 		return err
 	}
 
-	// Start the sentry worker.
-	if err := n.SentryWorker.Start(); err != nil {
+	// Start the worker registration service.
+	if err := n.RegistrationWorker.Start(); err != nil {
 		return err
 	}
 
-	// Start the worker registration service.
-	if err := n.RegistrationWorker.Start(); err != nil {
+	// Start the sentry worker.
+	if err := n.SentryWorker.Start(); err != nil {
 		return err
 	}
 

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -526,7 +526,7 @@ func newNode(testNode bool) (*Node, error) { // nolint: gocyclo
 		)
 		return nil, err
 	}
-	node.Identity, err = identity.LoadOrGenerate(dataDir, signerFactory)
+	node.Identity, err = identity.LoadOrGenerate(dataDir, signerFactory, false)
 	if err != nil {
 		logger.Error("failed to load/generate identity",
 			"err", err,

--- a/go/oasis-node/cmd/storage/benchmark/benchmark.go
+++ b/go/oasis-node/cmd/storage/benchmark/benchmark.go
@@ -70,7 +70,7 @@ func doBenchmark(cmd *cobra.Command, args []string) { // nolint: gocyclo
 	}
 
 	// Create an identity.
-	ident, err := identity.LoadOrGenerate(dataDir, memorySigner.NewFactory())
+	ident, err := identity.LoadOrGenerate(dataDir, memorySigner.NewFactory(), false)
 	if err != nil {
 		logger.Error("failed to generate a new identity",
 			"err", err,

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -307,10 +307,10 @@ func (args *argBuilder) grpcSentryUpstreamAddresses(addrs []string) *argBuilder 
 	return args
 }
 
-func (args *argBuilder) grpcSentryUpstreamCertFiles(certFiles []string) *argBuilder {
-	for _, certFile := range certFiles {
+func (args *argBuilder) grpcSentryUpstreamIDs(ids []string) *argBuilder {
+	for _, id := range ids {
 		args.vec = append(args.vec, []string{
-			"--" + workerGrpcSentry.CfgUpstreamCert, certFile,
+			"--" + workerGrpcSentry.CfgUpstreamID, id,
 		}...)
 	}
 	return args
@@ -374,31 +374,32 @@ func (args *argBuilder) addSentries(sentries []*Sentry) *argBuilder {
 }
 
 func (args *argBuilder) addValidatorsAsSentryUpstreams(validators []*Validator) *argBuilder {
-	var addrs []string
+	var addrs, ids []string
 	for _, val := range validators {
 		addrs = append(addrs, fmt.Sprintf("%s@127.0.0.1:%d", val.tmAddress, val.consensusPort))
+		ids = append(ids, val.NodeID.String())
 	}
-	return args.tendermintSentryUpstreamAddress(addrs)
+	return args.tendermintSentryUpstreamAddress(addrs).grpcSentryUpstreamIDs(ids)
 }
 
 func (args *argBuilder) addSentryStorageWorkers(storageWorkers []*Storage) *argBuilder {
-	var addrs, certFiles, tmAddrs []string
+	var addrs, ids, tmAddrs []string
 	for _, storageWorker := range storageWorkers {
 		addrs = append(addrs, fmt.Sprintf("127.0.0.1:%d", storageWorker.clientPort))
-		certFiles = append(certFiles, storageWorker.TLSCertPath())
+		ids = append(ids, storageWorker.NodeID.String())
 		tmAddrs = append(tmAddrs, fmt.Sprintf("%s@127.0.0.1:%d", storageWorker.tmAddress, storageWorker.consensusPort))
 	}
-	return args.grpcSentryUpstreamAddresses(addrs).grpcSentryUpstreamCertFiles(certFiles).tendermintSentryUpstreamAddress(tmAddrs)
+	return args.grpcSentryUpstreamAddresses(addrs).grpcSentryUpstreamIDs(ids).tendermintSentryUpstreamAddress(tmAddrs)
 }
 
 func (args *argBuilder) addSentryKeymanagerWorkers(keymanagerWorkers []*Keymanager) *argBuilder {
-	var addrs, certFiles, tmAddrs []string
+	var addrs, ids, tmAddrs []string
 	for _, keymanager := range keymanagerWorkers {
 		addrs = append(addrs, fmt.Sprintf("127.0.0.1:%d", keymanager.workerClientPort))
-		certFiles = append(certFiles, keymanager.TLSCertPath())
+		ids = append(ids, keymanager.NodeID.String())
 		tmAddrs = append(tmAddrs, fmt.Sprintf("%s@127.0.0.1:%d", keymanager.tmAddress, keymanager.consensusPort))
 	}
-	return args.grpcSentryUpstreamAddresses(addrs).grpcSentryUpstreamCertFiles(certFiles).tendermintSentryUpstreamAddress(tmAddrs)
+	return args.grpcSentryUpstreamAddresses(addrs).grpcSentryUpstreamIDs(ids).tendermintSentryUpstreamAddress(tmAddrs)
 }
 
 func (args *argBuilder) appendSeedNodes(net *Network) *argBuilder {

--- a/go/oasis-test-runner/oasis/byzantine.go
+++ b/go/oasis-test-runner/oasis/byzantine.go
@@ -83,7 +83,7 @@ func (net *Network) NewByzantine(cfg *ByzantineCfg) (*Byzantine, error) {
 	}
 
 	// Pre-provision the node identity so that we can update the entity.
-	publicKey, err := net.provisionNodeIdentity(byzantineDir, cfg.IdentitySeed)
+	publicKey, err := net.provisionNodeIdentity(byzantineDir, cfg.IdentitySeed, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/byzantine: failed to provision node identity")
 	}

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -121,7 +121,7 @@ func (net *Network) NewCompute(cfg *ComputeCfg) (*Compute, error) {
 
 	// Pre-provision the node identity so that we can update the entity.
 	seed := fmt.Sprintf(computeIdentitySeedTemplate, len(net.computeWorkers))
-	publicKey, err := net.provisionNodeIdentity(computeDir, seed)
+	publicKey, err := net.provisionNodeIdentity(computeDir, seed, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/compute: failed to provision node identity")
 	}

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -238,10 +238,16 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 		return nil, errors.Wrap(err, "oasis/keymanager: failed to create keymanager subdir")
 	}
 
+	// If we're using sentry nodes, we need to have a static TLS certificate.
+	var persistTLS bool
+	if len(cfg.SentryIndices) > 0 {
+		persistTLS = true
+	}
+
 	// Pre-provision the node identity so that we can update the entity.
 	// TODO: Use proper key manager index when multiple key managers are supported.
 	seed := fmt.Sprintf(keymanagerIdentitySeedTemplate, 0)
-	publicKey, err := net.provisionNodeIdentity(kmDir, seed)
+	publicKey, err := net.provisionNodeIdentity(kmDir, seed, persistTLS)
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/keymanager: failed to provision node identity")
 	}

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -238,16 +238,10 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 		return nil, errors.Wrap(err, "oasis/keymanager: failed to create keymanager subdir")
 	}
 
-	// If we're using sentry nodes, we need to have a static TLS certificate.
-	var persistTLS bool
-	if len(cfg.SentryIndices) > 0 {
-		persistTLS = true
-	}
-
 	// Pre-provision the node identity so that we can update the entity.
 	// TODO: Use proper key manager index when multiple key managers are supported.
 	seed := fmt.Sprintf(keymanagerIdentitySeedTemplate, 0)
-	publicKey, err := net.provisionNodeIdentity(kmDir, seed, persistTLS)
+	publicKey, err := net.provisionNodeIdentity(kmDir, seed, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/keymanager: failed to provision node identity")
 	}

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -625,7 +625,7 @@ func (net *Network) startOasisNode(
 	args = append(args, baseArgs...)
 	args = append(args, extraArgs.vec...)
 
-	if !strings.HasPrefix(node.Name, "sentry-") && len(net.byzantine) == 0 && net.iasProxy == nil {
+	if !strings.HasPrefix(node.Name, "sentry-") && !strings.HasPrefix(node.Name, "ias-proxy") && len(net.byzantine) == 0 {
 		args = append(args, []string{"--" + registration.CfgRegistrationRotateCerts, "1"}...)
 	}
 

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -625,7 +625,7 @@ func (net *Network) startOasisNode(
 	args = append(args, baseArgs...)
 	args = append(args, extraArgs.vec...)
 
-	if len(net.sentries) == 0 && len(net.byzantine) == 0 && net.iasProxy == nil {
+	if !strings.HasPrefix(node.Name, "sentry-") && len(net.byzantine) == 0 && net.iasProxy == nil {
 		args = append(args, []string{"--" + registration.CfgRegistrationRotateCerts, "1"}...)
 	}
 

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -28,6 +28,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/genesis"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
 	"github.com/oasislabs/oasis-core/go/oasis-test-runner/log"
+	"github.com/oasislabs/oasis-core/go/worker/registration"
 )
 
 const (
@@ -624,6 +625,10 @@ func (net *Network) startOasisNode(
 	args = append(args, baseArgs...)
 	args = append(args, extraArgs.vec...)
 
+	if len(net.sentries) == 0 && len(net.byzantine) == 0 && net.iasProxy == nil {
+		args = append(args, []string{"--" + registration.CfgRegistrationRotateCerts, "1"}...)
+	}
+
 	w, err := node.dir.NewLogWriter(logConsoleFile)
 	if err != nil {
 		return err
@@ -746,7 +751,7 @@ func (net *Network) BasePath() string {
 	return net.baseDir.String()
 }
 
-func (net *Network) provisionNodeIdentity(dataDir *env.Dir, seed string) (signature.PublicKey, error) {
+func (net *Network) provisionNodeIdentity(dataDir *env.Dir, seed string, persistTLS bool) (signature.PublicKey, error) {
 	if net.cfg.DeterministicIdentities {
 		if err := net.generateDeterministicNodeIdentity(dataDir, seed); err != nil {
 			return signature.PublicKey{}, errors.Wrap(err, "oasis: failed to generate deterministic identity")
@@ -757,7 +762,7 @@ func (net *Network) provisionNodeIdentity(dataDir *env.Dir, seed string) (signat
 	if err != nil {
 		return signature.PublicKey{}, errors.Wrap(err, "oasis: failed to create node file signer factory")
 	}
-	nodeIdentity, err := identity.LoadOrGenerate(dataDir.String(), signerFactory)
+	nodeIdentity, err := identity.LoadOrGenerate(dataDir.String(), signerFactory, persistTLS)
 	if err != nil {
 		return signature.PublicKey{}, errors.Wrap(err, "oasis: failed to provision node identity")
 	}

--- a/go/oasis-test-runner/oasis/seed.go
+++ b/go/oasis-test-runner/oasis/seed.go
@@ -57,7 +57,7 @@ func (net *Network) newSeedNode() (*seedNode, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/seed: failed to create seed signer factory")
 	}
-	seedIdentity, err := identity.LoadOrGenerate(seedDir.String(), signerFactory)
+	seedIdentity, err := identity.LoadOrGenerate(seedDir.String(), signerFactory, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/seed: failed to provision seed identity")
 	}

--- a/go/oasis-test-runner/oasis/sentry.go
+++ b/go/oasis-test-runner/oasis/sentry.go
@@ -61,7 +61,8 @@ func (sentry *Sentry) startNode() error {
 		workerSentryControlPort(sentry.controlPort).
 		tendermintCoreListenAddress(sentry.consensusPort).
 		appendNetwork(sentry.net).
-		appendSeedNodes(sentry.net)
+		appendSeedNodes(sentry.net).
+		internalSocketAddress(sentry.net.validators[0].SocketPath())
 
 	if len(validators) > 0 {
 		args = args.addValidatorsAsSentryUpstreams(validators)

--- a/go/oasis-test-runner/oasis/sentry.go
+++ b/go/oasis-test-runner/oasis/sentry.go
@@ -112,7 +112,7 @@ func (net *Network) NewSentry(cfg *SentryCfg) (*Sentry, error) {
 		)
 		return nil, fmt.Errorf("oasis/sentry: failed to create sentry file signer: %w", err)
 	}
-	sentryIdentity, err := identity.LoadOrGenerate(sentryDir.String(), signerFactory)
+	sentryIdentity, err := identity.LoadOrGenerate(sentryDir.String(), signerFactory, true)
 	if err != nil {
 		net.logger.Error("failed to provision sentry identity",
 			"err", err,

--- a/go/oasis-test-runner/oasis/storage.go
+++ b/go/oasis-test-runner/oasis/storage.go
@@ -141,9 +141,15 @@ func (net *Network) NewStorage(cfg *StorageCfg) (*Storage, error) {
 		return nil, errors.Wrap(err, "oasis/storage: failed to create storage subdir")
 	}
 
+	// If we're using sentry nodes, we need to have a static TLS certificate.
+	var persistTLS bool
+	if len(cfg.SentryIndices) > 0 {
+		persistTLS = true
+	}
+
 	// Pre-provision the node identity so that we can update the entity.
 	seed := fmt.Sprintf(storageIdentitySeedTemplate, len(net.storageWorkers))
-	publicKey, err := net.provisionNodeIdentity(storageDir, seed)
+	publicKey, err := net.provisionNodeIdentity(storageDir, seed, persistTLS)
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/storage: failed to provision node identity")
 	}

--- a/go/oasis-test-runner/oasis/storage.go
+++ b/go/oasis-test-runner/oasis/storage.go
@@ -141,15 +141,9 @@ func (net *Network) NewStorage(cfg *StorageCfg) (*Storage, error) {
 		return nil, errors.Wrap(err, "oasis/storage: failed to create storage subdir")
 	}
 
-	// If we're using sentry nodes, we need to have a static TLS certificate.
-	var persistTLS bool
-	if len(cfg.SentryIndices) > 0 {
-		persistTLS = true
-	}
-
 	// Pre-provision the node identity so that we can update the entity.
 	seed := fmt.Sprintf(storageIdentitySeedTemplate, len(net.storageWorkers))
-	publicKey, err := net.provisionNodeIdentity(storageDir, seed, persistTLS)
+	publicKey, err := net.provisionNodeIdentity(storageDir, seed, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/storage: failed to provision node identity")
 	}

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -157,16 +157,10 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 		consensusAddrs = append(consensusAddrs, &consensusAddr)
 	}
 
-	// If we're using sentry nodes, we need to have a static TLS certificate.
-	var persistTLS bool
-	if len(val.sentries) > 0 {
-		persistTLS = true
-	}
-
 	// Load node's identity, so that we can pass the validator's Tendermint
 	// address to sentry node(s) to configure it as a private peer.
 	seed := fmt.Sprintf(validatorIdentitySeedTemplate, len(net.validators))
-	valPublicKey, err := net.provisionNodeIdentity(valDir, seed, persistTLS)
+	valPublicKey, err := net.provisionNodeIdentity(valDir, seed, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/validator: failed to provision node identity")
 	}

--- a/go/oasis-test-runner/oasis/validator.go
+++ b/go/oasis-test-runner/oasis/validator.go
@@ -157,10 +157,16 @@ func (net *Network) NewValidator(cfg *ValidatorCfg) (*Validator, error) {
 		consensusAddrs = append(consensusAddrs, &consensusAddr)
 	}
 
+	// If we're using sentry nodes, we need to have a static TLS certificate.
+	var persistTLS bool
+	if len(val.sentries) > 0 {
+		persistTLS = true
+	}
+
 	// Load node's identity, so that we can pass the validator's Tendermint
 	// address to sentry node(s) to configure it as a private peer.
 	seed := fmt.Sprintf(validatorIdentitySeedTemplate, len(net.validators))
-	valPublicKey, err := net.provisionNodeIdentity(valDir, seed)
+	valPublicKey, err := net.provisionNodeIdentity(valDir, seed, persistTLS)
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/validator: failed to provision node identity")
 	}

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -496,6 +496,7 @@ func (r *registryCLIImpl) initNode(childEnv *env.Env, ent *entity.Entity, entDir
 	// Replace our testNode fields with the generated one, so we can just marshal both nodes and compare the output afterwards.
 	testNode.ID = n.ID
 	testNode.Committee.Certificate = n.Committee.Certificate
+	testNode.Committee.NextCertificate = n.Committee.NextCertificate
 	testNode.P2P.ID = n.P2P.ID
 	testNode.Consensus.ID = n.Consensus.ID
 	for idx := range testNode.Committee.Addresses {
@@ -517,6 +518,15 @@ func (r *registryCLIImpl) initNode(childEnv *env.Env, ent *entity.Entity, entDir
 	if err != nil {
 		return nil, err
 	}
+
+	// TLS certificates are regenerated each time, so replace them with new ones.
+	testNode.Committee.Certificate = n.Committee.Certificate
+	testNode.Committee.NextCertificate = n.Committee.NextCertificate
+	for idx := range testNode.Committee.Addresses {
+		testNode.Committee.Addresses[idx].Certificate = n.Committee.Certificate
+	}
+	testNodeStr, _ = json.Marshal(testNode)
+
 	nStr, _ = json.Marshal(n)
 	if !bytes.Equal(nStr, testNodeStr) {
 		return nil, fmt.Errorf("second run test node mismatch! Original node: %s, imported node: %s", testNodeStr, nStr)

--- a/go/registry/tests/tester.go
+++ b/go/registry/tests/tester.go
@@ -597,12 +597,12 @@ func randomIdentity(rng *drbg.Drbg) *identity.Identity {
 		ConsensusSigner: mustGenerateSigner(),
 	}
 
-	var err error
-	ident.TLSCertificate, err = tls.Generate(identity.CommonName)
+	cert, err := tls.Generate(identity.CommonName)
 	if err != nil {
 		panic(err)
 	}
-	ident.TLSSigner = memorySigner.NewFromRuntime(ident.TLSCertificate.PrivateKey.(ed25519.PrivateKey))
+	ident.SetTLSCertificate(cert)
+	ident.SetTLSSigner(memorySigner.NewFromRuntime(cert.PrivateKey.(ed25519.PrivateKey)))
 
 	return ident
 }
@@ -628,7 +628,7 @@ func (ent *TestEntity) NewTestNodes(nCompute int, nStorage int, idNonce []byte, 
 			ent.Signer,
 			nodeIdentity.P2PSigner,
 			nodeIdentity.ConsensusSigner,
-			nodeIdentity.TLSSigner,
+			nodeIdentity.GetTLSSigner(),
 		}
 		invalidIdentity := randomIdentity(rng)
 
@@ -660,7 +660,7 @@ func (ent *TestEntity) NewTestNodes(nCompute int, nStorage int, idNonce []byte, 
 		nod.Node.P2P.Addresses = append(nod.Node.P2P.Addresses, addr)
 		nod.Node.Consensus.ID = nodeIdentity.ConsensusSigner.Public()
 		// Generate dummy TLS certificate.
-		nod.Node.Committee.Certificate = nodeIdentity.TLSCertificate.Certificate[0]
+		nod.Node.Committee.Certificate = nodeIdentity.GetTLSCertificate().Certificate[0]
 		nod.Node.Committee.Addresses = []node.CommitteeAddress{
 			node.CommitteeAddress{
 				Certificate: nod.Node.Committee.Certificate,
@@ -756,7 +756,7 @@ func (ent *TestEntity) NewTestNodes(nCompute int, nStorage int, idNonce []byte, 
 					nodeIdentity.NodeSigner,
 					ent.Signer,
 					nodeIdentity.ConsensusSigner,
-					nodeIdentity.TLSSigner,
+					nodeIdentity.GetTLSSigner(),
 				},
 				api.RegisterNodeSignatureContext,
 				&invNode6,
@@ -821,7 +821,7 @@ func (ent *TestEntity) NewTestNodes(nCompute int, nStorage int, idNonce []byte, 
 				nodeIdentity.NodeSigner,
 				ent.Signer,
 				nodeIdentity.P2PSigner,
-				nodeIdentity.TLSSigner,
+				nodeIdentity.GetTLSSigner(),
 			},
 			api.RegisterNodeSignatureContext,
 			&invNode10,
@@ -838,14 +838,14 @@ func (ent *TestEntity) NewTestNodes(nCompute int, nStorage int, idNonce []byte, 
 		invNode11 := *nod.Node
 		invNode11.ID = invalidIdentity.NodeSigner.Public()
 		invNode11.Consensus.ID = invalidIdentity.ConsensusSigner.Public()
-		invNode11.Committee.Certificate = invalidIdentity.TLSCertificate.Certificate[0]
+		invNode11.Committee.Certificate = invalidIdentity.GetTLSCertificate().Certificate[0]
 		invalid11.signed, err = node.MultiSignNode(
 			[]signature.Signer{
 				invalidIdentity.NodeSigner,
 				ent.Signer,
 				invalidIdentity.ConsensusSigner,
 				nodeIdentity.P2PSigner,
-				invalidIdentity.TLSSigner,
+				invalidIdentity.GetTLSSigner(),
 			},
 			api.RegisterNodeSignatureContext,
 			&invNode11,
@@ -862,14 +862,14 @@ func (ent *TestEntity) NewTestNodes(nCompute int, nStorage int, idNonce []byte, 
 		invNode12 := *nod.Node
 		invNode12.ID = invalidIdentity.NodeSigner.Public()
 		invNode12.P2P.ID = invalidIdentity.ConsensusSigner.Public()
-		invNode12.Committee.Certificate = invalidIdentity.TLSCertificate.Certificate[0]
+		invNode12.Committee.Certificate = invalidIdentity.GetTLSCertificate().Certificate[0]
 		invalid12.signed, err = node.MultiSignNode(
 			[]signature.Signer{
 				invalidIdentity.NodeSigner,
 				ent.Signer,
 				nodeIdentity.ConsensusSigner,
 				invalidIdentity.P2PSigner,
-				invalidIdentity.TLSSigner,
+				invalidIdentity.GetTLSSigner(),
 			},
 			api.RegisterNodeSignatureContext,
 			&invNode12,
@@ -893,7 +893,7 @@ func (ent *TestEntity) NewTestNodes(nCompute int, nStorage int, idNonce []byte, 
 				ent.Signer,
 				invalidIdentity.ConsensusSigner,
 				invalidIdentity.P2PSigner,
-				nodeIdentity.TLSSigner,
+				nodeIdentity.GetTLSSigner(),
 			},
 			api.RegisterNodeSignatureContext,
 			&invNode13,
@@ -945,14 +945,14 @@ func (ent *TestEntity) NewTestNodes(nCompute int, nStorage int, idNonce []byte, 
 		}
 		newNode.P2P.ID = invalidIdentity.P2PSigner.Public()
 		newNode.Consensus.ID = invalidIdentity.ConsensusSigner.Public()
-		newNode.Committee.Certificate = invalidIdentity.TLSCertificate.Certificate[0]
+		newNode.Committee.Certificate = invalidIdentity.GetTLSCertificate().Certificate[0]
 		invalid14.signed, err = node.MultiSignNode(
 			[]signature.Signer{
 				nodeIdentity.NodeSigner,
 				ent.Signer,
 				invalidIdentity.ConsensusSigner,
 				invalidIdentity.P2PSigner,
-				invalidIdentity.TLSSigner,
+				invalidIdentity.GetTLSSigner(),
 			},
 			api.RegisterNodeSignatureContext,
 			newNode,

--- a/go/runtime/committee/client.go
+++ b/go/runtime/committee/client.go
@@ -264,9 +264,11 @@ func (cc *committeeClient) updateConnectionLocked(n *node.Node) error {
 		RootCAs:    certPool,
 		ServerName: identity.CommonName,
 	}
-	if cc.clientIdentity != nil {
+	if cc.clientIdentity != nil && cc.clientIdentity.GetTLSCertificate() != nil {
 		// Configure TLS client authentication if required.
-		tlsCfg.Certificates = []tls.Certificate{*cc.clientIdentity.TLSCertificate}
+		tlsCfg.GetClientCertificate = func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return cc.clientIdentity.GetTLSCertificate(), nil
+		}
 	}
 	creds := credentials.NewTLS(&tlsCfg)
 

--- a/go/sentry/api/api.go
+++ b/go/sentry/api/api.go
@@ -3,7 +3,6 @@ package api
 
 import (
 	"context"
-	"crypto/tls"
 
 	"github.com/oasislabs/oasis-core/go/common/node"
 )
@@ -14,12 +13,6 @@ type SentryAddresses struct {
 	Committee []node.CommitteeAddress
 }
 
-// UpstreamTLSCertificates contains the upstream TLS certificates.
-type UpstreamTLSCertificates struct {
-	Certificate     *tls.Certificate
-	NextCertificate *tls.Certificate
-}
-
 // Backend is a sentry backend implementation.
 type Backend interface {
 	// Get addresses returns the list of consensus and committee addresses of
@@ -28,8 +21,8 @@ type Backend interface {
 
 	// SetUpstreamTLSCertificates notifies the sentry node of the new
 	// TLS certificates used by its upstream node.
-	SetUpstreamTLSCertificates(context.Context, *tls.Certificate, *tls.Certificate) error
+	SetUpstreamTLSCertificates(context.Context, [][]byte) error
 
 	// GetUpstreamTLSCertificates returns the TLS certificates of the sentry node's upstream node.
-	GetUpstreamTLSCertificates(context.Context) (*UpstreamTLSCertificates, error)
+	GetUpstreamTLSCertificates(context.Context) ([][]byte, error)
 }

--- a/go/sentry/api/api.go
+++ b/go/sentry/api/api.go
@@ -3,6 +3,7 @@ package api
 
 import (
 	"context"
+	"crypto/tls"
 
 	"github.com/oasislabs/oasis-core/go/common/node"
 )
@@ -13,9 +14,22 @@ type SentryAddresses struct {
 	Committee []node.CommitteeAddress
 }
 
+// UpstreamTLSCertificates contains the upstream TLS certificates.
+type UpstreamTLSCertificates struct {
+	Certificate     *tls.Certificate
+	NextCertificate *tls.Certificate
+}
+
 // Backend is a sentry backend implementation.
 type Backend interface {
 	// Get addresses returns the list of consensus and committee addresses of
 	// the sentry node.
 	GetAddresses(context.Context) (*SentryAddresses, error)
+
+	// SetUpstreamTLSCertificates notifies the sentry node of the new
+	// TLS certificates used by its upstream node.
+	SetUpstreamTLSCertificates(context.Context, *tls.Certificate, *tls.Certificate) error
+
+	// GetUpstreamTLSCertificates returns the TLS certificates of the sentry node's upstream node.
+	GetUpstreamTLSCertificates(context.Context) (*UpstreamTLSCertificates, error)
 }

--- a/go/sentry/client/client.go
+++ b/go/sentry/client/client.go
@@ -45,9 +45,11 @@ func (c *Client) createConnection() error {
 	certPool := x509.NewCertPool()
 	certPool.AddCert(c.sentryCert)
 	creds := credentials.NewTLS(&tls.Config{
-		Certificates: []tls.Certificate{*c.nodeIdentity.TLSCertificate},
-		RootCAs:      certPool,
-		ServerName:   identity.CommonName,
+		RootCAs:    certPool,
+		ServerName: identity.CommonName,
+		GetClientCertificate: func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return c.nodeIdentity.GetTLSCertificate(), nil
+		},
 	})
 	opts := grpc.WithTransportCredentials(creds)
 

--- a/go/sentry/client/client.go
+++ b/go/sentry/client/client.go
@@ -45,11 +45,9 @@ func (c *Client) createConnection() error {
 	certPool := x509.NewCertPool()
 	certPool.AddCert(c.sentryCert)
 	creds := credentials.NewTLS(&tls.Config{
-		RootCAs:    certPool,
-		ServerName: identity.CommonName,
-		GetClientCertificate: func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-			return c.nodeIdentity.GetTLSCertificate(), nil
-		},
+		RootCAs:      certPool,
+		ServerName:   identity.CommonName,
+		Certificates: []tls.Certificate{*c.nodeIdentity.TLSSentryClientCertificate},
 	})
 	opts := grpc.WithTransportCredentials(creds)
 

--- a/go/sentry/sentry.go
+++ b/go/sentry/sentry.go
@@ -40,7 +40,7 @@ func (b *backend) GetAddresses(ctx context.Context) (*api.SentryAddresses, error
 	var committeeAddresses []node.CommitteeAddress
 	for _, addr := range committeeAddrs {
 		committeeAddresses = append(committeeAddresses, node.CommitteeAddress{
-			Certificate: b.identity.TLSCertificate.Certificate[0],
+			Certificate: b.identity.GetTLSCertificate().Certificate[0],
 			Address:     addr,
 		})
 	}

--- a/go/sentry/sentry.go
+++ b/go/sentry/sentry.go
@@ -3,7 +3,6 @@ package sentry
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"sync"
 
@@ -25,8 +24,7 @@ type backend struct {
 	consensus consensus.Backend
 	identity  *identity.Identity
 
-	upstreamTLSCertificate     *tls.Certificate
-	upstreamTLSCertificateNext *tls.Certificate
+	upstreamTLSCertificates [][]byte
 }
 
 func (b *backend) GetAddresses(ctx context.Context) (*api.SentryAddresses, error) {
@@ -67,24 +65,20 @@ func (b *backend) GetAddresses(ctx context.Context) (*api.SentryAddresses, error
 	}, nil
 }
 
-func (b *backend) SetUpstreamTLSCertificates(ctx context.Context, cert *tls.Certificate, certNext *tls.Certificate) error {
+func (b *backend) SetUpstreamTLSCertificates(ctx context.Context, certs [][]byte) error {
 	b.Lock()
 	defer b.Unlock()
 
-	b.upstreamTLSCertificate = cert
-	b.upstreamTLSCertificateNext = certNext
+	b.upstreamTLSCertificates = certs
 
 	return nil
 }
 
-func (b *backend) GetUpstreamTLSCertificates(ctx context.Context) (*api.UpstreamTLSCertificates, error) {
+func (b *backend) GetUpstreamTLSCertificates(ctx context.Context) ([][]byte, error) {
 	b.RLock()
 	defer b.RUnlock()
 
-	return &api.UpstreamTLSCertificates{
-		Certificate:     b.upstreamTLSCertificate,
-		NextCertificate: b.upstreamTLSCertificateNext,
-	}, nil
+	return b.upstreamTLSCertificates, nil
 }
 
 // New constructs a new sentry Backend instance.

--- a/go/storage/mkvs/interop/cmd/protocol_server.go
+++ b/go/storage/mkvs/interop/cmd/protocol_server.go
@@ -45,7 +45,7 @@ func doProtoServer(cmd *cobra.Command, args []string) {
 	genesisTestHelpers.SetTestChainContext()
 
 	// Generate dummy identity.
-	ident, err := identity.LoadOrGenerate(dataDir, memorySigner.NewFactory())
+	ident, err := identity.LoadOrGenerate(dataDir, memorySigner.NewFactory(), false)
 	if err != nil {
 		logger.Error("failed to generate identity",
 			"err", err,

--- a/go/worker/common/committee/accessctl.go
+++ b/go/worker/common/committee/accessctl.go
@@ -29,9 +29,19 @@ func (ap AccessPolicy) AddRulesForCommittee(policy *accessctl.Policy, committee 
 			continue
 		}
 
+		// Allow the node to perform actions from the given access policy.
 		subject := accessctl.SubjectFromDER(node.Committee.Certificate)
 		for _, action := range ap.Actions {
 			policy.Allow(subject, action)
+		}
+
+		// Make sure to also allow the node to perform actions after it has
+		// rotated its TLS certificates.
+		if node.Committee.NextCertificate != nil {
+			subject := accessctl.SubjectFromDER(node.Committee.NextCertificate)
+			for _, action := range ap.Actions {
+				policy.Allow(subject, action)
+			}
 		}
 	}
 }
@@ -58,7 +68,15 @@ func (ap AccessPolicy) AddRulesForNodeRoles(
 			for _, action := range ap.Actions {
 				policy.Allow(subject, action)
 			}
-		}
 
+			// Make sure to also allow the node to perform actions after is has
+			// rotated its TLS certificates.
+			if n.Committee.NextCertificate != nil {
+				subject := accessctl.SubjectFromDER(n.Committee.NextCertificate)
+				for _, action := range ap.Actions {
+					policy.Allow(subject, action)
+				}
+			}
+		}
 	}
 }

--- a/go/worker/common/worker.go
+++ b/go/worker/common/worker.go
@@ -267,9 +267,9 @@ func New(
 
 	// Create externally-accessible gRPC server.
 	serverConfig := &grpc.ServerConfig{
-		Name:        "external",
-		Port:        cfg.ClientPort,
-		Certificate: identity.TLSCertificate,
+		Name:     "external",
+		Port:     cfg.ClientPort,
+		Identity: identity,
 	}
 	grpc, err := grpc.NewServer(serverConfig)
 	if err != nil {

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -165,7 +165,15 @@ func (w *Worker) registrationLoop() { // nolint: gocyclo
 				}
 				defer client.Close()
 
-				err = client.SetUpstreamTLSCertificates(w.ctx, w.identity.GetTLSCertificate(), w.identity.GetNextTLSCertificate())
+				certs := [][]byte{}
+				if c := w.identity.GetTLSCertificate(); c != nil {
+					certs = append(certs, c.Certificate[0])
+				}
+				if c := w.identity.GetNextTLSCertificate(); c != nil {
+					certs = append(certs, c.Certificate[0])
+				}
+
+				err = client.SetUpstreamTLSCertificates(w.ctx, certs)
 				if err != nil {
 					return err
 				}
@@ -677,7 +685,14 @@ func (w *Worker) querySentries() ([]node.ConsensusAddress, []node.CommitteeAddre
 		}
 
 		// Keep sentries updated with our latest TLS certificates.
-		err = client.SetUpstreamTLSCertificates(w.ctx, w.identity.GetTLSCertificate(), w.identity.GetNextTLSCertificate())
+		certs := [][]byte{}
+		if c := w.identity.GetTLSCertificate(); c != nil {
+			certs = append(certs, c.Certificate[0])
+		}
+		if c := w.identity.GetNextTLSCertificate(); c != nil {
+			certs = append(certs, c.Certificate[0])
+		}
+		err = client.SetUpstreamTLSCertificates(w.ctx, certs)
 		if err != nil {
 			w.logger.Warn("failed to provide upstream TLS certificates to sentry node",
 				"err", err,

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -508,8 +508,10 @@ func (w *Worker) gatherCommitteeAddresses(sentryCommitteeAddrs []node.CommitteeA
 }
 
 func (w *Worker) registerNode(epoch epochtime.EpochTime, hook RegisterNodeHook) error {
+	identityPublic := w.identity.NodeSigner.Public()
 	w.logger.Info("performing node (re-)registration",
 		"epoch", epoch,
+		"node_id", identityPublic.String(),
 	)
 
 	var nextCert []byte
@@ -517,7 +519,6 @@ func (w *Worker) registerNode(epoch epochtime.EpochTime, hook RegisterNodeHook) 
 		nextCert = c.Certificate[0]
 	}
 
-	identityPublic := w.identity.NodeSigner.Public()
 	nodeDesc := node.Node{
 		ID:         identityPublic,
 		EntityID:   w.entityID,
@@ -631,7 +632,7 @@ func (w *Worker) querySentries() ([]node.ConsensusAddress, []node.CommitteeAddre
 		// Query sentry node for addresses.
 		sentryAddresses, err := client.GetAddresses(w.ctx)
 		if err != nil {
-			w.logger.Warn("failed to obtain addressesfrom sentry node",
+			w.logger.Warn("failed to obtain addresses from sentry node",
 				"err", err,
 				"sentry_address", sentryAddr,
 			)

--- a/go/worker/sentry/grpc/init.go
+++ b/go/worker/sentry/grpc/init.go
@@ -6,13 +6,16 @@ import (
 	tlsPkg "crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/resolver"
 
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	cmnGrpc "github.com/oasislabs/oasis-core/go/common/grpc"
 	"github.com/oasislabs/oasis-core/go/common/grpc/policy"
 	"github.com/oasislabs/oasis-core/go/common/grpc/proxy"
@@ -20,6 +23,9 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/identity"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
+	genesis "github.com/oasislabs/oasis-core/go/genesis/file"
+	cmdGrpc "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/grpc"
+	registry "github.com/oasislabs/oasis-core/go/registry/api"
 	"github.com/oasislabs/oasis-core/go/worker/common/configparser"
 )
 
@@ -29,14 +35,16 @@ const (
 
 	// CfgUpstreamAddress is the grpc address of the upstream node.
 	CfgUpstreamAddress = "worker.sentry.grpc.upstream.address"
-
-	// CfgUpstreamCert is the path to the certificate files of the upstream node.
-	CfgUpstreamCert = "worker.sentry.grpc.upstream.cert"
+	// CfgUpstreamID is the node ID of the upstream node.
+	CfgUpstreamID = "worker.sentry.grpc.upstream.id"
 
 	// CfgClientAddresses are addresses on which the gRPC endpoint is reachable.
 	CfgClientAddresses = "worker.sentry.grpc.client.address"
 	// CfgClientPort is the sentry node's client port.
 	CfgClientPort = "worker.sentry.grpc.client.port"
+
+	maxRetries    = 3
+	retryInterval = 1 * time.Second
 )
 
 // Flags has the configuration flags.
@@ -51,25 +59,146 @@ func GetNodeAddresses() ([]node.Address, error) {
 	return clientAddresses, nil
 }
 
-func initConnection(ident *identity.Identity) (*upstreamConn, error) {
+func initConnection(ctx context.Context, logger *logging.Logger, ident *identity.Identity) (*upstreamConn, error) {
 	var err error
 
 	addr := viper.GetString(CfgUpstreamAddress)
-	certFile := viper.GetString(CfgUpstreamCert)
 
 	upstreamAddrs, err := configparser.ParseAddressList([]string{addr})
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse address: %s: %w", addr, err)
 	}
 
-	upstreamCerts, err := configparser.ParseCertificateFiles([]string{certFile})
+	upstreamNodeIDRaw := viper.GetString(CfgUpstreamID)
+	var upstreamNodeID signature.PublicKey
+	err = upstreamNodeID.UnmarshalText([]byte(upstreamNodeIDRaw))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse certificate file %s: %w", certFile, err)
+		return nil, fmt.Errorf("malformed upstream node ID: %s: %w", upstreamNodeIDRaw, err)
 	}
+
+	logger.Info("upstream node ID is valid",
+		"upstream_node_id", upstreamNodeIDRaw,
+	)
+
+	// Get upstream node's certificates from registry.
+	regAddr := viper.GetString(cmdGrpc.CfgAddress)
+	regConn, err := cmnGrpc.Dial(regAddr, []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
+	}...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create registry gRPC client: %w", err)
+	}
+	regClient := registry.NewRegistryClient(regConn)
+
+	var upstreamNode *node.Node
+	var numRetries uint
+
+	retryGetNode := func() error {
+		var grr error
+		upstreamNode, grr = regClient.GetNode(ctx, &registry.IDQuery{
+			Height: 0,
+			ID:     upstreamNodeID,
+		})
+
+		if numRetries < maxRetries {
+			numRetries++
+			return grr
+		}
+		return backoff.Permanent(grr)
+	}
+	retryGetNodeSchedule := backoff.NewConstantBackOff(retryInterval)
+	err = backoff.Retry(retryGetNode, backoff.WithContext(retryGetNodeSchedule, ctx))
+	if err != nil {
+		// Failed to get node from registry, try the genesis doc instead.
+		logger.Warn("unable to get upstream node from registry, falling back to genesis",
+			"err", err,
+		)
+
+		genesisProvider, grr := genesis.DefaultFileProvider()
+		if grr != nil {
+			return nil, fmt.Errorf("failed to get upstream node from both registry and genesis, failure loading genesis file: %w", grr)
+		}
+
+		genDoc, grr := genesisProvider.GetGenesisDocument()
+		if grr != nil {
+			return nil, fmt.Errorf("failed to get upstream node from both registry and genesis, failure getting genesis document: %w", grr)
+		}
+
+		genNodes := genDoc.Registry.Nodes
+		upstreamNode = nil
+		for _, sn := range genNodes {
+			var n node.Node
+			if grr := sn.Open(registry.RegisterGenesisNodeSignatureContext, &n); grr != nil {
+				return nil, fmt.Errorf("failed to open signed node: %w", grr)
+			}
+			if n.ID.Equal(upstreamNodeID) {
+				upstreamNode = &n
+				break
+			}
+		}
+	}
+
+	if upstreamNode == nil {
+		// Wait for the node to register.
+		regCh, regSub, regErr := regClient.WatchNodes(ctx)
+		if regErr != nil {
+			return nil, fmt.Errorf("unable to watch for nodes: %w", regErr)
+		}
+		defer regSub.Close()
+		logger.Info("waiting for upstream node to register...",
+			"upstream_node_id", upstreamNodeID.String(),
+		)
+		for {
+			select {
+			case nodeEvent, ok := <-regCh:
+				if !ok {
+					return nil, fmt.Errorf("WatchNodes channel closed while waiting for upstream node to register")
+				}
+
+				if nodeEvent.Node.ID.Equal(upstreamNodeID) {
+					// Our upstream node finally registered!
+					upstreamNode = nodeEvent.Node
+					break
+				}
+			case <-ctx.Done():
+				return nil, fmt.Errorf("context aborted")
+			}
+
+			if upstreamNode != nil {
+				break
+			}
+		}
+	}
+
+	if upstreamNode == nil {
+		return nil, fmt.Errorf("upstream node not found in registry nor genesis document, nor did it register")
+	}
+
+	upstreamCerts := [][]byte{}
+	if upstreamNode.Committee.Certificate != nil {
+		upstreamCerts = append(upstreamCerts, upstreamNode.Committee.Certificate)
+	}
+	if upstreamNode.Committee.NextCertificate != nil {
+		upstreamCerts = append(upstreamCerts, upstreamNode.Committee.NextCertificate)
+	}
+	if len(upstreamCerts) == 0 {
+		return nil, fmt.Errorf("upstream node has no defined TLS certificates")
+	}
+
+	logger.Info("found certificates for upstream node",
+		"num_certs", len(upstreamCerts),
+	)
 
 	certPool := x509.NewCertPool()
 	for _, cert := range upstreamCerts {
-		certPool.AddCert(cert)
+		// Parse cert and add it to the pool.
+		parsedCert, grr := x509.ParseCertificate(cert)
+		if grr != nil {
+			// This should never happen.
+			return nil, fmt.Errorf("unable to parse certificate: %w", grr)
+		}
+		certPool.AddCert(parsedCert)
 	}
 	creds := credentials.NewTLS(&tlsPkg.Config{
 		RootCAs:    certPool,
@@ -98,8 +227,11 @@ func initConnection(ident *identity.Identity) (*upstreamConn, error) {
 	manualResolver.UpdateState(resolverState)
 
 	return &upstreamConn{
-		conn:              conn,
-		resolverCleanupCb: cleanupCb,
+		nodeID:             upstreamNodeID,
+		certs:              upstreamCerts,
+		conn:               conn,
+		registryClientConn: regConn,
+		resolverCleanupCb:  cleanupCb,
 	}, nil
 }
 
@@ -126,7 +258,7 @@ func New(identity *identity.Identity) (*Worker, error) {
 	if g.enabled {
 		logger.Info("Initializing gRPC sentry worker")
 
-		upstreamConn, err := initConnection(identity)
+		upstreamConn, err := initConnection(g.ctx, logger, identity)
 		if err != nil {
 			return nil, fmt.Errorf("gRPC sentry worker initializing upstream connection failure: %w", err)
 		}
@@ -143,11 +275,11 @@ func New(identity *identity.Identity) (*Worker, error) {
 				grpc.UnknownServiceHandler(proxy.Handler(upstreamConn.conn)),
 			},
 		}
-		grpc, err := cmnGrpc.NewServer(serverConfig)
+		grpcServer, err := cmnGrpc.NewServer(serverConfig)
 		if err != nil {
 			return nil, err
 		}
-		g.grpc = grpc
+		g.grpc = grpcServer
 	}
 
 	return g, nil
@@ -156,9 +288,10 @@ func New(identity *identity.Identity) (*Worker, error) {
 func init() {
 	Flags.Bool(CfgEnabled, false, "Enable Sentry gRPC worker (NOTE: This should only be enabled on gRPC Sentry nodes.)")
 	Flags.String(CfgUpstreamAddress, "", "Address of the upstream node")
-	Flags.String(CfgUpstreamCert, "", "Path to tls certificate of the upstream node")
+	Flags.String(CfgUpstreamID, "", "ID of the upstream node")
 	Flags.StringSlice(CfgClientAddresses, []string{}, "Address/port(s) to use for client connections for accessing this node")
 	Flags.Uint16(CfgClientPort, 9100, "Port to use for incoming gRPC client connections")
 
 	_ = viper.BindPFlags(Flags)
+	Flags.AddFlagSet(cmdGrpc.ClientFlags)
 }

--- a/go/worker/sentry/grpc/init.go
+++ b/go/worker/sentry/grpc/init.go
@@ -75,22 +75,13 @@ func initConnection(ctx context.Context, logger *logging.Logger, ident *identity
 	)
 
 	// Get upstream node's certificates.
-	certs, err := backend.GetUpstreamTLSCertificates(ctx)
+	upstreamCerts, err := backend.GetUpstreamTLSCertificates(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get upstream node's TLS certificates: %w", err)
-	}
-
-	upstreamCerts := [][]byte{}
-	if certs.Certificate != nil {
-		upstreamCerts = append(upstreamCerts, certs.Certificate.Certificate[0])
-	}
-	if certs.NextCertificate != nil {
-		upstreamCerts = append(upstreamCerts, certs.NextCertificate.Certificate[0])
 	}
 	if len(upstreamCerts) == 0 {
 		return nil, fmt.Errorf("upstream node has no defined TLS certificates")
 	}
-
 	logger.Info("found certificates for upstream node",
 		"num_certs", len(upstreamCerts),
 	)

--- a/go/worker/sentry/worker.go
+++ b/go/worker/sentry/worker.go
@@ -120,9 +120,9 @@ func New(backend api.Backend, identity *identity.Identity) (*Worker, error) {
 
 	if w.enabled {
 		grpcServer, err := grpc.NewServer(&grpc.ServerConfig{
-			Name:        "sentry",
-			Port:        uint16(viper.GetInt(CfgControlPort)),
-			Certificate: identity.TLSCertificate,
+			Name:     "sentry",
+			Port:     uint16(viper.GetInt(CfgControlPort)),
+			Identity: identity,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("worker/sentry: failed to create a new gRPC server: %w", err)


### PR DESCRIPTION
Closes #2098.

TODO:
- [x] Add a flag to set node TLS certificate rotation interval.
- [x] Figure out why the storage client unit tests fail with `storage client: failed to write to any storage node` (I used `GetCertificate` where I should have used `GetClientCertificate` :man_facepalming: ).
- [x] Fix sentry nodes (these need to have persistent TLS certs, so no rotation for you).
- [x] Fix e2e tests (need to take NextCertificate into account when comparing nodes in the registry_cli test).
- [x] Enable cert rotation in e2e tests.
- [x] Fix e2e tests again (tests using the IAS proxy should also not do rotation).
- [x] Put the TLSSigner stuff back in (I temporarily removed this before to make debugging easier).
- [x] Write changelog fragment.
- [x] Fix the gRPC proxy so it dials connections itself rather than relying on an externally-established connection.
- [x] Upstream node should send its TLS certs to the sentry node on init and on every rotation.
- [x] Enable TLS cert rotation in e2e tests that use sentry nodes.
- [x] Make the IAS proxy not panic when connection is dropped, it should just reconnect.
- [x] Address review comments.
- [x] Add check to gRPC proxy to make sure that upstream connection is in a good state before forwarding calls (and re-dial upstream if the connection has gone bad).
- [x] Add separate long-term TLS certificates for the sentry node's control connection client.
- [x] Address review comments.