### PR TITLE
go/badger: enable truncate to recover from corrupted value log file

### DIFF
--- a/.changelog/2732.bugfix.md
+++ b/.changelog/2732.bugfix.md
@@ -1,0 +1,4 @@
+go/badger: enable truncate to recover from corrupted value log file
+
+Apparently badger is not at all resilient to crashes unless the truncate
+option is enabled.

--- a/go/common/persistent/persistent.go
+++ b/go/common/persistent/persistent.go
@@ -49,6 +49,9 @@ func NewCommonStore(dataDir string) (*CommonStore, error) {
 	opts := badger.DefaultOptions(filepath.Join(dataDir, dbName))
 	opts = opts.WithLogger(cmnBadger.NewLogAdapter(logger))
 	opts = opts.WithSyncWrites(true)
+	// Allow value log truncation if required (this is needed to recover the
+	// value log file which can get corrupted in crashes).
+	opts = opts.WithTruncate(true)
 	opts = opts.WithCompression(options.None)
 	// Reduce cache size to 128 KiB as the default is 1 GiB.
 	opts = opts.WithMaxCacheSize(128 * 1024)

--- a/go/consensus/tendermint/db/badger/badger.go
+++ b/go/consensus/tendermint/db/badger/badger.go
@@ -66,6 +66,9 @@ func New(fn string, noSuffix bool) (dbm.DB, error) {
 	opts := badger.DefaultOptions(fn) // This may benefit from LSMOnlyOptions.
 	opts = opts.WithLogger(cmnBadger.NewLogAdapter(logger))
 	opts = opts.WithSyncWrites(false)
+	// Allow value log truncation if required (this is needed to recover the
+	// value log file which can get corrupted in crashes).
+	opts = opts.WithTruncate(true)
 	opts = opts.WithCompression(options.Snappy)
 	// Reduce cache size to 64 MiB as the default is 1 GiB.
 	opts = opts.WithMaxCacheSize(64 * 1024 * 1024)

--- a/go/runtime/history/db.go
+++ b/go/runtime/history/db.go
@@ -53,6 +53,9 @@ func newDB(fn string, runtimeID common.Namespace) (*DB, error) {
 	opts := badger.DefaultOptions(fn)
 	opts = opts.WithLogger(cmnBadger.NewLogAdapter(logger))
 	opts = opts.WithSyncWrites(true)
+	// Allow value log truncation if required (this is needed to recover the
+	// value log file which can get corrupted in crashes).
+	opts = opts.WithTruncate(true)
 	opts = opts.WithCompression(options.None)
 	// Reduce cache size to 10 MiB as the default is 1 GiB.
 	opts = opts.WithMaxCacheSize(10 * 1024 * 1024)

--- a/go/runtime/localstorage/localstorage.go
+++ b/go/runtime/localstorage/localstorage.go
@@ -111,6 +111,9 @@ func New(dataDir, fn string, runtimeID common.Namespace) (LocalStorage, error) {
 	opts := badger.DefaultOptions(filepath.Join(dataDir, fn))
 	opts = opts.WithLogger(cmnBadger.NewLogAdapter(s.logger))
 	opts = opts.WithSyncWrites(true)
+	// Allow value log truncation if required (this is needed to recover the
+	// value log file which can get corrupted in crashes).
+	opts = opts.WithTruncate(true)
 	opts = opts.WithCompression(options.None)
 	// Reduce cache size to 128 KiB as the default is 1 GiB.
 	opts = opts.WithMaxCacheSize(128 * 1024)

--- a/go/storage/mkvs/urkel/db/badger/badger.go
+++ b/go/storage/mkvs/urkel/db/badger/badger.go
@@ -125,6 +125,9 @@ func New(cfg *api.Config) (api.NodeDB, error) {
 	opts := badger.DefaultOptions(cfg.DB)
 	opts = opts.WithLogger(cmnBadger.NewLogAdapter(db.logger))
 	opts = opts.WithSyncWrites(!cfg.DebugNoFsync)
+	// Allow value log truncation if required (this is needed to recover the
+	// value log file which can get corrupted in crashes).
+	opts = opts.WithTruncate(true)
 	opts = opts.WithCompression(options.None)
 	opts = opts.WithMaxCacheSize(cfg.MaxCacheSize)
 


### PR DESCRIPTION
Encountered corrupted badger value log file when running txsource tests with node restarts. Apparently badger is not at all resilient to crashes unless the truncate option is set on (which could result in data loss, but i think this should be safe as this means the crash happened while it was being written to the value log, so not yet committed). 

> {"caller":"node.go:741","err":"tendermint: failed to create node: tendermint/db/badger: failed to open database: During db.vlog.open: Value log truncate required to run DB. This might result in data loss","level":"error","module":"oasis-node","msg":"failed to start tendermint service","ts":"2020-02-27T09:42:18.599026044Z"}


This was also default behavior before an configuration option was added: https://github.com/dgraph-io/badger/pull/452 https://github.com/dgraph-io/badger/issues/740