### PR TITLE
github: Don't trigger ci-reproducibility workflow for pull requests

### DIFF
--- a/.changelog/2704.internal.md
+++ b/.changelog/2704.internal.md
@@ -1,0 +1,1 @@
+github: Don't trigger ci-reproducibility workflow for pull requests

--- a/.github/workflows/ci-reproducibility.yml
+++ b/.github/workflows/ci-reproducibility.yml
@@ -8,12 +8,9 @@ on:
     branches:
       - master
       - stable/*
-  # Or when a pull request event occurs for a pull request against one of the
-  # matched branches.
-  pull_request:
-    branches:
-      - master
-      - stable/*
+  # Or every day at 00:00 UTC.
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
 


### PR DESCRIPTION
Almost none of the pull requests touches things that would break Go build reproducibility, so it makes more sense to only trigger the workflow for pushes to `master` and `stable/*` branches and on schedule, once every day.