### PR TITLE
Increase scheduler max batch size

### DIFF
--- a/.changelog/2741.bugfix.md
+++ b/.changelog/2741.bugfix.md
@@ -1,0 +1,3 @@
+Increase scheduler max batch size to 16 MiB
+
+This change facilitates RPCs to larger, more featureful runtimes.

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -96,7 +96,7 @@ func NewDefaultFixture() (*oasis.NetworkFixture, error) {
 					Algorithm:         registry.TxnSchedulerAlgorithmBatching,
 					GroupSize:         2,
 					MaxBatchSize:      1,
-					MaxBatchSizeBytes: 1000,
+					MaxBatchSizeBytes: 16 * 1024 * 1024, // 16 MiB
 					BatchFlushTimeout: 20 * time.Second,
 				},
 				Storage: registry.StorageParameters{


### PR DESCRIPTION
The value of 16M was taken from the [the CLI flags](https://github.com/oasislabs/oasis-core/blob/master/go/oasis-node/cmd/registry/runtime/runtime.go#L525)