### PR TITLE
go/oasis-node: Add go toolchain info to `--version`

### DIFF
--- a/.changelog/2730.trivial.md
+++ b/.changelog/2730.trivial.md
@@ -1,0 +1,1 @@
+go/oasis-node: Add go toolchain info to `--version`

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -3,6 +3,7 @@ package version
 
 import (
 	"fmt"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -77,6 +78,9 @@ var (
 
 	// ABCI is the version of the tendermint ABCI library.
 	ABCI = parseSemVerStr(version.ABCIVersion)
+
+	// Toolchain is the version of the Go compiler/standard library.
+	Toolchain = parseSemVerStr(strings.TrimPrefix(runtime.Version(), "go"))
 )
 
 // Versions contains all known protocol versions.
@@ -86,12 +90,14 @@ var Versions = struct {
 	ConsensusProtocol Version
 	Tendermint        Version
 	ABCI              Version
+	Toolchain         Version
 }{
 	RuntimeProtocol,
 	CommitteeProtocol,
 	ConsensusProtocol,
 	Tendermint,
 	ABCI,
+	Toolchain,
 }
 
 func parseSemVerStr(s string) Version {

--- a/go/oasis-node/cmd/root.go
+++ b/go/oasis-node/cmd/root.go
@@ -58,6 +58,7 @@ Consensus protocol version: {{ .ConsensusProtocol }}
 Committee protocol version: {{ .CommitteeProtocol }}
 Tendermint core version: {{ .Tendermint }}
 ABCI library version: {{ .ABCI }}
+Go toolchain version: {{ .Toolchain }}
 {{ end -}}
 `)
 }


### PR DESCRIPTION
Fixes #2730 
