### PR TITLE
runtime: Remove the non-webpki/snow related uses of ring

### DIFF
--- a/.changelog/2733.internal.md
+++ b/.changelog/2733.internal.md
@@ -1,0 +1,5 @@
+runtime: Remove the non-webpki/snow related uses of ring
+
+As much as I like the concept of ring as a library, and the
+implementation, the SGX support situation is rediculous, and we should
+minimize the use of the library for cases where alternatives exist.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,15 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "crypto-mac"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,7 +355,7 @@ dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -495,6 +504,15 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hmac"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -832,6 +850,7 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "intrusive-collections 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "io-context 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -839,7 +858,6 @@ dependencies = [
  "pem-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.16.11 (git+https://github.com/oasislabs/ring-sgx?branch=sgx-target)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -848,6 +866,7 @@ dependencies = [
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sgx-isa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1361,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1490,7 +1509,7 @@ dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.11 (git+https://github.com/oasislabs/ring-sgx?branch=sgx-target)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1517,6 +1536,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "strsim"
 version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "subtle"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2106,6 +2130,7 @@ dependencies = [
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+"checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 "checksum deoxysii 0.2.0 (git+https://github.com/oasislabs/deoxysii-rust)" = "<none>"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
@@ -2129,6 +2154,7 @@ dependencies = [
 "checksum half 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ff54597ea139063f4225f1ec47011b03c9de4a486957ff3fc506881dac951d0"
 "checksum hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum intrusive-collections 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f0207c3d23d0b13d569d4103a98f31c4cd65f30c92c3a157272966b2affd177e"
 "checksum io-context 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6deff8086863b4b598829cfe72d405540d1497fe997f903cc171aade51dae88c"
@@ -2210,7 +2236,7 @@ dependencies = [
 "checksum sgx-isa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "749959307fc786b8d0724d6ce621d9c5292e3bd992b14ea79e8930cf5d82c30e"
 "checksum sgxs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f7c8d19a8f677295b0f96bafe9cccae0a6df9ec47f5ac6f3d321d56f72f3415"
 "checksum sgxs-loaders 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73022068235965eab2c0051c03067d962110fd7341a2216dbe8469b70d11ead7"
-"checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
+"checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
 "checksum slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
@@ -2222,6 +2248,7 @@ dependencies = [
 "checksum sp800-185 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b18e3b1ddbf090b195425aca6edf8efb8e9b1fd42708131adf0f882db24fc9"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab3af2eb31c42e8f0ccf43548232556c42737e01a96db6e1777b0be108e79799"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,8 +21,6 @@ crossbeam = "0.7.1"
 byteorder = "1.3.1"
 failure = "0.1.5"
 sgx-isa = { version = "0.3.0", features = ["sgxstd"] }
-# TODO: Change version when merged upstream (briansmith/ring#738).
-ring = "0.16.11"
 webpki = "0.21.2"
 untrusted = "0.7.0"
 bincode = "1.0.0"
@@ -44,6 +42,8 @@ tiny-keccak = "1.4.2"
 sp800-185 = "0.2.0"
 zeroize = "0.6"
 intrusive-collections = "0.7"
+sha2 = "0.8.1"
+hmac = "0.7.1"
 
 [dev-dependencies]
 # For storage interoperability tests only.

--- a/runtime/src/common/crypto/hash.rs
+++ b/runtime/src/common/crypto/hash.rs
@@ -1,5 +1,5 @@
 //! Hash type.
-use ring::digest;
+use sha2::{Digest, Sha512Trunc256};
 
 impl_bytes!(Hash, 32, "A 32-byte SHA-512/256 hash.");
 
@@ -7,20 +7,20 @@ impl Hash {
     /// Compute a digest of the passed slice of bytes.
     pub fn digest_bytes(data: &[u8]) -> Hash {
         let mut result = [0u8; 32];
-        result[..].copy_from_slice(digest::digest(&digest::SHA512_256, &data).as_ref());
+        result[..].copy_from_slice(Sha512Trunc256::digest(&data).as_ref());
 
         Hash(result)
     }
 
     /// Compute a digest of the passed slices of bytes.
     pub fn digest_bytes_list(data: &[&[u8]]) -> Hash {
-        let mut ctx = digest::Context::new(&digest::SHA512_256);
+        let mut ctx = Sha512Trunc256::new();
         for datum in data {
-            ctx.update(datum);
+            ctx.input(datum);
         }
 
         let mut result = [0u8; 32];
-        result[..].copy_from_slice(ctx.finish().as_ref());
+        result[..].copy_from_slice(ctx.result().as_ref());
 
         Hash(result)
     }

--- a/runtime/src/common/crypto/mrae/mod.rs
+++ b/runtime/src/common/crypto/mrae/mod.rs
@@ -1,6 +1,7 @@
 //! MRAE primitives.
 extern crate deoxysii as deoxysii_rust;
-extern crate ring;
+extern crate hmac;
+extern crate sha2;
 extern crate x25519_dalek;
 
 pub mod deoxysii;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -36,7 +36,7 @@ extern crate intrusive_collections;
 extern crate io_context;
 extern crate pem_iterator;
 extern crate percent_encoding;
-extern crate ring;
+extern crate rand;
 extern crate rustc_hex;
 extern crate snow;
 #[cfg(test)]

--- a/runtime/src/rak.rs
+++ b/runtime/src/rak.rs
@@ -15,7 +15,7 @@ use crate::common::{
 #[cfg(target_env = "sgx")]
 use base64;
 #[cfg(target_env = "sgx")]
-use ring::rand::{SecureRandom, SystemRandom};
+use rand::{rngs::OsRng, Rng};
 #[cfg(target_env = "sgx")]
 use sgx_isa::Report;
 
@@ -101,12 +101,11 @@ impl RAK {
         // it's passed around as a JSON string, so this uses 24 bytes
         // of entropy, Base64 encoded.
         //
-        // XXX/yawning: Whiten the output, exposing raw SystemRandom output
+        // XXX/yawning: Whiten the output, exposing raw OsRng output
         // to outside the enclave makes me uneasy.
-        let rng = SystemRandom::new();
+        let mut rng = OsRng {};
         let mut nonce_bytes = [0u8; 24]; // 24 bytes is 32 chars in Base64.
-        rng.fill(&mut nonce_bytes)
-            .expect("random nonce generation must succeed");
+        rng.fill(&mut nonce_bytes);
 
         base64::encode(&nonce_bytes)
     }

--- a/runtime/src/rpc/types.rs
+++ b/runtime/src/rpc/types.rs
@@ -1,5 +1,5 @@
 //! RPC protocol types.
-use ring::rand::{SecureRandom, SystemRandom};
+use rand::{rngs::OsRng, Rng};
 use serde_derive::{Deserialize, Serialize};
 
 use crate::common::cbor::Value;
@@ -14,10 +14,9 @@ impl_bytes!(
 impl SessionID {
     /// Generate a random session identifier.
     pub fn random() -> Self {
-        let rng = SystemRandom::new();
+        let mut rng = OsRng {};
         let mut session_id = [0u8; 32];
-        rng.fill(&mut session_id)
-            .expect("random session id generation must succeed");
+        rng.fill(&mut session_id);
 
         SessionID(session_id)
     }


### PR DESCRIPTION
As much as I like the concept of ring as a library, and the
implementation, the SGX support situation is rediculous, and we should
minimize the use of the library for cases where alternatives exist.

Part of #2683.