### PR TITLE
backport: go/consensus/tendermint: Properly cache consensus parameters

### DIFF
--- a/.buildkite/code-skip.pipeline.yml
+++ b/.buildkite/code-skip.pipeline.yml
@@ -1,0 +1,10 @@
+##
+# Code-skip pipeline
+##
+#
+# Buildkite pipeline for skipping running code-related linters and tests.
+#
+
+steps:
+  - label: No code-related changes detected, skipping Code pipeline
+    command: exit 0

--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -1,6 +1,10 @@
-################
-# Build pipeline
-################
+##
+# Code pipeline
+##
+#
+# Main Buildkite pipeline for running code-related linters and tests.
+#
+
 docker_plugin_default_config: &docker_plugin_default_config
   image: "oasislabs/testing:0.3.0"
   always_pull: true

--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -13,8 +13,8 @@ docker_plugin_default_config: &docker_plugin_default_config
     - /var/lib/buildkite-agent/.coveralls:/root/.coveralls
     - /var/lib/buildkite-agent/.codecov:/root/.codecov
     # Shared Rust incremental compile caches.
-    - /var/tmp/cargo_ic/debug:/var/tmp/artifacts/debug/incremental
-    - /var/tmp/cargo_ic/debug_sgx:/var/tmp/artifacts/x86_64-unknown-linux-sgx/debug/incremental
+    - /var/tmp/cargo_ic/debug:/var/tmp/artifacts/default/debug/incremental
+    - /var/tmp/cargo_ic/debug_sgx:/var/tmp/artifacts/sgx/x86_64-unknown-linux-sgx/debug/incremental
     # Shared Rust package checkouts directory.
     - /var/tmp/cargo_pkg/git:/root/.cargo/git
     - /var/tmp/cargo_pkg/registry:/root/.cargo/registry
@@ -124,7 +124,7 @@ steps:
       - .buildkite/rust/build_generic.sh /workdir -p simple-keyvalue-ops-client
 
       # Upload the built artifacts.
-      - cd /var/tmp/artifacts/debug
+      - cd /var/tmp/artifacts/default/debug
       - buildkite-agent artifact upload oasis-core-runtime-loader
       # Clients for E2E tests.
       - buildkite-agent artifact upload test-long-term-client
@@ -147,10 +147,10 @@ steps:
       - .buildkite/rust/build_runtime.sh tests/runtimes/simple-keyvalue
 
       # Upload the built artifacts.
-      - cd /var/tmp/artifacts/x86_64-fortanix-unknown-sgx/debug
+      - cd /var/tmp/artifacts/sgx/x86_64-fortanix-unknown-sgx/debug
       - buildkite-agent artifact upload oasis-core-keymanager-runtime.sgxs
       - buildkite-agent artifact upload simple-keyvalue.sgxs
-      - cd /var/tmp/artifacts/debug
+      - cd /var/tmp/artifacts/default/debug
       - buildkite-agent artifact upload oasis-core-keymanager-runtime
       - buildkite-agent artifact upload simple-keyvalue
     agents:

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+##
+# Dynamic Buildkite pipeline generator.
+##
+#
+# It outputs valid Buildkite pipeline in YAML format.
+#
+# To use it, define the following Steps under your Buildkite's Pipeline Settings:
+#
+# steps:
+#   - command: .buildkite/pipeline.sh | buildkite-agent pipeline upload
+#     label: ":pipeline: Upload"
+#
+# For more details, see:
+# https://buildkite.com/docs/pipelines/defining-steps#dynamic-pipelines.
+#
+
+set -eux
+
+# Helper that ensures the build is triggered for a pull request and that there
+# are no code-related changes compared to the pull request's base branch.
+pr_and_no_code_related_changes() {
+  # Check if the build was triggered for a pull request.
+  if [[ -z $BUILDKITE_PULL_REQUEST_BASE_BRANCH ]]; then
+    return 1
+  fi
+  # Get the list of changes files, excluding changes unrelated to code.
+  # NOTE: The exclude patterns below use git's pathspec syntax:
+  # https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec.
+  git diff --name-only --exit-code "refs/remotes/origin/$BUILDKITE_PULL_REQUEST_BASE_BRANCH.." 1>&2 -- \
+      ':(exclude)*.md' \
+      ':(exclude).changelog/' \
+      ':(exclude).github/' \
+      ':(exclude).gitlint' \
+      ':(exclude).markdownlint.yml' \
+      ':(exclude).punch_config.py' \
+      ':(exclude)docs/' \
+      ':(exclude)towncrier.toml'
+}
+
+if pr_and_no_code_related_changes; then
+    cat .buildkite/code-skip.pipeline.yml
+else
+    cat .buildkite/code.pipeline.yml
+fi

--- a/.buildkite/rust/build_generic.sh
+++ b/.buildkite/rust/build_generic.sh
@@ -35,5 +35,5 @@ source .buildkite/rust/common.sh
 # Run the build
 ###############
 pushd $src_dir
-  cargo build --locked $extra_args
+  CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/default" cargo build --locked $extra_args
 popd

--- a/.buildkite/rust/build_runtime.sh
+++ b/.buildkite/rust/build_runtime.sh
@@ -46,10 +46,10 @@ fi
 ###############
 pushd $src_dir
     # Build non-SGX runtime. Checking KM policy requires SGX, disable it.
-    OASIS_UNSAFE_SKIP_KM_POLICY="1" cargo build --locked
+    CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/default" OASIS_UNSAFE_SKIP_KM_POLICY="1" cargo build --locked
 
     # Build SGX runtime.
     unset OASIS_UNSAFE_SKIP_KM_POLICY
-    cargo build --locked --target x86_64-fortanix-unknown-sgx
-    cargo elf2sgxs
+    CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/sgx" cargo build --locked --target x86_64-fortanix-unknown-sgx
+    CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/sgx" cargo elf2sgxs
 popd

--- a/.buildkite/rust/test_generic.sh
+++ b/.buildkite/rust/test_generic.sh
@@ -27,7 +27,7 @@ shift
 # Run the build and tests
 #########################
 pushd $src_dir
-  cargo build --all --locked --exclude simple-keyvalue
+  CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/default" cargo build --all --locked --exclude simple-keyvalue
   cargo fmt -- --check
-  cargo test --all --locked --exclude simple-keyvalue
+  CARGO_TARGET_DIR="${CARGO_TARGET_DIR}/default" cargo test --all --locked --exclude simple-keyvalue
 popd

--- a/.buildkite/scripts/download_e2e_test_artifacts.sh
+++ b/.buildkite/scripts/download_e2e_test_artifacts.sh
@@ -16,17 +16,17 @@ source .buildkite/scripts/common.sh
 download_artifact oasis-node go/oasis-node 755
 download_artifact integrationrunner.test go/oasis-node/integrationrunner 755
 download_artifact oasis-test-runner go/oasis-test-runner 755
-download_artifact oasis-core-runtime-loader target/debug 755
+download_artifact oasis-core-runtime-loader target/default/debug 755
 
 # Key manager runtime.
-download_artifact oasis-core-keymanager-runtime.sgxs target/x86_64-fortanix-unknown-sgx/debug 755
-download_artifact oasis-core-keymanager-runtime target/debug 755
+download_artifact oasis-core-keymanager-runtime.sgxs target/sgx/x86_64-fortanix-unknown-sgx/debug 755
+download_artifact oasis-core-keymanager-runtime target/default/debug 755
 
 # Test simple-keyvalue runtime and clients.
-download_artifact test-long-term-client target/debug 755
-download_artifact simple-keyvalue-client target/debug 755
-download_artifact simple-keyvalue-enc-client target/debug 755
-download_artifact simple-keyvalue-ops-client target/debug 755
+download_artifact test-long-term-client target/default/debug 755
+download_artifact simple-keyvalue-client target/default/debug 755
+download_artifact simple-keyvalue-enc-client target/default/debug 755
+download_artifact simple-keyvalue-ops-client target/default/debug 755
 
-download_artifact simple-keyvalue.sgxs target/x86_64-fortanix-unknown-sgx/debug 755
-download_artifact simple-keyvalue target/debug 755
+download_artifact simple-keyvalue.sgxs target/sgx/x86_64-fortanix-unknown-sgx/debug 755
+download_artifact simple-keyvalue target/default/debug 755

--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -18,9 +18,9 @@ WORKDIR=$PWD
 # Run test suite.
 #################
 # Determine correct runtime to use for SGX.
-runtime_target="."
+runtime_target="default"
 if [[ "${OASIS_TEE_HARDWARE:-""}" == "intel-sgx" ]]; then
-    runtime_target="x86_64-fortanix-unknown-sgx"
+    runtime_target="sgx/x86_64-fortanix-unknown-sgx"
 fi
 
 # We need a directory in the workdir so that Buildkite can fetch artifacts.
@@ -40,9 +40,9 @@ ${WORKDIR}/go/oasis-test-runner/oasis-test-runner \
     ${BUILDKITE:+--basedir ${TEST_BASE_DIR:-$PWD}/e2e} \
     --basedir.no_cleanup \
     --e2e.node.binary ${node_binary} \
-    --e2e.client.binary_dir ${WORKDIR}/target/debug \
+    --e2e.client.binary_dir ${WORKDIR}/target/default/debug \
     --e2e.runtime.binary_dir ${WORKDIR}/target/${runtime_target}/debug \
-    --e2e.runtime.loader ${WORKDIR}/target/debug/oasis-core-runtime-loader \
+    --e2e.runtime.loader ${WORKDIR}/target/default/debug/oasis-core-runtime-loader \
     --e2e.tee_hardware ${OASIS_TEE_HARDWARE:-""} \
     --log.level info \
     ${BUILDKITE_PARALLEL_JOB_COUNT:+--parallel.job_count ${BUILDKITE_PARALLEL_JOB_COUNT}} \

--- a/.changelog/2666.bugfix.md
+++ b/.changelog/2666.bugfix.md
@@ -1,0 +1,1 @@
+runtime: Bump ring to 0.16.11, snow to 0.6.2, Rust to 2020-02-16

--- a/.changelog/2702.internal.md
+++ b/.changelog/2702.internal.md
@@ -1,0 +1,6 @@
+ci: Skip some steps for non-code changes
+
+When one makes a pull request that e.g. only adds documentation or
+assembles the Change Log from fragments, all the *heavy* Buildkite
+pipeline steps (e.g. Go/Rust building, Go tests, E2E tests) should be
+skipped.

--- a/.changelog/2708.bugfix.md
+++ b/.changelog/2708.bugfix.md
@@ -1,0 +1,1 @@
+go/consensus/tendermint: Properly cache consensus parameters

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arc-swap"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +132,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byte-tools"
@@ -311,6 +321,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "deoxysii"
 version = "0.2.0"
 source = "git+https://github.com/oasislabs/deoxysii-rust#4687841cc6bd090e39a5f2908f34f49d64046200"
@@ -431,11 +453,6 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +504,14 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hostname"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +542,14 @@ dependencies = [
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "js-sys"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -577,6 +610,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memoffset"
@@ -662,6 +700,15 @@ dependencies = [
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num-integer"
@@ -806,7 +853,7 @@ dependencies = [
  "pem-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.14.5 (git+https://github.com/akash-fortanix/ring?branch=sgx-target)",
+ "ring 0.16.11 (git+https://github.com/oasislabs/ring-sgx?branch=sgx-target)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -819,14 +866,14 @@ dependencies = [
  "slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-stdlog 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "snow 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snow 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp800-185 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "webpki 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -986,15 +1033,6 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1165,27 +1203,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.14.5"
-source = "git+https://github.com/akash-fortanix/ring?branch=sgx-target#5b5b3792fc409288039937ca422ebdd8426de8a8"
+version = "0.16.11"
+source = "git+https://github.com/oasislabs/ring-sgx?branch=sgx-target#765fab6352395852091bc0605de16fcfc73712ec"
 dependencies = [
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rust-crypto"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (git+https://github.com/jethrogb/rustc-serialize?branch=portability)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1197,11 +1224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rustc-hex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "git+https://github.com/jethrogb/rustc-serialize?branch=portability#9800ee078b22e2aa9886a6751f9778fda80a16b6"
 
 [[package]]
 name = "rustc_version"
@@ -1472,25 +1494,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "snow"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chacha20-poly1305-aead 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.14.5 (git+https://github.com/akash-fortanix/ring?branch=sgx-target)",
- "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.16.11 (git+https://github.com/oasislabs/ring-sgx?branch=sgx-target)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "static_slice 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "sourcefile"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sp800-185"
@@ -1504,11 +1526,6 @@ dependencies = [
 [[package]]
 name = "spin"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "static_slice"
-version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1821,6 +1838,11 @@ version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1859,6 +1881,11 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1869,12 +1896,96 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "webpki"
-version = "0.19.1"
+name = "wasm-bindgen"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ring 0.14.5 (git+https://github.com/akash-fortanix/ring?branch=sgx-target)",
- "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wasm-bindgen-webidl"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-webidl 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ring 0.16.11 (git+https://github.com/oasislabs/ring-sgx?branch=sgx-target)",
+ "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "weedle"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1934,11 +2045,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "zeroize"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "zeroize_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1951,9 +2080,21 @@ dependencies = [
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "zeroize_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum aesm-client 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "95a2d87c3d15461218087c46189c0e910d5e9fe2a84f9912f5ea6d831b207f0c"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 "checksum arc-swap 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f1a1eca3195b729bbd64e292ef2f5fff6b1c28504fed762ce2b1013dde4d8e92"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
@@ -1967,6 +2108,7 @@ dependencies = [
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
+"checksum bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
@@ -1989,6 +2131,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
+"checksum curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 "checksum deoxysii 0.2.0 (git+https://github.com/oasislabs/deoxysii-rust)" = "<none>"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)" = "845aaacc16f01178f33349e7c992ecd0cee095aa5e577f0f4dee35971bd36455"
@@ -2004,18 +2147,19 @@ dependencies = [
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
-"checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum grpcio 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "211932b84a0001a88d9443bef8a95726c6e2eb1cc50e7655592e2596060ba5e1"
 "checksum grpcio-sys 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8402e77dd7de882c3fed55f68b2ec0ce0ce9df94de87f5c111059517f111438a"
 "checksum half 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ff54597ea139063f4225f1ec47011b03c9de4a486957ff3fc506881dac951d0"
 "checksum hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum intrusive-collections 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f0207c3d23d0b13d569d4103a98f31c4cd65f30c92c3a157272966b2affd177e"
 "checksum io-context 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6deff8086863b4b598829cfe72d405540d1497fe997f903cc171aade51dae88c"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)" = "74dfca3d9957906e8d1e6a0b641dc9a59848e793f1da2165889fd4f62d10d79c"
@@ -2024,6 +2168,7 @@ dependencies = [
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lru 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "5d8f669d42c72d18514dfca8115689c5f6370a17d980cb5bd777a67f404594c8"
+"checksum memchr 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53445de381a1f436797497c61d851644d0e8e88e6140f22872ad33a704933978"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
@@ -2032,6 +2177,7 @@ dependencies = [
 "checksum nix 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "becb657d662f1cd2ef38c7ad480ec6b8cf9e96b27adb543e594f9cf0f2e6065c"
 "checksum nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b"
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+"checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
@@ -2052,7 +2198,6 @@ dependencies = [
 "checksum protoc-rust 1.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2349054a25cab820bf488beac2b00fd42474db3ed7bad434b421894129d9672a"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
-"checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
@@ -2071,11 +2216,9 @@ dependencies = [
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum ring 0.14.5 (git+https://github.com/akash-fortanix/ring?branch=sgx-target)" = "<none>"
-"checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
+"checksum ring 0.16.11 (git+https://github.com/oasislabs/ring-sgx?branch=sgx-target)" = "<none>"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "403bb3a286107a04825a5f82e1270acc1e14028d3d554d7a1e08914549575ab8"
-"checksum rustc-serialize 0.3.24 (git+https://github.com/jethrogb/rustc-serialize?branch=portability)" = "<none>"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustracing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ea969b6fe046c17d43c47f25d9a605a01d7ea011406646a904f4f60e63e0268"
 "checksum rustracing_jaeger 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5840ca7d3fb57a07e79f7cfe0393f5cd9491cefd6fe38db3dc085dcc5585ea17"
@@ -2099,10 +2242,10 @@ dependencies = [
 "checksum slog-scope 4.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53a5819e0ab73a542e42b0d8ce8bf9e0a470c8f0a370e176a18855566332a120"
 "checksum slog-stdlog 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f1c469573d1e3f36f9eee66cd132206caf47b50c94b1f6c6e7b4d8235e9ecf01"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
-"checksum snow 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5a64f02fd208ef15bd2d1a65861df4707e416151e1272d02c8faafad1c138100"
+"checksum snow 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "afb767eee7d257ba202f0b9b08673bc13b22281632ef45267b19f13100accd2f"
+"checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum sp800-185 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b18e3b1ddbf090b195425aca6edf8efb8e9b1fd42708131adf0f882db24fc9"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-"checksum static_slice 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "92a7e0c5e3dfb52e8fbe0e63a1b947bbb17b4036408b151353c4491374931362"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab3af2eb31c42e8f0ccf43548232556c42737e01a96db6e1777b0be108e79799"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
@@ -2131,16 +2274,26 @@ dependencies = [
 "checksum trackable 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "11475c3c53b075360eac9794965822cb053996046545f91cf61d90e00b72efa5"
 "checksum trackable_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0f4062d54dd240bde289717d6b4af18048c3dd552f01a0fd93824f5fc4d2d084"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+"checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum unix_socket2 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b57c6eace16c00eccb98a28e85db3370eab0685bdd5e13831d59e2bcb49a1d8a"
-"checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
+"checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
-"checksum webpki 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4f7e1cd7900a3a6b65a3e8780c51a3e6b59c0e2c55c6dc69578c288d69f7d082"
+"checksum wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"
+"checksum wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45"
+"checksum wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3"
+"checksum wasm-bindgen-macro-support 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
+"checksum wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601"
+"checksum wasm-bindgen-webidl 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d"
+"checksum web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b"
+"checksum webpki 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1f50e1972865d6b1adb54167d1c8ed48606004c2c9d0ea5f1eeb34d95e863ef"
+"checksum weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
@@ -2149,5 +2302,8 @@ dependencies = [
 "checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee1585dc1484373cbc1cee7aafda26634665cf449436fd6e24bfd1fad230538"
+"checksum x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 "checksum zeroize 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e68403b858b6af538b11614e62dfe9ab2facba9f13a0cafb974855cfb495ec95"
+"checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 "checksum zeroize_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3f07490820219949839d0027b965ffdd659d75be9220c00798762e36c6cd281"
+"checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,7 @@ members = [
 
 [patch.crates-io]
 # TODO: Remove when merged upstream (briansmith/ring#738).
-ring = { git = "https://github.com/akash-fortanix/ring", branch = "sgx-target" }
-# TODO: Remove when merged upstream (rust-lang-deprecated/rustc-serialize#195).
-rustc-serialize = { git = "https://github.com/jethrogb/rustc-serialize", branch = "portability" }
+ring = { git = "https://github.com/oasislabs/ring-sgx", branch = "sgx-target" }
 
 [profile.release]
 panic = "abort"

--- a/Makefile
+++ b/Makefile
@@ -16,21 +16,21 @@ build-targets := build-tools build-runtimes build-rust build-go
 build-tools:
 	@$(ECHO) "$(MAGENTA)*** Building Rust tools...$(OFF)"
 	@# Suppress "binary already exists" error by redirecting stderr and stdout to /dev/null.
-	@cargo install --path tools >/dev/null 2>&1 || true
+	@CARGO_TARGET_DIR=target/default cargo install --path tools >/dev/null 2>&1 || true
 
 build-runtimes:
-	@for e in $(RUNTIMES); do \
+	@CARGO_TARGET_ROOT=$(shell pwd)/target && for e in $(RUNTIMES); do \
 		$(ECHO) "$(MAGENTA)*** Building runtime: $$e...$(OFF)"; \
 		(cd $$e && \
-			cargo build --target x86_64-fortanix-unknown-sgx && \
-			cargo build && \
-			cargo elf2sgxs \
+			CARGO_TARGET_DIR=$${CARGO_TARGET_ROOT}/sgx cargo build --target x86_64-fortanix-unknown-sgx && \
+			CARGO_TARGET_DIR=$${CARGO_TARGET_ROOT}/default cargo build && \
+			CARGO_TARGET_DIR=$${CARGO_TARGET_ROOT}/sgx cargo elf2sgxs \
 		) || exit 1; \
 	done
 
 build-rust:
 	@$(ECHO) "$(MAGENTA)*** Building Rust libraries and runtime loader...$(OFF)"
-	@cargo build
+	@CARGO_TARGET_DIR=target/default cargo build
 
 build-go go:
 	@$(MAKE) -C go build
@@ -64,7 +64,7 @@ test-targets := test-unit test-e2e
 test-unit-rust: build-helpers
 	@$(ECHO) "$(CYAN)*** Running Rust unit tests...$(OFF)"
 	@export OASIS_STORAGE_PROTOCOL_SERVER_BINARY=$(realpath go/$(GO_TEST_HELPER_URKEL_PATH)) && \
-		cargo test
+		CARGO_TARGET_DIR=target/default cargo test
 
 test-unit-go:
 	@$(MAKE) -C go test
@@ -82,13 +82,15 @@ clean-targets := clean-runtimes clean-rust clean-go clean-version-files
 
 clean-runtimes:
 	@$(ECHO) "$(CYAN)*** Cleaning up runtimes...$(OFF)"
-	@for e in $(RUNTIMES); do \
-		(cd $$e && cargo clean) || exit 1; \
+	@CARGO_TARGET_ROOT=$(shell pwd)/target && for e in $(RUNTIMES); do \
+		(cd $$e && \
+			CARGO_TARGET_DIR=$${CARGO_TARGET_ROOT}/default cargo clean && \
+			CARGO_TARGET_DIR=$${CARGO_TARGET_ROOT}/sgx cargo clean) || exit 1; \
 	done
 
 clean-rust:
 	@$(ECHO) "$(CYAN)*** Cleaning up Rust...$(OFF)"
-	@cargo clean
+	@CARGO_TARGET_DIR=target/default cargo clean
 
 clean-go:
 	@$(MAKE) -C go clean

--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ running the `simple-keyvalue` test runtime, do:
 ```
 ./go/oasis-net-runner/oasis-net-runner \
   --net.node.binary go/oasis-node/oasis-node \
-  --net.runtime.binary target/debug/simple-keyvalue \
-  --net.runtime.loader target/debug/oasis-core-runtime-loader \
-  --net.keymanager.binary target/debug/oasis-core-keymanager-runtime
+  --net.runtime.binary target/default/debug/simple-keyvalue \
+  --net.runtime.loader target/default/debug/oasis-core-runtime-loader \
+  --net.keymanager.binary target/default/debug/oasis-core-keymanager-runtime
 ```
 
 Wait for the network to start, there should be messages about nodes being started
@@ -241,9 +241,9 @@ except the `oasis-net-runner` invocation:
 ```
 ./go/oasis-net-runner/oasis-net-runner \
   --net.node.binary go/oasis-node/oasis-node \
-  --net.runtime.binary target/x86_64-fortanix-unknown-sgx/debug/simple-keyvalue.sgxs \
-  --net.runtime.loader target/debug/oasis-core-runtime-loader \
-  --net.keymanager.binary target/x86_64-fortanix-unknown-sgx/debug/oasis-core-keymanager-runtime.sgxs
+  --net.runtime.binary target/sgx/x86_64-fortanix-unknown-sgx/debug/simple-keyvalue.sgxs \
+  --net.runtime.loader target/default/debug/oasis-core-runtime-loader \
+  --net.keymanager.binary target/sgx/x86_64-fortanix-unknown-sgx/debug/oasis-core-keymanager-runtime.sgxs
 ```
 
 ## Running tests and benchmarks

--- a/go/consensus/genesis/genesis.go
+++ b/go/consensus/genesis/genesis.go
@@ -4,6 +4,8 @@ package genesis
 import (
 	"fmt"
 	"time"
+
+	"github.com/oasislabs/oasis-core/go/consensus/api/transaction"
 )
 
 // Genesis contains various consensus config flags that should be part of the genesis state.
@@ -18,10 +20,10 @@ type Parameters struct {
 	SkipTimeoutCommit  bool          `json:"skip_timeout_commit"`
 	EmptyBlockInterval time.Duration `json:"empty_block_interval"`
 
-	MaxTxSize      uint64 `json:"max_tx_size"`
-	MaxBlockSize   uint64 `json:"max_block_size"`
-	MaxBlockGas    uint64 `json:"max_block_gas"`
-	MaxEvidenceAge uint64 `json:"max_evidence_age"`
+	MaxTxSize      uint64          `json:"max_tx_size"`
+	MaxBlockSize   uint64          `json:"max_block_size"`
+	MaxBlockGas    transaction.Gas `json:"max_block_gas"`
+	MaxEvidenceAge uint64          `json:"max_evidence_age"`
 }
 
 // SanityCheck does basic sanity checking on the genesis state.

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -294,8 +294,6 @@ type abciMux struct {
 
 	lastBeginBlock int64
 	currentTime    time.Time
-	maxTxSize      uint64
-	maxBlockGas    transaction.Gas
 
 	genesisHooks []func()
 	haltHooks    []func(context.Context, int64, epochtime.EpochTime)
@@ -368,13 +366,6 @@ func (mux *abciMux) InitChain(req types.RequestInitChain) types.ResponseInitChai
 			"err", err,
 		)
 		panic("mux: invalid genesis application state")
-	}
-
-	if mux.maxTxSize = st.Consensus.Parameters.MaxTxSize; mux.maxTxSize == 0 {
-		mux.logger.Warn("maximum transaction size enforcement is disabled")
-	}
-	if mux.maxBlockGas = transaction.Gas(st.Consensus.Parameters.MaxBlockGas); mux.maxBlockGas == 0 {
-		mux.logger.Warn("maximum block gas enforcement is disabled")
 	}
 
 	b, _ := json.Marshal(st)
@@ -452,6 +443,11 @@ func (mux *abciMux) InitChain(req types.RequestInitChain) types.ResponseInitChai
 	evBinary := cbor.Marshal(ctx.GetEvents())
 	mux.state.deliverTxTree.Set([]byte(stateKeyInitChainEvents), evBinary)
 
+	// Refresh consensus parameters.
+	if err = mux.state.refreshConsensusParameters(); err != nil {
+		panic(fmt.Errorf("mux: failed to refresh consensus parameters: %w", err))
+	}
+
 	return resp
 }
 
@@ -469,10 +465,15 @@ func (mux *abciMux) BeginBlock(req types.RequestBeginBlock) types.ResponseBeginB
 	mux.lastBeginBlock = blockHeight
 	mux.currentTime = req.Header.Time
 
+	params, err := mux.state.ConsensusParameters()
+	if err != nil {
+		panic(fmt.Errorf("failed to fetch consensus parameters: %w", err))
+	}
+
 	// Create empty block context.
 	mux.state.blockCtx = NewBlockContext()
-	if mux.maxBlockGas > 0 {
-		mux.state.blockCtx.Set(GasAccountantKey{}, NewGasAccountant(mux.maxBlockGas))
+	if params.MaxBlockGas > 0 {
+		mux.state.blockCtx.Set(GasAccountantKey{}, NewGasAccountant(params.MaxBlockGas))
 	} else {
 		mux.state.blockCtx.Set(GasAccountantKey{}, NewNopGasAccountant())
 	}
@@ -549,7 +550,11 @@ func (mux *abciMux) decodeTx(ctx *Context, rawTx []byte) (*transaction.Transacti
 		return nil, nil, fmt.Errorf("halt mode, rejecting all transactions")
 	}
 
-	if mux.maxTxSize > 0 && uint64(len(rawTx)) > mux.maxTxSize {
+	params, err := mux.state.ConsensusParameters()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch consensus parameters: %w", err)
+	}
+	if params.MaxTxSize > 0 && uint64(len(rawTx)) > params.MaxTxSize {
 		// This deliberately avoids logging the rawTx since spamming the
 		// logs is also bad.
 		ctx.Logger().Error("received oversized transaction",

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -23,6 +23,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/common/quantity"
 	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
+	"github.com/oasislabs/oasis-core/go/consensus/api/transaction"
 	consensusGenesis "github.com/oasislabs/oasis-core/go/consensus/genesis"
 	tendermint "github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
@@ -216,7 +217,7 @@ func doInitGenesis(cmd *cobra.Command, args []string) {
 			EmptyBlockInterval: viper.GetDuration(cfgConsensusEmptyBlockInterval),
 			MaxTxSize:          uint64(viper.GetSizeInBytes(cfgConsensusMaxTxSizeBytes)),
 			MaxBlockSize:       uint64(viper.GetSizeInBytes(cfgConsensusMaxBlockSizeBytes)),
-			MaxBlockGas:        viper.GetUint64(cfgConsensusMaxBlockGas),
+			MaxBlockGas:        transaction.Gas(viper.GetUint64(cfgConsensusMaxBlockGas)),
 			MaxEvidenceAge:     viper.GetUint64(cfgConsensusMaxEvidenceAge),
 		},
 	}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,11 +22,11 @@ byteorder = "1.3.1"
 failure = "0.1.5"
 sgx-isa = { version = "0.3.0", features = ["sgxstd"] }
 # TODO: Change version when merged upstream (briansmith/ring#738).
-ring = "=0.14.5"
-webpki = "0.19.1"
-untrusted = "0.6.2"
+ring = "0.16.11"
+webpki = "0.21.2"
+untrusted = "0.7.0"
 bincode = "1.0.0"
-snow = { version = "0.5.2", default-features = false, features = ["ring-accelerated"] }
+snow = { version = "0.6.2", default-features = false, features = ["ring-accelerated"] }
 percent-encoding = "1.0.1"
 pem-iterator = "0.2.0"
 chrono = "0.4.6"

--- a/runtime/src/common/crypto/mrae/deoxysii.rs
+++ b/runtime/src/common/crypto/mrae/deoxysii.rs
@@ -2,10 +2,7 @@
 
 pub use super::deoxysii_rust::{DeoxysII, KEY_SIZE, NONCE_SIZE, TAG_SIZE};
 
-use super::{
-    ring::{digest, hmac},
-    x25519_dalek,
-};
+use super::{ring::hmac, x25519_dalek};
 
 use failure::Fallible;
 use rand::rngs::OsRng;
@@ -18,8 +15,8 @@ fn derive_symmetric_key(public: &[u8; 32], private: &[u8; 32]) -> [u8; KEY_SIZE]
 
     let pmk = private.diffie_hellman(&public);
 
-    let k = hmac::SigningKey::new(&digest::SHA256, b"MRAE_Box_Deoxys-II-256-128");
-    let mut ctx = hmac::SigningContext::with_key(&k);
+    let k = hmac::Key::new(hmac::HMAC_SHA256, b"MRAE_Box_Deoxys-II-256-128");
+    let mut ctx = hmac::Context::with_key(&k);
 
     ctx.update(pmk.as_bytes());
     drop(pmk);


### PR DESCRIPTION
Backport of fix for #2708 (from #2709).

Also backports some fixes that are required for the new CI pipeline.