### PR TITLE
go/consensus/tendermint: Expire txes when CheckTx is disabled

### DIFF
--- a/.changelog/2720.internal.md
+++ b/.changelog/2720.internal.md
@@ -1,0 +1,6 @@
+go/consensus/tendermint: Expire txes when CheckTx is disabled
+
+When CheckTx is disabled (for debug purposes only, e.g. in E2E tests), we
+still need to periodically remove old transactions as otherwise the mempool
+will fill up. Keep track of transactions were added and invalidate them when
+they expire.


### PR DESCRIPTION
When CheckTx is disabled (for debug purposes only, e.g. in E2E tests), we still
need to periodically remove old transactions as otherwise the mempool will fill
up. Keep track of transactions were added and invalidate them when they expire.