### PR TITLE
go/consensus/tendermint: Store consensus parameters in ABCI state

### DIFF
--- a/.changelog/2710.breaking.md
+++ b/.changelog/2710.breaking.md
@@ -1,0 +1,3 @@
+go/consensus/tendermint: Store consensus parameters in ABCI state
+
+This allows for updating the consensus parameters later.

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -444,8 +444,8 @@ func (mux *abciMux) InitChain(req types.RequestInitChain) types.ResponseInitChai
 	evBinary := cbor.Marshal(ctx.GetEvents())
 	mux.state.deliverTxTree.Set([]byte(stateKeyInitChainEvents), evBinary)
 
-	// Refresh consensus parameters.
-	if err = mux.state.refreshConsensusParameters(); err != nil {
+	// Initialize consensus parameters.
+	if err = mux.state.setConsensusParameters(&st.Consensus.Parameters); err != nil {
 		panic(fmt.Errorf("mux: failed to refresh consensus parameters: %w", err))
 	}
 


### PR DESCRIPTION
Fixes #2710.

This allows for updating the consensus parameters later.