### PR TITLE
registration workload

### DIFF
--- a/.changelog/2718.feature.md
+++ b/.changelog/2718.feature.md
@@ -1,0 +1,1 @@
+go/oasis-node/txsource: add registration txsource workload

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -44,6 +44,8 @@ var (
 // ClientBackend is a limited consensus interface used by clients that
 // connect to the local node.
 type ClientBackend interface {
+	TransactionAuthHandler
+
 	// SubmitTx submits a signed consensus transaction.
 	SubmitTx(ctx context.Context, tx *transaction.SignedTransaction) error
 
@@ -117,9 +119,6 @@ type Backend interface {
 	// SubmitEvidence submits evidence of misbehavior.
 	SubmitEvidence(ctx context.Context, evidence Evidence) error
 
-	// TransactionAuthHandler returns the transaction authentication handler.
-	TransactionAuthHandler() TransactionAuthHandler
-
 	// SubmissionManager returns the transaction submission manager.
 	SubmissionManager() SubmissionManager
 
@@ -150,7 +149,7 @@ type Backend interface {
 type TransactionAuthHandler interface {
 	// GetSignerNonce returns the nonce that should be used by the given
 	// signer for transmitting the next transaction.
-	GetSignerNonce(ctx context.Context, id signature.PublicKey, height int64) (uint64, error)
+	GetSignerNonce(ctx context.Context, req *GetSignerNonceRequest) (uint64, error)
 }
 
 // EvidenceKind is kind of evindence of a node misbehaving.
@@ -207,4 +206,10 @@ func NewConsensusEvidence(inner interface{}) ConsensusEvidence {
 type EstimateGasRequest struct {
 	Caller      signature.PublicKey      `json:"caller"`
 	Transaction *transaction.Transaction `json:"transaction"`
+}
+
+// GetSignerNonceRequest is a GetSignerNonce request.
+type GetSignerNonceRequest struct {
+	ID     signature.PublicKey `json:"id"`
+	Height int64               `json:"height"`
 }

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -50,6 +50,9 @@ type ClientBackend interface {
 	// StateToGenesis returns the genesis state at the specified block height.
 	StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error)
 
+	// EstimateGas calculates the amount of gas required to execute the given transaction.
+	EstimateGas(ctx context.Context, req *EstimateGasRequest) (transaction.Gas, error)
+
 	// WaitEpoch waits for consensus to reach an epoch.
 	//
 	// Note that an epoch is considered reached even if any epoch greater than
@@ -88,9 +91,6 @@ type Block struct {
 // Backend is an interface that a consensus backend must provide.
 type Backend interface {
 	ClientBackend
-
-	// EstimateGas calculates the amount of gas required to execute the given transaction.
-	EstimateGas(ctx context.Context, caller signature.PublicKey, tx *transaction.Transaction) (transaction.Gas, error)
 
 	// Synced returns a channel that is closed once synchronization is
 	// complete.
@@ -201,4 +201,10 @@ func (ce ConsensusEvidence) Unwrap() interface{} {
 // NewConsensusEvidence creates new consensus backend-specific evidence.
 func NewConsensusEvidence(inner interface{}) ConsensusEvidence {
 	return ConsensusEvidence{inner: inner}
+}
+
+// EstimateGasRequest is a EstimateGas request.
+type EstimateGasRequest struct {
+	Caller      signature.PublicKey      `json:"caller"`
+	Transaction *transaction.Transaction `json:"transaction"`
 }

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -57,6 +57,9 @@ type ClientBackend interface {
 	// in the future).
 	WaitEpoch(ctx context.Context, epoch epochtime.EpochTime) error
 
+	// GetEpoch returns the current epoch.
+	GetEpoch(ctx context.Context, height int64) (epochtime.EpochTime, error)
+
 	// GetBlock returns a consensus block at a specific height.
 	GetBlock(ctx context.Context, height int64) (*Block, error)
 

--- a/go/consensus/api/submission.go
+++ b/go/consensus/api/submission.go
@@ -77,7 +77,7 @@ func (m *submissionManager) signAndSubmitTx(ctx context.Context, signer signatur
 	if tx.Fee == nil {
 		// Estimate amount of gas needed to perform the update.
 		var gas transaction.Gas
-		gas, err = m.backend.EstimateGas(ctx, signer.Public(), tx)
+		gas, err = m.backend.EstimateGas(ctx, &EstimateGasRequest{Caller: signer.Public(), Transaction: tx})
 		if err != nil {
 			return fmt.Errorf("failed to estimate gas: %w", err)
 		}

--- a/go/consensus/api/submission.go
+++ b/go/consensus/api/submission.go
@@ -63,7 +63,7 @@ type submissionManager struct {
 func (m *submissionManager) signAndSubmitTx(ctx context.Context, signer signature.Signer, tx *transaction.Transaction) error {
 	// Update transaction nonce.
 	var err error
-	tx.Nonce, err = m.backend.TransactionAuthHandler().GetSignerNonce(ctx, signer.Public(), HeightLatest)
+	tx.Nonce, err = m.backend.GetSignerNonce(ctx, &GetSignerNonceRequest{ID: signer.Public(), Height: HeightLatest})
 	if err != nil {
 		if errors.Is(err, ErrNoCommittedBlocks) {
 			// No committed blocks available, retry submission.

--- a/go/consensus/tendermint/apps/staking/auth.go
+++ b/go/consensus/tendermint/apps/staking/auth.go
@@ -3,7 +3,7 @@ package staking
 import (
 	"context"
 
-	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/consensus/api"
 	"github.com/oasislabs/oasis-core/go/consensus/api/transaction"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
 	stakingState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/staking/state"
@@ -12,13 +12,13 @@ import (
 var _ abci.TransactionAuthHandler = (*stakingApplication)(nil)
 
 // Implements abci.TransactionAuthHandler.
-func (app *stakingApplication) GetSignerNonce(ctx context.Context, id signature.PublicKey, height int64) (uint64, error) {
-	q, err := app.QueryFactory().(*QueryFactory).QueryAt(ctx, height)
+func (app *stakingApplication) GetSignerNonce(ctx context.Context, req *api.GetSignerNonceRequest) (uint64, error) {
+	q, err := app.QueryFactory().(*QueryFactory).QueryAt(ctx, req.Height)
 	if err != nil {
 		return 0, err
 	}
 
-	acct, err := q.AccountInfo(ctx, id)
+	acct, err := q.AccountInfo(ctx, req.ID)
 	if err != nil {
 		return 0, err
 	}

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -651,6 +651,10 @@ func (t *tendermintService) Scheduler() schedulerAPI.Backend {
 	return t.scheduler
 }
 
+func (t *tendermintService) GetEpoch(ctx context.Context, height int64) (epochtimeAPI.EpochTime, error) {
+	return t.epochtime.GetEpoch(ctx, height)
+}
+
 func (t *tendermintService) WaitEpoch(ctx context.Context, epoch epochtimeAPI.EpochTime) error {
 	ch, sub := t.epochtime.WatchEpochs()
 	defer sub.Close()

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -547,8 +547,8 @@ func (t *tendermintService) SubmitEvidence(ctx context.Context, evidence consens
 	return nil
 }
 
-func (t *tendermintService) EstimateGas(ctx context.Context, caller signature.PublicKey, tx *transaction.Transaction) (transaction.Gas, error) {
-	return t.mux.EstimateGas(caller, tx)
+func (t *tendermintService) EstimateGas(ctx context.Context, req *consensusAPI.EstimateGasRequest) (transaction.Gas, error) {
+	return t.mux.EstimateGas(req.Caller, req.Transaction)
 }
 
 func (t *tendermintService) Subscribe(subscriber string, query tmpubsub.Query) (tmtypes.Subscription, error) {

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -683,6 +683,10 @@ func (t *tendermintService) GetBlock(ctx context.Context, height int64) (*consen
 	return api.NewBlock(blk), nil
 }
 
+func (t *tendermintService) GetSignerNonce(ctx context.Context, req *consensusAPI.GetSignerNonceRequest) (uint64, error) {
+	return t.mux.TransactionAuthHandler().GetSignerNonce(ctx, req)
+}
+
 func (t *tendermintService) GetTransactions(ctx context.Context, height int64) ([][]byte, error) {
 	blk, err := t.GetTendermintBlock(ctx, height)
 	if err != nil {

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -48,4 +48,8 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.ClientBackend)
 			t.Fatalf("failed to receive consensus block")
 		}
 	}
+
+	epoch, err := backend.GetEpoch(ctx, consensus.HeightLatest)
+	require.NoError(err, "GetEpoch")
+	require.True(epoch > 0, "epoch height should be greater than zero")
 }

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -61,4 +61,11 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.ClientBackend)
 		Transaction: transaction.NewTransaction(0, nil, epochtimemock.MethodSetEpoch, 0),
 	})
 	require.NoError(err, "EstimateGas")
+
+	nonce, err := backend.GetSignerNonce(ctx, &consensus.GetSignerNonceRequest{
+		ID:     memorySigner.NewTestSigner("get signer nonce signer").Public(),
+		Height: consensus.HeightLatest,
+	})
+	require.NoError(err, "GetSignerNonce")
+	require.Equal(uint64(0), nonce, "Nonce should be zero")
 }

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -8,7 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	memorySigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/memory"
 	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
+	"github.com/oasislabs/oasis-core/go/consensus/api/transaction"
+	"github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/epochtime_mock"
 )
 
 const (
@@ -52,4 +55,10 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.ClientBackend)
 	epoch, err := backend.GetEpoch(ctx, consensus.HeightLatest)
 	require.NoError(err, "GetEpoch")
 	require.True(epoch > 0, "epoch height should be greater than zero")
+
+	_, err = backend.EstimateGas(ctx, &consensus.EstimateGasRequest{
+		Caller:      memorySigner.NewTestSigner("estimate gas signer").Public(),
+		Transaction: transaction.NewTransaction(0, nil, epochtimemock.MethodSetEpoch, 0),
+	})
+	require.NoError(err, "EstimateGas")
 }

--- a/go/oasis-node/cmd/debug/txsource/txsource.go
+++ b/go/oasis-node/cmd/debug/txsource/txsource.go
@@ -106,6 +106,7 @@ func doRun(cmd *cobra.Command, args []string) error {
 
 	logger.Debug("entering workload", "name", name)
 	if err = w.Run(ctx, rng, conn, cnsc, rtc); err != nil {
+		logger.Error("workload error", "err", err)
 		return fmt.Errorf("workload %s: %w", name, err)
 	}
 	logger.Debug("workload returned", "name", name)

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -1,0 +1,343 @@
+package workload
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+
+	"github.com/oasislabs/oasis-core/go/common"
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	memorySigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/memory"
+	"github.com/oasislabs/oasis-core/go/common/entity"
+	"github.com/oasislabs/oasis-core/go/common/identity"
+	"github.com/oasislabs/oasis-core/go/common/logging"
+	"github.com/oasislabs/oasis-core/go/common/node"
+	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
+	"github.com/oasislabs/oasis-core/go/consensus/api/transaction"
+	cmdCommon "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	registry "github.com/oasislabs/oasis-core/go/registry/api"
+	runtimeClient "github.com/oasislabs/oasis-core/go/runtime/client/api"
+	staking "github.com/oasislabs/oasis-core/go/staking/api"
+)
+
+const (
+	NameRegistration = "registration"
+
+	registryNumEntities        = 10
+	registryNumNodesPerEntity  = 5
+	registryNodeMaxEpochUpdate = 5
+)
+
+var registryLogger = logging.GetLogger("cmd/txsource/workload/registry")
+
+type registration struct {
+	ns common.Namespace
+}
+
+func getRuntime(entityID signature.PublicKey, id common.Namespace) *registry.Runtime {
+	rt := &registry.Runtime{
+		ID:       id,
+		EntityID: entityID,
+		Kind:     registry.KindCompute,
+		Executor: registry.ExecutorParameters{
+			GroupSize:    1,
+			RoundTimeout: 1 * time.Second,
+		},
+		Merge: registry.MergeParameters{
+			GroupSize:    1,
+			RoundTimeout: 1 * time.Second,
+		},
+		TxnScheduler: registry.TxnSchedulerParameters{
+			GroupSize:         1,
+			Algorithm:         "batching",
+			BatchFlushTimeout: 1 * time.Second,
+			MaxBatchSize:      1,
+			MaxBatchSizeBytes: 1,
+		},
+		Storage: registry.StorageParameters{
+			GroupSize:               1,
+			MaxApplyWriteLogEntries: 100_000,
+			MaxApplyOps:             2,
+			MaxMergeRoots:           8,
+			MaxMergeOps:             2,
+		},
+		AdmissionPolicy: registry.RuntimeAdmissionPolicy{
+			AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},
+		},
+	}
+	rt.Genesis.StateRoot.Empty()
+	return rt
+}
+
+func getNodeDesc(rng *rand.Rand, nodeIdentity *identity.Identity, entityID signature.PublicKey, runtimeID common.Namespace) *node.Node {
+	nodeAddr := node.Address{
+		TCPAddr: net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 12345,
+			Zone: "",
+		},
+	}
+
+	// NOTE: we shouldn't be registering validators, as that would lead to
+	// consensus stopping as the registered validators wouldn't actually
+	// exist.
+	availableRoles := []node.RolesMask{
+		node.RoleStorageWorker,
+		node.RoleComputeWorker,
+		node.RoleStorageWorker | node.RoleComputeWorker,
+	}
+
+	nodeDesc := node.Node{
+		ID:         nodeIdentity.NodeSigner.Public(),
+		EntityID:   entityID,
+		Expiration: 0,
+		Roles:      availableRoles[rng.Intn(len(availableRoles))],
+		Committee: node.CommitteeInfo{
+			Certificate: nodeIdentity.TLSCertificate.Certificate[0],
+			Addresses: []node.CommitteeAddress{
+				{
+					Certificate: nodeIdentity.TLSCertificate.Certificate[0],
+					Address:     nodeAddr,
+				},
+			},
+		},
+		P2P: node.P2PInfo{
+			ID: nodeIdentity.P2PSigner.Public(),
+			Addresses: []node.Address{
+				nodeAddr,
+			},
+		},
+		Consensus: node.ConsensusInfo{
+			ID: nodeIdentity.ConsensusSigner.Public(),
+			Addresses: []node.ConsensusAddress{
+				{
+					ID:      nodeIdentity.ConsensusSigner.Public(),
+					Address: nodeAddr,
+				},
+			},
+		},
+		Runtimes: []*node.Runtime{
+			{
+				ID: runtimeID,
+			},
+		},
+	}
+	return &nodeDesc
+}
+
+func signNode(identity *identity.Identity, nodeDesc *node.Node) (*node.MultiSignedNode, error) {
+	nodeSigners := []signature.Signer{
+		identity.NodeSigner,
+		identity.P2PSigner,
+		identity.ConsensusSigner,
+		identity.TLSSigner,
+	}
+
+	sigNode, err := node.MultiSignNode(nodeSigners, registry.RegisterNodeSignatureContext, nodeDesc)
+	if err != nil {
+		registryLogger.Error("failed to sign node descriptor",
+			"err", err,
+		)
+		return nil, err
+	}
+
+	return sigNode, nil
+}
+
+func getAccountNonce(ctx context.Context, conn *grpc.ClientConn, pubKey signature.PublicKey) (uint64, error) {
+	stakingClient := staking.NewStakingClient(conn)
+	account, err := stakingClient.AccountInfo(ctx, &staking.OwnerQuery{
+		Height: consensus.HeightLatest,
+		Owner:  pubKey,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("stakingClient.AccountInfo %s: %w", pubKey, err)
+	}
+	return account.General.Nonce, nil
+}
+
+func (r *registration) Run(gracefulExit context.Context, rng *rand.Rand, conn *grpc.ClientConn, cnsc consensus.ClientBackend, rtc runtimeClient.RuntimeClient) error {
+	ctx := context.Background()
+	var err error
+
+	if err = r.ns.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000002"); err != nil {
+		panic(err)
+	}
+
+	baseDir := viper.GetString(cmdCommon.CfgDataDir)
+	nodeIdentitiesDir := filepath.Join(baseDir, "node-identities")
+	if err = common.Mkdir(nodeIdentitiesDir); err != nil {
+		return fmt.Errorf("txsource/registry: failed to create node-identities dir: %w", err)
+	}
+
+	// Fetch fees.
+	// TODO: Don't dump everything, instead add a method to query just the parameters.
+	genesisDoc, err := cnsc.StateToGenesis(ctx, 1)
+	if err != nil {
+		return fmt.Errorf("failed to query state at genesis: %w", err)
+	}
+	// Entity registration fees.
+	entityRegisterFee := transaction.Fee{
+		// Entity registration fee.
+		Gas: genesisDoc.Registry.Parameters.GasCosts[registry.GasOpRegisterEntity] +
+			// Entity nodes fee.
+			(genesisDoc.Registry.Parameters.GasCosts[registry.GasOpRegisterNode] * registryNumNodesPerEntity) +
+			// Runtime registration fee.
+			genesisDoc.Registry.Parameters.GasCosts[registry.GasOpRegisterRuntime],
+	}
+	// Node registration fees.
+	nodeRegisterFee := transaction.Fee{
+		// Node registration fee.
+		Gas: genesisDoc.Registry.Parameters.GasCosts[registry.GasOpRegisterNode] +
+			// Runtime maintenance * epochs fee (NOTE: we register nodes for at most registryNodeMaxEpochUpdate epochs).
+			(genesisDoc.Registry.Parameters.GasCosts[registry.GasOpRuntimeEpochMaintenance] * registryNodeMaxEpochUpdate),
+	}
+
+	// Load all accounts.
+	type nodeAcc struct {
+		id            *identity.Identity
+		nodeDesc      *node.Node
+		reckonedNonce uint64
+	}
+	entityAccs := make([]struct {
+		signer         signature.Signer
+		reckonedNonce  uint64
+		nodeIdentities []*nodeAcc
+	}, registryNumEntities)
+
+	fac := memorySigner.NewFactory()
+	for i := range entityAccs {
+		entityAccs[i].signer, err = fac.Generate(signature.SignerEntity, rng)
+		if err != nil {
+			return fmt.Errorf("memory signer factory Generate account %d: %w", i, err)
+		}
+	}
+
+	// Register entities.
+	// XXX: currently entities are only registered at start. Could also
+	// periodically register new entities.
+	for i := range entityAccs {
+		entityAccs[i].reckonedNonce, err = getAccountNonce(ctx, conn, entityAccs[i].signer.Public())
+		if err != nil {
+			return fmt.Errorf("getAccountNonce error: %w", err)
+		}
+
+		ent := &entity.Entity{
+			ID: entityAccs[i].signer.Public(),
+		}
+
+		// Generate entity node identities.
+		for j := 0; j < registryNumNodesPerEntity; j++ {
+			dataDir, err := ioutil.TempDir(nodeIdentitiesDir, "node_")
+			if err != nil {
+				return fmt.Errorf("failed to create a temporary directory: %w", err)
+			}
+			ident, err := identity.LoadOrGenerate(dataDir, memorySigner.NewFactory())
+			if err != nil {
+				return fmt.Errorf("failed generating account node identity: %w", err)
+			}
+			nodeDesc := getNodeDesc(rng, ident, entityAccs[i].signer.Public(), r.ns)
+
+			var nodeAccNonce uint64
+			nodeAccNonce, err = getAccountNonce(ctx, conn, ident.NodeSigner.Public())
+			if err != nil {
+				return fmt.Errorf("getAccountNonce error: %w", err)
+			}
+
+			entityAccs[i].nodeIdentities = append(entityAccs[i].nodeIdentities, &nodeAcc{ident, nodeDesc, nodeAccNonce})
+			ent.Nodes = append(ent.Nodes, ident.NodeSigner.Public())
+		}
+
+		// Register entity.
+		sigEntity, err := entity.SignEntity(entityAccs[i].signer, registry.RegisterEntitySignatureContext, ent)
+		if err != nil {
+			return fmt.Errorf("failed to sign entity: %w", err)
+		}
+
+		tx := registry.NewRegisterEntityTx(entityAccs[i].reckonedNonce, &entityRegisterFee, sigEntity)
+		entityAccs[i].reckonedNonce++
+
+		signedTx, err := transaction.Sign(entityAccs[i].signer, tx)
+		if err != nil {
+			return fmt.Errorf("transaction.Sign: %w", err)
+		}
+		if err = cnsc.SubmitTx(ctx, signedTx); err != nil {
+			return fmt.Errorf("cnsc.SubmitTx: %w", err)
+		}
+
+		// Register runtime.
+		// XXX: currently only a single runtime is registered at start. Could
+		// also periodically register new runtimes.
+		if i == 0 {
+			runtimeDesc := getRuntime(entityAccs[i].signer.Public(), r.ns)
+			sigRuntime, err := registry.SignRuntime(entityAccs[i].signer, registry.RegisterRuntimeSignatureContext, runtimeDesc)
+			if err != nil {
+				return fmt.Errorf("failed to sign entity: %w", err)
+			}
+
+			tx := registry.NewRegisterRuntimeTx(entityAccs[i].reckonedNonce, &entityRegisterFee, sigRuntime)
+			entityAccs[i].reckonedNonce++
+
+			signedTx, err := transaction.Sign(entityAccs[i].signer, tx)
+			if err != nil {
+				return fmt.Errorf("transaction.Sign: %w", err)
+			}
+			if err = cnsc.SubmitTx(ctx, signedTx); err != nil {
+				return fmt.Errorf("cnsc.SubmitTx: %w", err)
+			}
+		}
+	}
+
+	for {
+		// Select a random node from random entity and register it.
+		selectedAcc := &entityAccs[rng.Intn(registryNumEntities)]
+		selectedNode := selectedAcc.nodeIdentities[rng.Intn(registryNumNodesPerEntity)]
+
+		// Current epoch.
+		epoch, err := cnsc.GetEpoch(ctx, consensus.HeightLatest)
+		if err != nil {
+			return fmt.Errorf("GetEpoch: %w", err)
+		}
+
+		// Randomized expiration.
+		// We should update for at minimum 2 epochs, as the epoch could change between querying it
+		// and actually performing the registration.
+		selectedNode.nodeDesc.Expiration = uint64(epoch) + 2 + uint64(rng.Intn(registryNodeMaxEpochUpdate-1))
+		sigNode, err := signNode(selectedNode.id, selectedNode.nodeDesc)
+		if err != nil {
+			return fmt.Errorf("signNode: %w", err)
+		}
+
+		// Register node.
+		tx := registry.NewRegisterNodeTx(selectedNode.reckonedNonce, &nodeRegisterFee, sigNode)
+		selectedNode.reckonedNonce++
+
+		signedTx, err := transaction.Sign(selectedNode.id.NodeSigner, tx)
+		if err != nil {
+			return fmt.Errorf("transaction.Sign: %w", err)
+		}
+		transferLogger.Debug("submitting registration",
+			"node", selectedNode.nodeDesc,
+		)
+		if err = cnsc.SubmitTx(ctx, signedTx); err != nil {
+			return fmt.Errorf("cnsc.SubmitTx: %w", err)
+		}
+		transferLogger.Debug("registered node",
+			"node", selectedNode.nodeDesc,
+		)
+
+		select {
+		case <-gracefulExit.Done():
+			transferLogger.Debug("time's up")
+			return nil
+		default:
+		}
+	}
+}

--- a/go/oasis-node/cmd/debug/txsource/workload/workload.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/workload.go
@@ -27,6 +27,7 @@ type Workload interface {
 
 // ByName is the registry of workloads that you can access with `--workload <name>` on the command line.
 var ByName = map[string]Workload{
-	NameTransfer:  transfer{},
-	NameOversized: oversized{},
+	NameTransfer:     transfer{},
+	NameOversized:    oversized{},
+	NameRegistration: &registration{},
 }

--- a/go/oasis-test-runner/scenario/e2e/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/txsource.go
@@ -37,6 +37,7 @@ var TxSourceMultiShort scenario.Scenario = &txSourceImpl{
 	workloads: []string{
 		workload.NameTransfer,
 		workload.NameOversized,
+		workload.NameRegistration,
 	},
 	timeLimit:             timeLimitShort,
 	livenessCheckInterval: livenessCheckInterval,
@@ -48,6 +49,7 @@ var TxSourceMulti scenario.Scenario = &txSourceImpl{
 	workloads: []string{
 		workload.NameTransfer,
 		workload.NameOversized,
+		workload.NameRegistration,
 	},
 	timeLimit:             timeLimitLong,
 	nodeRestartInterval:   nodeRestartIntervalLong,
@@ -201,6 +203,7 @@ func (sc *txSourceImpl) startWorkload(childEnv *env.Env, errCh chan error, name 
 		"debug", "txsource",
 		"--address", "unix:" + sc.net.Clients()[0].SocketPath(),
 		"--" + common.CfgDebugAllowTestKeys,
+		"--" + common.CfgDataDir, sc.net.BasePath(),
 		"--" + flags.CfgDebugDontBlameOasis,
 		"--" + flags.CfgDebugTestEntity,
 		"--log.format", logFmt.String(),

--- a/go/oasis-test-runner/scenario/e2e/txsource.go
+++ b/go/oasis-test-runner/scenario/e2e/txsource.go
@@ -203,7 +203,7 @@ func (sc *txSourceImpl) startWorkload(childEnv *env.Env, errCh chan error, name 
 		"debug", "txsource",
 		"--address", "unix:" + sc.net.Clients()[0].SocketPath(),
 		"--" + common.CfgDebugAllowTestKeys,
-		"--" + common.CfgDataDir, sc.net.BasePath(),
+		"--" + common.CfgDataDir, d.String(),
 		"--" + flags.CfgDebugDontBlameOasis,
 		"--" + flags.CfgDebugTestEntity,
 		"--log.format", logFmt.String(),


### PR DESCRIPTION
- Adds registration txsource workloads (part of: https://github.com/oasislabs/oasis-core/issues/2506)

Currently runtime and entities only register at start and the workload then continuously registers nodes. Could update to also register new entities & runtimes during the run, if reviewers find it useful.

TODO:
- [x] cleanup todo's 
- [x] randomized registration descriptors (randomized roles, expiration epochs, could do more)