### PR TITLE
Makefile: set correct target-dir for elf2sgxs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,16 +18,16 @@ build-tools:
 	@# Suppress "binary already exists" error by redirecting stderr and stdout to /dev/null.
 	@cargo install --path tools >/dev/null 2>&1 || true
 
-# NOTE: We epxplictly set target-dir as a workaround to avoid recompilations in
-#       newer cargo nightly builds.
+# NOTE: We epxplictly set CARGO_TARGET_DIR as a workaround to avoid
+#       recompilations in newer cargo nightly builds.
 #       See https://github.com/oasislabs/oasis-core/pull/2673 for details.
 build-runtimes:
 	@for e in $(RUNTIMES); do \
 		$(ECHO) "$(MAGENTA)*** Building runtime: $$e...$(OFF)"; \
 		(cd $$e && \
-			cargo build --target-dir target/x86_64-fortanix-unknown-sgx --target x86_64-fortanix-unknown-sgx && \
-			cargo build --target-dir target/default && \
-			cargo elf2sgxs \
+			CARGO_TARGET_DIR=target/x86_64-fortanix-unknown-sgx cargo build --target x86_64-fortanix-unknown-sgx && \
+			CARGO_TARGET_DIR=target/default cargo build && \
+			CARGO_TARGET_DIR=target/x86_64-fortanix-unknown-sgx cargo elf2sgxs \
 		) || exit 1; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,9 @@ clean-targets := clean-runtimes clean-rust clean-go clean-version-files
 clean-runtimes:
 	@$(ECHO) "$(CYAN)*** Cleaning up runtimes...$(OFF)"
 	@for e in $(RUNTIMES); do \
-		(cd $$e && cargo clean) || exit 1; \
+		(cd $$e && \
+			CARGO_TARGET_DIR=target/default cargo clean && \
+			CARGO_TARGET_DIR=target/x86_64-fortanix-unknown-sgx cargo clean) || exit 1; \
 	done
 
 clean-rust:


### PR DESCRIPTION
Also using env var setting for consistency, as `cargo elf2sgxs` doesn't support the `--target-dir` flag