### PR TITLE
Increase leniency of semver parsing

### DIFF
--- a/.changelog/2742.bugfix.md
+++ b/.changelog/2742.bugfix.md
@@ -1,0 +1,4 @@
+version: Allow omission of trailing semver numbers
+
+Release builds of Go
+[omit the patch number](https://golang.org/pkg/runtime/#Version)

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -101,18 +101,18 @@ var Versions = struct {
 }
 
 func parseSemVerStr(s string) Version {
-	split := strings.Split(s, ".")
-	if len(split) != 3 {
-		panic("version: failed to split SemVer")
-	}
+	split := strings.SplitN(s, ".", 4)
 
-	var semVers []uint16
-	for _, v := range split {
-		i, err := strconv.ParseUint(v, 10, 16)
+	var semVers []uint16 = []uint16{0, 0, 0}
+	for i, v := range split {
+		if i >= 3 {
+			break
+		}
+		ver, err := strconv.ParseUint(v, 10, 16)
 		if err != nil {
 			panic("version: failed to parse SemVer: " + err.Error())
 		}
-		semVers = append(semVers, uint16(i))
+		semVers[i] = uint16(ver)
 	}
 
 	return Version{Major: semVers[0], Minor: semVers[1], Patch: semVers[2]}


### PR DESCRIPTION
Not all sources of semvers provide three fields. For instance, [runtime.Version()](https://golang.org/pkg/runtime/#Version) will return only major and minor when it's part of a release build ([usage](https://golang.org/pkg/runtime/#Version)). This fixes oasis-node startup issues.