### PR TITLE
stats: figure out how many blocks they propose

### DIFF
--- a/.changelog/2693.feature.md
+++ b/.changelog/2693.feature.md
@@ -1,0 +1,4 @@
+stats: Figure out how many blocks they propose
+
+Cross reference which node proposed each block and report these
+per-entity as well.

--- a/.changelog/2693.feature.md
+++ b/.changelog/2693.feature.md
@@ -1,4 +1,4 @@
-stats: Figure out how many blocks they propose
+extra/stats: Figure out how many blocks they propose
 
 Cross reference which node proposed each block and report these
 per-entity as well.


### PR DESCRIPTION
sample output:

```
$ ./go/extra/stats/stats entity-signatures --address unix:../testnet/quest-c/serverdir/node/internal.sock --start-block 0 --end-block 100 --top-n 100
|Rank |Entity ID                                                       |Nodes |Signatures| Proposals|
-----------------------------------------------------------------------------------------------------
|1    |p6UuBtDdJQNJl513U7caGqALObw5obOgpQ6dwpgnlpI=                    |     1|       100|         2|
|2    |rUywd4hma3h5cmKGkeYskIRAdrxqw6OBPi6JfuCOWHs=                    |     1|       100|         2|
|3    |eTpIJnjpMlm+qEgsW76eWYNxsh2xwLdlbIPXjXAoYTQ=                    |     1|       100|         2|
|4    |5s7OfLEjIrePZ35UnkwrPQ7YVyzd5HAiddbWZKYLo5w=                    |     1|       100|         2|
|5    |ot4uIdQrmBc2QsyEb0iBz6qCnCWenTVGNnSIL91kejE=                    |     1|       100|         3|
|6    |jYJJ7MIm3HUMIxdRLIIsaP/qB7T3PMZ7xoiT7BiFwzI=                    |     1|       100|         6|
|7    |fO4izgR+Ok4z1QJGKToAWG6a4BC4WCA+F9dU3PlafbQ=                    |     1|       100|         2|
|8    |/fgHhks5RMJ/W5ymnYCriSg73D+gkWFqH9CAfd1Xqo0=                    |     1|       100|         2|
|9    |N2xjsaubEThYSGPBka1HFW3Rv7PtYhzEFqqlGzyKIf8=                    |     1|       100|         2|
|10   |TYcIa2zx+Wx0Ut3kFnIFzHgxnWpkBlWt6YyCJLtx+N4=                    |     1|       100|         2|
```