### PR TITLE
Add sanity check for registered entities' stake

### DIFF
--- a/.changelog/2748.bugfix.md
+++ b/.changelog/2748.bugfix.md
@@ -1,0 +1,6 @@
+go: Extract and generalize registry's staking sanity checks
+
+Augment the checks to check if an entity has enough stake for all stake claims
+in the Genesis document to prevent panics at oasis-node start-up due to
+entities not having enough stake in the escrow to satisfy all their stake
+claims.

--- a/.changelog/2748.internal.md
+++ b/.changelog/2748.internal.md
@@ -1,0 +1,3 @@
+go/registry/api: Extend `NodeLookup` and `RuntimeLookup` interfaces
+
+Define `Nodes()` and `AllRuntimes()` methods.

--- a/go/consensus/tendermint/apps/supplementarysanity/checks.go
+++ b/go/consensus/tendermint/apps/supplementarysanity/checks.go
@@ -64,7 +64,7 @@ func checkRegistry(ctx *abciAPI.Context, now epochtime.EpochTime) error {
 	if err != nil {
 		return fmt.Errorf("SignedNodes: %w", err)
 	}
-	err = registry.SanityCheckNodes(logger, params, nodes, seenEntities, runtimeLookup, false, now)
+	_, err = registry.SanityCheckNodes(logger, params, nodes, seenEntities, runtimeLookup, false, now)
 	if err != nil {
 		return fmt.Errorf("SanityCheckNodes: %w", err)
 	}

--- a/go/genesis/api/sanity_check.go
+++ b/go/genesis/api/sanity_check.go
@@ -24,7 +24,7 @@ func (d *Document) SanityCheck() error {
 	if err = d.EpochTime.SanityCheck(); err != nil {
 		return err
 	}
-	if err = d.Registry.SanityCheck(d.EpochTime.Base); err != nil {
+	if err = d.Registry.SanityCheck(d.EpochTime.Base, d.Staking.Ledger, d.Staking.Parameters.Thresholds); err != nil {
 		return err
 	}
 	if err = d.RootHash.SanityCheck(); err != nil {

--- a/go/registry/api/api.go
+++ b/go/registry/api/api.go
@@ -315,6 +315,9 @@ type NodeLookup interface {
 
 	// Returns the node that corresponds to the given committee certificate.
 	NodeByCertificate(ctx context.Context, cert []byte) (*node.Node, error)
+
+	// Returns a list of all nodes.
+	Nodes(ctx context.Context) ([]*node.Node, error)
 }
 
 // RuntimeLookup interface implements various ways for the verification
@@ -331,6 +334,9 @@ type RuntimeLookup interface {
 
 	// AnyRuntime looks up either an active or suspended runtime by its identifier and returns it.
 	AnyRuntime(ctx context.Context, id common.Namespace) (*Runtime, error)
+
+	// AllRuntimes returns a list of all runtimes (including suspended ones).
+	AllRuntimes(ctx context.Context) ([]*Runtime, error)
 }
 
 // VerifyRegisterEntityArgs verifies arguments for RegisterEntity.

--- a/go/registry/api/sanity_check.go
+++ b/go/registry/api/sanity_check.go
@@ -11,12 +11,18 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/entity"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/node"
+	"github.com/oasislabs/oasis-core/go/common/quantity"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
+	staking "github.com/oasislabs/oasis-core/go/staking/api"
 )
 
 // SanityCheck does basic sanity checking on the genesis state.
-func (g *Genesis) SanityCheck(baseEpoch epochtime.EpochTime) error {
+func (g *Genesis) SanityCheck(
+	baseEpoch epochtime.EpochTime,
+	stakeLedger map[signature.PublicKey]*staking.Account,
+	stakeThresholds map[staking.ThresholdKind]quantity.Quantity,
+) error {
 	logger := logging.GetLogger("genesis/sanity-check")
 
 	if !flags.DebugDontBlameOasis() {
@@ -41,9 +47,26 @@ func (g *Genesis) SanityCheck(baseEpoch epochtime.EpochTime) error {
 	}
 
 	// Check nodes.
-	_, err = SanityCheckNodes(logger, &g.Parameters, g.Nodes, seenEntities, runtimesLookup, true, baseEpoch)
+	nodeLookup, err := SanityCheckNodes(logger, &g.Parameters, g.Nodes, seenEntities, runtimesLookup, true, baseEpoch)
 	if err != nil {
 		return err
+	}
+
+	if !g.Parameters.DebugBypassStake {
+		entities := []*entity.Entity{}
+		for _, ent := range seenEntities {
+			entities = append(entities, ent)
+		}
+		runtimes, err := runtimesLookup.AllRuntimes(context.Background())
+		if err != nil {
+			return fmt.Errorf("registry: sanity check failed: could not obtain all runtimes from runtimesLookup: %w", err)
+		}
+		nodes, err := nodeLookup.Nodes(context.Background())
+		if err != nil {
+			return fmt.Errorf("registry: sanity check failed: could not obtain node list from nodeLookup: %w", err)
+		}
+		// Check stake.
+		return SanityCheckStake(entities, stakeLedger, nodes, runtimes, stakeThresholds, true)
 	}
 
 	return nil
@@ -170,6 +193,127 @@ func SanityCheckNodes(
 	}
 
 	return nodeLookup, nil
+}
+
+// SanityCheckStake ensures entities' stake accumulator claims are consistent
+// with general state and entities have enough stake for themselves and all
+// their registered nodes and runtimes.
+func SanityCheckStake(
+	entities []*entity.Entity,
+	accounts map[signature.PublicKey]*staking.Account,
+	nodes []*node.Node,
+	runtimes []*Runtime,
+	stakeThresholds map[staking.ThresholdKind]quantity.Quantity,
+	isGenesis bool,
+) error {
+	// Entities' escrow accounts for checking claims and stake.
+	generatedEscrows := make(map[signature.PublicKey]*staking.EscrowAccount)
+
+	// Generate escrow account for all entities.
+	for _, entity := range entities {
+		var escrow *staking.EscrowAccount
+		acct, ok := accounts[entity.ID]
+		if ok {
+			// Generate an escrow account with the same active balance and shares number.
+			escrow = &staking.EscrowAccount{
+				Active: staking.SharePool{
+					Balance:     acct.Escrow.Active.Balance,
+					TotalShares: acct.Escrow.Active.TotalShares,
+				},
+			}
+		} else {
+			// No account is associated with this entity, generate an empty escrow account.
+			escrow = &staking.EscrowAccount{}
+		}
+
+		// Add entity stake claim.
+		escrow.StakeAccumulator.AddClaimUnchecked(StakeClaimRegisterEntity, []staking.ThresholdKind{staking.KindEntity})
+
+		generatedEscrows[entity.ID] = escrow
+	}
+
+	for _, node := range nodes {
+		// Add node stake claims.
+		generatedEscrows[node.EntityID].StakeAccumulator.AddClaimUnchecked(StakeClaimForNode(node.ID), StakeThresholdsForNode(node))
+	}
+	for _, rt := range runtimes {
+		// Add runtime stake claims.
+		generatedEscrows[rt.EntityID].StakeAccumulator.AddClaimUnchecked(StakeClaimForRuntime(rt.ID), StakeThresholdsForRuntime(rt))
+	}
+
+	// Compare entities' generated escrow accounts with actual ones.
+	for _, entity := range entities {
+		var generatedEscrow, actualEscrow *staking.EscrowAccount
+		generatedEscrow = generatedEscrows[entity.ID]
+		acct, ok := accounts[entity.ID]
+		if ok {
+			actualEscrow = &acct.Escrow
+		} else {
+			// No account is associated with this entity, generate an empty escrow account.
+			actualEscrow = &staking.EscrowAccount{}
+		}
+
+		if isGenesis {
+			// For a Genesis document, check if the entity has enough stake for all its stake claims.
+			// NOTE: We can't perform this check at an arbitrary point since the entity could
+			// reclaim its stake from the escrow but its nodes and/or runtimes will only be
+			// ineligible/suspended at the next epoch transition.
+			if err := generatedEscrow.CheckStakeClaims(stakeThresholds); err != nil {
+				expected := "unknown"
+				expectedQty, err2 := generatedEscrow.StakeAccumulator.TotalClaims(stakeThresholds, nil)
+				if err2 == nil {
+					expected = expectedQty.String()
+				}
+				return fmt.Errorf("insufficient stake for account %s (expected: %s got: %s): %w",
+					entity.ID,
+					expected,
+					generatedEscrow.Active.Balance,
+					err,
+				)
+			}
+		} else {
+			// Otherwise, compare the expected accumulator state with the actual one.
+			// NOTE: We can't perform this check for the Genesis document since it is not allowed to
+			// have non-empty stake accumulators.
+			expectedClaims := generatedEscrows[entity.ID].StakeAccumulator.Claims
+			actualClaims := actualEscrow.StakeAccumulator.Claims
+			if len(expectedClaims) != len(actualClaims) {
+				return fmt.Errorf("incorrect number of stake claims for account %s (expected: %d got: %d)",
+					entity.ID,
+					len(expectedClaims),
+					len(actualClaims),
+				)
+			}
+			for claim, expectedThresholds := range expectedClaims {
+				thresholds, ok := actualClaims[claim]
+				if !ok {
+					return fmt.Errorf("missing claim %s for account %s", claim, entity.ID)
+				}
+				if len(thresholds) != len(expectedThresholds) {
+					return fmt.Errorf("incorrect number of thresholds for claim %s for account %s (expected: %d got: %d)",
+						claim,
+						entity.ID,
+						len(expectedThresholds),
+						len(thresholds),
+					)
+				}
+				for i, expectedThreshold := range expectedThresholds {
+					threshold := thresholds[i]
+					if threshold != expectedThreshold {
+						return fmt.Errorf("incorrect threshold in position %d for claim %s for account %s (expected: %s got: %s)",
+							i,
+							claim,
+							entity.ID,
+							expectedThreshold,
+							threshold,
+						)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 // Runtimes lookup used in sanity checks.


### PR DESCRIPTION
Extract and generalize registry's staking sanity checks in `go/consensus/tendermint/apps/supplementarysanity.checkStakeClaims()` and move them to `go/registry/api.SanityCheckStake()` function.
    
Augment the checks to check if an entity has enough stake for all stake claims in the Genesis document to prevent panics at oasis-node start-up due to entities not having enough stake in the escrow to satisfy all their stake claims.

Example panic when an entity doesn't have enough stake to be registered:
```
panic: mux: InitChain: fatal error in application: '200_registry': registry: genesis entity registration failure: staking: insufficient stake

goroutine 1 [running]:
github.com/oasislabs/oasis-core/go/consensus/tendermint/abci.(*abciMux).InitChain(0xc0001f64b0, 0x0, 0xed5d4d490, 0x0, 0xc000fd3580, 0x32, 0xc00005ae40, 0xc000128fc0, 0x1, 0x1, ...)
	github.com/oasislabs/oasis-core/go@/consensus/tendermint/abci/mux.go:442 +0xedd
github.com/tendermint/tendermint/abci/client.(*localClient).InitChainSync(0xc00117ade0, 0x0, 0xed5d4d490, 0x0, 0xc000fd3580, 0x32, 0xc00005ae40, 0xc000128fc0, 0x1, 0x1, ...)
	github.com/tendermint/tendermint@v0.32.8/abci/client/local_client.go:223 +0x101
github.com/tendermint/tendermint/proxy.(*appConnConsensus).InitChainSync(0xc007dbca90, 0x0, 0xed5d4d490, 0x0, 0xc000fd3580, 0x32, 0xc00005ae40, 0xc000128fc0, 0x1, 0x1, ...)
	github.com/tendermint/tendermint@v0.32.8/proxy/app_conn.go:65 +0x6b
github.com/tendermint/tendermint/consensus.(*Handshaker).ReplayBlocks(0xc000fa3238, 0xa, 0x170000, 0x173efdc, 0x6, 0xc000fd3580, 0x32, 0x0, 0x0, 0x0, ...)
	github.com/tendermint/tendermint@v0.32.8/consensus/replay.go:318 +0x666
github.com/tendermint/tendermint/consensus.(*Handshaker).Handshake(0xc000fa3238, 0x1af0dc0, 0xc0001f8230, 0x203001, 0x203001)
	github.com/tendermint/tendermint@v0.32.8/consensus/replay.go:269 +0x485
github.com/tendermint/tendermint/node.doHandshake(0x1aef940, 0xc007d51da0, 0xa, 0x0, 0x173efdc, 0x6, 0xc000fd3580, 0x32, 0x0, 0x0, ...)
	github.com/tendermint/tendermint@v0.32.8/node/node.go:281 +0x19a
github.com/tendermint/tendermint/node.NewNode(0xc0000f2500, 0x1acc940, 0xc0000db360, 0xc00db685f0, 0x1aaad60, 0xc00d95ff20, 0xc00d838520, 0x18e8718, 0xc00db60700, 0x1ad6a40, ...)
	github.com/tendermint/tendermint@v0.32.8/node/node.go:596 +0x343
github.com/oasislabs/oasis-core/go/consensus/tendermint.(*tendermintService).lazyInit.func2(0xc001020500, 0x0)
	github.com/oasislabs/oasis-core/go@/consensus/tendermint/tendermint.go:1015 +0x2bf
github.com/oasislabs/oasis-core/go/consensus/tendermint.(*tendermintService).Start(0xc00056de00, 0x2586e60, 0x152f980)
	github.com/oasislabs/oasis-core/go@/consensus/tendermint/tendermint.go:233 +0x89
github.com/oasislabs/oasis-core/go/oasis-node/cmd/node.newNode(0x1741200, 0x0, 0x0, 0x0)
	github.com/oasislabs/oasis-core/go@/oasis-node/cmd/node/node.go:740 +0x238a
github.com/oasislabs/oasis-core/go/oasis-node/cmd/node.NewNode(...)
	github.com/oasislabs/oasis-core/go@/oasis-node/cmd/node/node.go:454
github.com/oasislabs/oasis-core/go/oasis-node/cmd/node.Run(0x258a700, 0xc000f754a0, 0x0, 0x2)
	github.com/oasislabs/oasis-core/go@/oasis-node/cmd/node/node.go:82 +0x32
github.com/spf13/cobra.(*Command).execute(0x258a700, 0xc00003c190, 0x2, 0x2, 0x258a700, 0xc00003c190)
	github.com/spf13/cobra@v0.0.5/command.go:830 +0x2aa
github.com/spf13/cobra.(*Command).ExecuteC(0x258a700, 0x3f, 0x0, 0x0)
	github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v0.0.5/command.go:864
github.com/oasislabs/oasis-core/go/oasis-node/cmd.Execute()
	github.com/oasislabs/oasis-core/go@/oasis-node/cmd/root.go:46 +0x4b
main.main()
	github.com/oasislabs/oasis-core/go@/oasis-node/main.go:9 +0x20
```

Example panic when an entity doesn't have enough stake to have a node registered:

```
panic: mux: InitChain: fatal error in application: '200_registry': registry: genesis node registration failure: staking: insufficient stake

goroutine 1 [running]:
github.com/oasislabs/oasis-core/go/consensus/tendermint/abci.(*abciMux).InitChain(0xc000fca960, 0x0, 0xed5d4d490, 0x0, 0xc0001e80c0, 0x32, 0xc000530400, 0xc0012262a0, 0x1, 0x1, ...)
        github.com/oasislabs/oasis-core/go@/consensus/tendermint/abci/mux.go:442 +0xedd
github.com/tendermint/tendermint/abci/client.(*localClient).InitChainSync(0xc00f31c480, 0x0, 0xed5d4d490, 0x0, 0xc0001e80c0, 0x32, 0xc000530400, 0xc0012262a0, 0x1, 0x1, ...)
        github.com/tendermint/tendermint@v0.32.8/abci/client/local_client.go:223 +0x101
github.com/tendermint/tendermint/proxy.(*appConnConsensus).InitChainSync(0xc0004ea000, 0x0, 0xed5d4d490, 0x0, 0xc0001e80c0, 0x32, 0xc000530400, 0xc0012262a0, 0x1, 0x1, ...)
        github.com/tendermint/tendermint@v0.32.8/proxy/app_conn.go:65 +0x6b
github.com/tendermint/tendermint/consensus.(*Handshaker).ReplayBlocks(0xc000ff1238, 0xa, 0x170000, 0x173b41c, 0x6, 0xc0001e80c0, 0x32, 0x0, 0x0, 0x0, ...)
        github.com/tendermint/tendermint@v0.32.8/consensus/replay.go:318 +0x666
github.com/tendermint/tendermint/consensus.(*Handshaker).Handshake(0xc000ff1238, 0x1aed900, 0xc00052e1c0, 0x203000, 0x203000)
        github.com/tendermint/tendermint@v0.32.8/consensus/replay.go:269 +0x485
github.com/tendermint/tendermint/node.doHandshake(0x1aec380, 0xc0011c4780, 0xa, 0x0, 0x173b41c, 0x6, 0xc0001e80c0, 0x32, 0x0, 0x0, ...)
        github.com/tendermint/tendermint@v0.32.8/node/node.go:281 +0x19a
github.com/tendermint/tendermint/node.NewNode(0xc0001eadc0, 0x1ac9420, 0xc000535400, 0xc00dabb4d0, 0x1aa7840, 0xc00da76540, 0xc00d7a7400, 0x18e4d18, 0xc00daa95e0, 0x1ad3560, ...)
        github.com/tendermint/tendermint@v0.32.8/node/node.go:596 +0x343
github.com/oasislabs/oasis-core/go/consensus/tendermint.(*tendermintService).lazyInit.func2(0xc00000f3e0, 0x0)
        github.com/oasislabs/oasis-core/go@/consensus/tendermint/tendermint.go:1015 +0x2bf
github.com/oasislabs/oasis-core/go/consensus/tendermint.(*tendermintService).Start(0xc0004e0600, 0x2783e80, 0x152b880)
        github.com/oasislabs/oasis-core/go@/consensus/tendermint/tendermint.go:233 +0x89
github.com/oasislabs/oasis-core/go/oasis-node/cmd/node.newNode(0x173d700, 0x0, 0x0, 0x0)
        github.com/oasislabs/oasis-core/go@/oasis-node/cmd/node/node.go:740 +0x238a
github.com/oasislabs/oasis-core/go/oasis-node/cmd/node.NewNode(...)
        github.com/oasislabs/oasis-core/go@/oasis-node/cmd/node/node.go:454
github.com/oasislabs/oasis-core/go/oasis-node/cmd/node.Run(0x2787720, 0xc001047f60, 0x0, 0x2)
        github.com/oasislabs/oasis-core/go@/oasis-node/cmd/node/node.go:82 +0x32
github.com/spf13/cobra.(*Command).execute(0x2787720, 0xc0000ce160, 0x2, 0x2, 0x2787720, 0xc0000ce160)
        github.com/spf13/cobra@v0.0.5/command.go:830 +0x2aa
github.com/spf13/cobra.(*Command).ExecuteC(0x2787720, 0x3f, 0x0, 0x0)
        github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v0.0.5/command.go:864
github.com/oasislabs/oasis-core/go/oasis-node/cmd.Execute()
        github.com/oasislabs/oasis-core/go@/oasis-node/cmd/root.go:46 +0x4b
main.main()
        github.com/oasislabs/oasis-core/go@/oasis-node/main.go:9 +0x20
```