### PR TITLE
go: Various requested gRPC API additions.

### DIFF
--- a/.changelog/2739.feature.md
+++ b/.changelog/2739.feature.md
@@ -1,0 +1,4 @@
+go/scheduler: Validators now returns validators by node ID
+
+The consensus ID isn't all that useful for most external callers, so
+querying it should just return the validators by node ID instead.

--- a/.changelog/2740.feature.md
+++ b/.changelog/2740.feature.md
@@ -1,0 +1,4 @@
+go/staking: Add a Delegations call, and expose over gRPC
+
+This adds a Delegations call in the spirt of DebondingDelegations that
+returns a map of delegations for a given delegator.

--- a/go/consensus/tendermint/apps/staking/query.go
+++ b/go/consensus/tendermint/apps/staking/query.go
@@ -19,6 +19,7 @@ type Query interface {
 	DebondingInterval(context.Context) (epochtime.EpochTime, error)
 	Accounts(context.Context) ([]signature.PublicKey, error)
 	AccountInfo(context.Context, signature.PublicKey) (*staking.Account, error)
+	Delegations(context.Context, signature.PublicKey) (map[signature.PublicKey]*staking.Delegation, error)
 	DebondingDelegations(context.Context, signature.PublicKey) (map[signature.PublicKey][]*staking.DebondingDelegation, error)
 	Genesis(context.Context) (*staking.Genesis, error)
 }
@@ -89,6 +90,10 @@ func (sq *stakingQuerier) Accounts(ctx context.Context) ([]signature.PublicKey, 
 
 func (sq *stakingQuerier) AccountInfo(ctx context.Context, id signature.PublicKey) (*staking.Account, error) {
 	return sq.state.Account(id), nil
+}
+
+func (sq *stakingQuerier) Delegations(ctx context.Context, id signature.PublicKey) (map[signature.PublicKey]*staking.Delegation, error) {
+	return sq.state.DelegationsFor(id)
 }
 
 func (sq *stakingQuerier) DebondingDelegations(ctx context.Context, id signature.PublicKey) (map[signature.PublicKey][]*staking.DebondingDelegation, error) {

--- a/go/consensus/tendermint/staking/staking.go
+++ b/go/consensus/tendermint/staking/staking.go
@@ -80,6 +80,15 @@ func (tb *tendermintBackend) AccountInfo(ctx context.Context, query *api.OwnerQu
 	return q.AccountInfo(ctx, query.Owner)
 }
 
+func (tb *tendermintBackend) Delegations(ctx context.Context, query *api.OwnerQuery) (map[signature.PublicKey]*api.Delegation, error) {
+	q, err := tb.querier.QueryAt(ctx, query.Height)
+	if err != nil {
+		return nil, err
+	}
+
+	return q.Delegations(ctx, query.Owner)
+}
+
 func (tb *tendermintBackend) DebondingDelegations(ctx context.Context, query *api.OwnerQuery) (map[signature.PublicKey][]*api.DebondingDelegation, error) {
 	q, err := tb.querier.QueryAt(ctx, query.Height)
 	if err != nil {

--- a/go/scheduler/api/api.go
+++ b/go/scheduler/api/api.go
@@ -150,7 +150,7 @@ func (c *Committee) EncodedMembersHash() hash.Hash {
 
 // Validator is a consensus validator.
 type Validator struct {
-	// ID is the validator consensus (NOT oasis) identifier.
+	// ID is the validator Oasis node identifier.
 	ID signature.PublicKey `json:"id"`
 
 	// VotingPower is the validator's consensus voting power.

--- a/go/scheduler/tests/tester.go
+++ b/go/scheduler/tests/tester.go
@@ -148,7 +148,8 @@ func SchedulerImplementationTests(t *testing.T, name string, backend api.Backend
 	rt.Cleanup(t, consensus.Registry(), consensus)
 
 	// Since the integration tests run with validator elections disabled,
-	// just ensure that the GetValidators query returns the node's identity.
+	// the GetValidator query is special cased to return the node's consensus
+	// identity instead of node identities.
 	validators, err := backend.GetValidators(context.Background(), consensusAPI.HeightLatest)
 	require.NoError(err, "GetValidators")
 

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -84,6 +84,10 @@ type Backend interface {
 	// AccountInfo returns the account descriptor for the given account.
 	AccountInfo(ctx context.Context, query *OwnerQuery) (*Account, error)
 
+	// Delegations returns the list of delegations for the given owner
+	// (delegator).
+	Delegations(ctx context.Context, query *OwnerQuery) (map[signature.PublicKey]*Delegation, error)
+
 	// DebondingDelegations returns the list of debonding delegations for
 	// the given owner (delegator).
 	DebondingDelegations(ctx context.Context, query *OwnerQuery) (map[signature.PublicKey][]*DebondingDelegation, error)


### PR DESCRIPTION
 * [x] #2740 Expose list of delegators for given height via gRPC
 * [x] #2739 Expose NodeByConsensusAddress via gRPC

Notes:
 * The new Delegations call mimics the existing DebondingDelegations call, and requires specifying the delegator ID.