### PR TITLE
go staking: disable all transactions for locked accounts

### DIFF
--- a/.changelog/2727.breaking.md
+++ b/.changelog/2727.breaking.md
@@ -1,0 +1,5 @@
+go staking: Disable all transactions for locked accounts
+
+The account field `general.transfers_not_before` is replaced with
+`general.not_before`.
+Accounts can't send any transaction before the epoch in that field.

--- a/go/common/errors/errors.go
+++ b/go/common/errors/errors.go
@@ -51,8 +51,8 @@ func New(module string, code uint32, msg string) error {
 	}
 
 	key := errorKey(module, code)
-	if _, isRegistered := registeredErrors.Load(key); isRegistered {
-		panic(fmt.Errorf("error: already registered: %s", key))
+	if prev, isRegistered := registeredErrors.Load(key); isRegistered {
+		panic(fmt.Errorf("error: already registered: %s %s", key, prev))
 	}
 	registeredErrors.Store(key, e)
 

--- a/go/common/errors/errors.go
+++ b/go/common/errors/errors.go
@@ -52,7 +52,7 @@ func New(module string, code uint32, msg string) error {
 
 	key := errorKey(module, code)
 	if prev, isRegistered := registeredErrors.Load(key); isRegistered {
-		panic(fmt.Errorf("error: already registered: %s %s", key, prev))
+		panic(fmt.Errorf("error: already registered: %s (existing: %s)", key, prev))
 	}
 	registeredErrors.Store(key, e)
 

--- a/go/consensus/api/transaction/transaction.go
+++ b/go/consensus/api/transaction/transaction.go
@@ -21,6 +21,8 @@ const moduleName = "consensus/transaction"
 var (
 	// ErrInvalidNonce is the error returned when a nonce is invalid.
 	ErrInvalidNonce = errors.New(moduleName, 1, "transaction: invalid nonce")
+	// ErrAccountNotBefore is the error returned when an account is not allowed yet.
+	ErrAccountNotBefore = errors.New(moduleName, 4, "transaction: account not allowed yet")
 
 	// SignatureContext is the context used for signing transactions.
 	SignatureContext = signature.NewContext("oasis-core/consensus: tx", signature.WithChainSeparation())

--- a/go/consensus/tendermint/abci/context.go
+++ b/go/consensus/tendermint/abci/context.go
@@ -77,12 +77,14 @@ type Context struct {
 }
 
 // NewMockContext creates a new mock context for use in tests.
-func NewMockContext(mode ContextMode, now time.Time) *Context {
+func NewMockContext(mode ContextMode, now time.Time, state *iavl.MutableTree) *Context {
 	return &Context{
 		ctx:           context.Background(),
 		mode:          mode,
 		currentTime:   now,
 		gasAccountant: NewNopGasAccountant(),
+		state:         state,
+		blockCtx:      NewBlockContext(),
 		logger:        logging.GetLogger("consensus/tendermint/abci").With("mode", mode),
 	}
 }

--- a/go/consensus/tendermint/apps/staking/auth.go
+++ b/go/consensus/tendermint/apps/staking/auth.go
@@ -2,6 +2,7 @@ package staking
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/consensus/api/transaction"
@@ -27,5 +28,9 @@ func (app *stakingApplication) GetSignerNonce(ctx context.Context, id signature.
 
 // Implements abci.TransactionAuthHandler.
 func (app *stakingApplication) AuthenticateTx(ctx *abci.Context, tx *transaction.Transaction) error {
-	return stakingState.AuthenticateAndPayFees(ctx, ctx.TxSigner(), tx.Nonce, tx.Fee)
+	epoch, err := app.state.GetCurrentEpoch(ctx.Ctx())
+	if err != nil {
+		return fmt.Errorf("getting current epoch: %w", err)
+	}
+	return stakingState.AuthenticateAndPayFees(ctx, ctx.TxSigner(), tx.Nonce, tx.Fee, epoch)
 }

--- a/go/consensus/tendermint/apps/staking/transactions_test.go
+++ b/go/consensus/tendermint/apps/staking/transactions_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
-	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	staking "github.com/oasislabs/oasis-core/go/staking/api"
 )
 
@@ -15,16 +14,12 @@ func TestIsTransferPermitted(t *testing.T) {
 		msg       string
 		params    *staking.ConsensusParameters
 		fromID    signature.PublicKey
-		from      *staking.Account
-		epoch     epochtime.EpochTime
 		permitted bool
 	}{
 		{
 			"no disablement",
 			&staking.ConsensusParameters{},
 			signature.PublicKey{},
-			&staking.Account{},
-			0,
 			true,
 		},
 		{
@@ -33,8 +28,6 @@ func TestIsTransferPermitted(t *testing.T) {
 				DisableTransfers: true,
 			},
 			signature.PublicKey{},
-			&staking.Account{},
-			0,
 			false,
 		},
 		{
@@ -46,8 +39,6 @@ func TestIsTransferPermitted(t *testing.T) {
 				},
 			},
 			signature.PublicKey{},
-			&staking.Account{},
-			0,
 			false,
 		},
 		{
@@ -59,48 +50,9 @@ func TestIsTransferPermitted(t *testing.T) {
 				},
 			},
 			signature.PublicKey{},
-			&staking.Account{},
-			0,
 			true,
-		},
-		{
-			"before allowed",
-			&staking.ConsensusParameters{},
-			signature.PublicKey{},
-			&staking.Account{
-				General: staking.GeneralAccount{
-					TransfersNotBefore: 1,
-				},
-			},
-			0,
-			false,
-		},
-		{
-			"after allowed",
-			&staking.ConsensusParameters{},
-			signature.PublicKey{},
-			&staking.Account{},
-			1,
-			true,
-		},
-		{
-			"whitelisted before allowed ",
-			&staking.ConsensusParameters{
-				DisableTransfers: true,
-				UndisableTransfersFrom: map[signature.PublicKey]bool{
-					signature.PublicKey{}: true,
-				},
-			},
-			signature.PublicKey{},
-			&staking.Account{
-				General: staking.GeneralAccount{
-					TransfersNotBefore: 1,
-				},
-			},
-			0,
-			false,
 		},
 	} {
-		require.Equal(t, tt.permitted, isTransferPermitted(tt.params, tt.fromID, tt.from, tt.epoch), tt.msg)
+		require.Equal(t, tt.permitted, isTransferPermitted(tt.params, tt.fromID), tt.msg)
 	}
 }

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -414,9 +414,9 @@ func (sa *StakeAccumulator) TotalClaims(thresholds map[ThresholdKind]quantity.Qu
 
 // GeneralAccount is a general-purpose account.
 type GeneralAccount struct {
-	Balance            quantity.Quantity   `json:"balance"`
-	Nonce              uint64              `json:"nonce"`
-	TransfersNotBefore epochtime.EpochTime `json:"transfers_not_before,omitempty"`
+	Balance   quantity.Quantity   `json:"balance"`
+	Nonce     uint64              `json:"nonce"`
+	NotBefore epochtime.EpochTime `json:"not_before,omitempty"`
 }
 
 // EscrowAccount is an escrow account the balance of which is subject to


### PR DESCRIPTION
The account field `general.transfers_not_before` is replaced with `general.not_before`. Accounts can't send any transaction before the epoch in that field.