### PR TITLE
Bump GoReleaser to 0.127.0 and switch back to upstream

### DIFF
--- a/.changelog/2564.internal.md
+++ b/.changelog/2564.internal.md
@@ -1,0 +1,1 @@
+github: Bump GoReleaser to 0.127.0 and switch back to upstream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
           tar -xf ${GORELEASER_TARBALL}
           sudo mv goreleaser /usr/local/bin
         env:
-          GORELEASER_URL_PREFIX: https://github.com/oasislabs/goreleaser/releases/download/
-          GORELEASER_VERSION: 0.123.3-oasis1
+          GORELEASER_URL_PREFIX: https://github.com/goreleaser/goreleaser/releases/download/
+          GORELEASER_VERSION: 0.127.0
           GORELEASER_TARBALL: goreleaser_Linux_x86_64.tar.gz
           CURL_CMD: curl --proto =https --tlsv1.2 -sSL
       - name: Create release

--- a/common.mk
+++ b/common.mk
@@ -121,7 +121,7 @@ define ENSURE_NO_CHANGELOG_FRAGMENTS =
 		$(ECHO_STDERR) "$(RED)Error: Could not obtain Change Log fragments for $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH) branch.$(OFF)"; \
 		exit 1; \
 	fi; \
-	if CHANGELOG_FRAGMENTS=`echo "$$CHANGELOG_FILES" | grep --invert-match --extended-regexp '(README.md|template.md.j2)'`; then \
+	if CHANGELOG_FRAGMENTS=`echo "$$CHANGELOG_FILES" | grep --invert-match --extended-regexp '(README.md|template.md.j2|.markdownlint.yml)'`; then \
 		$(ECHO_STDERR) "$(RED)Error: Found the following Change Log fragments on $(OASIS_CORE_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH) branch:"; \
 		$(ECHO_STDERR) "$${CHANGELOG_FRAGMENTS}$(OFF)"; \
 		exit 1; \


### PR DESCRIPTION
Also fix Make's `ENSURE_NO_CHANGELOG_FRAGMENTS` helper.

Closes #2564.