### PR TITLE
github: Keep git history intact in Change Log fragment check

### DIFF
--- a/.changelog/2707.trivial.md
+++ b/.changelog/2707.trivial.md
@@ -1,0 +1,1 @@
+github: Keep git history intact in Change Log fragment check

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -47,7 +47,7 @@ jobs:
           # Fetch the pull request' base branch so towncrier will be able to
           # compare the current branch with the base branch.
           # Source: https://github.com/actions/checkout/#fetch-all-branches.
-          git fetch --no-tags --prune --depth=1 origin +refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}
+          git fetch --no-tags origin +refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}
           towncrier check --compare-with origin/${BASE_BRANCH}
         env:
           BASE_BRANCH: ${{ github.base_ref }}


### PR DESCRIPTION
The next step, _Lint git commits_, needs access git's history so it can lint the relevant commits, otherwise it just lints all commits.

This is an alternative fix for #2707 and partially supersedes #2706.

Closes #2707.