### PR TITLE
go/storage/mkvs: Use Badger to manage versions

### DIFF
--- a/.changelog/2674.feature.md
+++ b/.changelog/2674.feature.md
@@ -1,0 +1,5 @@
+go/storage/mkvs: Use Badger to manage versions
+
+By restricting how Prune behaves (it can now only remove the earliest round)
+we can leverage Badger's managed mode to have it manage versions for us. This
+avoids the need to track node lifetimes separately.

--- a/go/go.mod
+++ b/go/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d // indirect
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 // indirect
 	github.com/cznic/strutil v0.0.0-20181122101858-275e90344537 // indirect
-	github.com/dgraph-io/badger/v2 v2.0.0
+	github.com/dgraph-io/badger/v2 v2.0.1
 	github.com/eapache/channels v1.1.0
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -74,8 +74,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f h1:6itBiEUtu+gOzXZWn46bM5/qm8LlV6/byR7Yflx/y6M=
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
-github.com/dgraph-io/badger/v2 v2.0.0 h1:Cr05o2TUd2IcLbEY0aGd8mbjm1YyQpy+dswo3BcDXrE=
-github.com/dgraph-io/badger/v2 v2.0.0/go.mod h1:YoRSIp1LmAJ7zH7tZwRvjNMUYLxB4wl3ebYkaIruZ04=
+github.com/dgraph-io/badger/v2 v2.0.1 h1:+D6dhIqC6jIeCclnxMHqk4HPuXgrRN5UfBsLR4dNQ3A=
+github.com/dgraph-io/badger/v2 v2.0.1/go.mod h1:YoRSIp1LmAJ7zH7tZwRvjNMUYLxB4wl3ebYkaIruZ04=
 github.com/dgraph-io/ristretto v0.0.0-20191025175511-c1f00be0418e h1:aeUNgwup7PnDOBAD1BOKAqzb/W/NksOj6r3dwKKuqfg=
 github.com/dgraph-io/ristretto v0.0.0-20191025175511-c1f00be0418e/go.mod h1:edzKIzGvqUCMzhTVWbiTSe75zD9Xxq0GtSBtFmaUTZs=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=

--- a/go/storage/database/database.go
+++ b/go/storage/database/database.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/storage/api"
@@ -202,18 +201,10 @@ func (ba *databaseBackend) GetCheckpointChunk(ctx context.Context, chunk *checkp
 	return ba.checkpointer.GetCheckpointChunk(ctx, chunk, w)
 }
 
-func (ba *databaseBackend) HasRoot(root api.Root) bool {
-	return ba.nodedb.HasRoot(root)
-}
-
-func (ba *databaseBackend) Finalize(ctx context.Context, namespace common.Namespace, round uint64, roots []hash.Hash) error {
-	return ba.nodedb.Finalize(ctx, namespace, round, roots)
-}
-
-func (ba *databaseBackend) Prune(ctx context.Context, namespace common.Namespace, round uint64) (int, error) {
-	return ba.nodedb.Prune(ctx, namespace, round)
-}
-
 func (ba *databaseBackend) Checkpointer() checkpoint.CreateRestorer {
 	return ba.checkpointer
+}
+
+func (ba *databaseBackend) NodeDB() nodedb.NodeDB {
+	return ba.nodedb
 }

--- a/go/storage/database/database_test.go
+++ b/go/storage/database/database_test.go
@@ -36,6 +36,7 @@ func doTestImpl(t *testing.T, backend string) {
 			ApplyLockLRUSlots: 100,
 			Namespace:         testNs,
 			MaxCacheSize:      16 * 1024 * 1024,
+			NoFsync:           true,
 		}
 		err error
 	)

--- a/go/storage/mkvs/urkel/cache.go
+++ b/go/storage/mkvs/urkel/cache.go
@@ -419,7 +419,7 @@ func (c *cache) remoteSync(ctx context.Context, ptr *node.Pointer, fetcher readS
 	if c.persistEverythingFromSyncer {
 		// NOTE: This is a dummy batch, we assume that the node database backend is a
 		//       cache-only backend and does not care about correct values.
-		batch = c.db.NewBatch(c.syncRoot, false)
+		batch = c.db.NewBatch(c.syncRoot, c.syncRoot.Round, false)
 		dbSubtree = batch.MaybeStartSubtree(nil, 0, subtree)
 	}
 

--- a/go/storage/mkvs/urkel/checkpoint/checkpoint_test.go
+++ b/go/storage/mkvs/urkel/checkpoint/checkpoint_test.go
@@ -135,7 +135,7 @@ func TestFileCheckpointCreator(t *testing.T) {
 		err = rs.RestoreChunk(ctx, cm, &buf)
 		require.NoError(err, "RestoreChunk")
 	}
-	err = ndb2.Finalize(ctx, root.Namespace, root.Round, []hash.Hash{root.Hash})
+	err = ndb2.Finalize(ctx, root.Round, []hash.Hash{root.Hash})
 	require.NoError(err, "Finalize")
 
 	// Verify that everything has been restored.

--- a/go/storage/mkvs/urkel/checkpoint/chunk.go
+++ b/go/storage/mkvs/urkel/checkpoint/chunk.go
@@ -122,7 +122,7 @@ func restoreChunk(ctx context.Context, ndb db.NodeDB, chunk *ChunkMetadata, r io
 	}
 	emptyRoot.Hash.Empty()
 
-	batch := ndb.NewBatch(emptyRoot, true)
+	batch := ndb.NewBatch(emptyRoot, chunk.Root.Round, true)
 	defer batch.Reset()
 
 	subtree := batch.MaybeStartSubtree(nil, 0, ptr)

--- a/go/storage/mkvs/urkel/commit.go
+++ b/go/storage/mkvs/urkel/commit.go
@@ -46,7 +46,7 @@ func (t *tree) commitWithHooks(
 		oldRoot.Round = round
 	}
 
-	batch := t.cache.db.NewBatch(oldRoot, false)
+	batch := t.cache.db.NewBatch(oldRoot, round, false)
 	defer batch.Reset()
 
 	subtree := batch.MaybeStartSubtree(nil, 0, t.cache.pendingRoot)

--- a/go/storage/mkvs/urkel/db/badger/badger.go
+++ b/go/storage/mkvs/urkel/db/badger/badger.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/dgraph-io/badger/v2/options"
-	"github.com/pkg/errors"
 
 	"github.com/oasislabs/oasis-core/go/common"
 	cmnBadger "github.com/oasislabs/oasis-core/go/common/badger"
@@ -21,11 +20,9 @@ import (
 	"github.com/oasislabs/oasis-core/go/storage/mkvs/urkel/writelog"
 )
 
-const dbVersion = 1
+const dbVersion = 2
 
 var (
-	_ api.NodeDB = (*badgerNodeDB)(nil)
-
 	// nodeKeyFmt is the key format for nodes (node hash).
 	//
 	// Value is serialized node.
@@ -35,111 +32,51 @@ var (
 	//
 	// Value is CBOR-serialized write log.
 	writeLogKeyFmt = keyformat.New(0x01, uint64(0), &hash.Hash{}, &hash.Hash{})
-	// rootLinkKeyFmt is the key format for the root links (round, src root,
-	// dst root).
+	// rootsMetadataKeyFmt is the key format for roots metadata. The key format is (round).
 	//
-	// Value is empty.
-	rootLinkKeyFmt = keyformat.New(0x02, uint64(0), &hash.Hash{}, &hash.Hash{})
-	// rootGcUpdatesKeyFmt is the key format for the pending garbage collection
-	// index updates that need to be applied only in case the given root is among
-	// the finalized roots. The key format is (round, root).
-	//
-	// Value is CBOR-serialized list of updates for garbage collection index.
-	rootGcUpdatesKeyFmt = keyformat.New(0x03, uint64(0), &hash.Hash{})
-	// rootAddedNodesKeyFmt is the key format for the pending added nodes for the
+	// Value is CBOR-serialized rootsMetadata.
+	rootsMetadataKeyFmt = keyformat.New(0x02, uint64(0))
+	// rootUpdatedNodesKeyFmt is the key format for the pending updated nodes for the
 	// given root that need to be removed only in case the given root is not among
 	// the finalized roots. They key format is (round, root).
 	//
-	// Value is CBOR-serialized list of node hashes.
-	rootAddedNodesKeyFmt = keyformat.New(0x04, uint64(0), &hash.Hash{})
-	// gcIndexKeyFmt is the key format for the garbage collection index
-	// (end round, start round, node hash).
-	//
-	// Value is empty.
-	gcIndexKeyFmt = keyformat.New(0x05, uint64(0), uint64(0), &hash.Hash{})
-	// finalizedKeyFmt is the key format for the last finalized round number.
-	//
-	// Value is the last finalized round number.
-	finalizedKeyFmt = keyformat.New(0x06)
+	// Value is CBOR-serialized []updatedNode.
+	rootUpdatedNodesKeyFmt = keyformat.New(0x03, uint64(0), &hash.Hash{})
 	// metadataKeyFmt is the key format for metadata.
 	//
 	// Value is CBOR-serialized metadata.
-	metadataKeyFmt = keyformat.New(0x07)
+	metadataKeyFmt = keyformat.New(0x04)
 )
-
-// rootGcIndexUpdate is an element of the rootGcUpdates list.
-type rootGcUpdate struct {
-	_ struct{} `cbor:",toarray"` //nolint
-
-	EndRound   uint64
-	StartRound uint64
-	Node       hash.Hash
-}
-
-// rootGcIndexUpdates is the value of the rootGcUpdates keys.
-type rootGcUpdates []rootGcUpdate
-
-// rootAddedNodes is the value of the rootAddedNodes keys.
-type rootAddedNodes []hash.Hash
-
-// metadata is the database metadata.
-type metadata struct {
-	sync.RWMutex `json:"-"`
-
-	// Version is the database schema version.
-	Version uint64 `json:"version"`
-	// Namespace is the namespace this database is for.
-	Namespace common.Namespace `json:"namespace"`
-
-	lastFinalizedRound *uint64
-}
-
-func (m *metadata) getLastFinalizedRound() (uint64, bool) {
-	m.RLock()
-	defer m.RUnlock()
-
-	if m.lastFinalizedRound == nil {
-		return 0, false
-	}
-	return *m.lastFinalizedRound, true
-}
-
-func (m *metadata) setLastFinalizedRound(round uint64) {
-	m.Lock()
-	defer m.Unlock()
-
-	if m.lastFinalizedRound != nil && round <= *m.lastFinalizedRound {
-		return
-	}
-
-	m.lastFinalizedRound = &round
-}
 
 // New creates a new BadgerDB-backed node database.
 func New(cfg *api.Config) (api.NodeDB, error) {
 	db := &badgerNodeDB{
-		logger:    logging.GetLogger("urkel/db/badger"),
-		namespace: cfg.Namespace,
+		logger:           logging.GetLogger("urkel/db/badger"),
+		namespace:        cfg.Namespace,
+		discardWriteLogs: cfg.DiscardWriteLogs,
 	}
 
 	opts := badger.DefaultOptions(cfg.DB)
 	opts = opts.WithLogger(cmnBadger.NewLogAdapter(db.logger))
-	opts = opts.WithSyncWrites(!cfg.DebugNoFsync)
+	opts = opts.WithSyncWrites(!cfg.NoFsync)
 	// Allow value log truncation if required (this is needed to recover the
 	// value log file which can get corrupted in crashes).
 	opts = opts.WithTruncate(true)
-	opts = opts.WithCompression(options.None)
+	opts = opts.WithCompression(options.Snappy)
 	opts = opts.WithMaxCacheSize(cfg.MaxCacheSize)
 
 	var err error
-	if db.db, err = badger.Open(opts); err != nil {
-		return nil, errors.Wrap(err, "urkel/db/badger: failed to open database")
+	if db.db, err = badger.OpenManaged(opts); err != nil {
+		return nil, fmt.Errorf("mkvs/badger: failed to open database: %w", err)
 	}
+
+	// Make sure that we can discard any deleted/invalid metadata.
+	db.db.SetDiscardTs(tsMetadata)
 
 	// Load database metadata.
 	if err = db.load(); err != nil {
 		_ = db.db.Close()
-		return nil, errors.Wrap(err, "urkel/db/badger: failed to load metadata")
+		return nil, fmt.Errorf("mkvs/badger: failed to load metadata: %w", err)
 	}
 
 	db.gc = cmnBadger.NewGCWorker(db.logger, db.db)
@@ -147,68 +84,67 @@ func New(cfg *api.Config) (api.NodeDB, error) {
 	return db, nil
 }
 
-type badgerNodeDB struct {
+type badgerNodeDB struct { // nolint: maligned
 	logger *logging.Logger
 
 	namespace common.Namespace
 
-	db   *badger.DB
-	gc   *cmnBadger.GCWorker
-	meta metadata
+	discardWriteLogs bool
+
+	db *badger.DB
+	gc *cmnBadger.GCWorker
+
+	// metaUpdateLock must be held at any point where data at tsMetadata is read and updated. This
+	// is required because all metadata updates happen at the same timestamp and as such conflicts
+	// cannot be detected.
+	metaUpdateLock sync.Mutex
+	meta           metadata
 
 	closeOnce sync.Once
 }
 
 func (d *badgerNodeDB) load() error {
-	return d.db.Update(func(tx *badger.Txn) error {
-		// Load metadata.
-		item, err := tx.Get(metadataKeyFmt.Encode())
-		switch err {
-		case nil:
-			// Metadata already exists, just load it and verify that it is
-			// compatible with what we have here.
-			err = item.Value(func(data []byte) error {
-				return cbor.Unmarshal(data, &d.meta)
-			})
-			if err != nil {
-				return err
-			}
+	tx := d.db.NewTransactionAt(tsMetadata, true)
+	defer tx.Discard()
 
-			if d.meta.Version != dbVersion {
-				return fmt.Errorf("incompatible database version (expected: %d got: %d)",
-					dbVersion,
-					d.meta.Version,
-				)
-			}
-			if !d.meta.Namespace.Equal(&d.namespace) {
-				return fmt.Errorf("incompatible namespace (expected: %s got: %s)",
-					d.namespace,
-					d.meta.Namespace,
-				)
-			}
-
-			// Load last finalized round.
-			item, err = tx.Get(finalizedKeyFmt.Encode())
-			switch err {
-			case nil:
-				return item.Value(func(data []byte) error {
-					return cbor.Unmarshal(data, &d.meta.lastFinalizedRound)
-				})
-			case badger.ErrKeyNotFound:
-				return nil
-			default:
-				return err
-			}
-		case badger.ErrKeyNotFound:
-		default:
+	// Load metadata.
+	item, err := tx.Get(metadataKeyFmt.Encode())
+	switch err {
+	case nil:
+		// Metadata already exists, just load it and verify that it is
+		// compatible with what we have here.
+		err = item.Value(func(data []byte) error {
+			return cbor.Unmarshal(data, &d.meta.value)
+		})
+		if err != nil {
 			return err
 		}
 
-		// No metadata exists, create some.
-		d.meta.Version = dbVersion
-		d.meta.Namespace = d.namespace
-		return tx.Set(metadataKeyFmt.Encode(), cbor.Marshal(&d.meta))
-	})
+		if d.meta.value.Version != dbVersion {
+			return fmt.Errorf("incompatible database version (expected: %d got: %d)",
+				dbVersion,
+				d.meta.value.Version,
+			)
+		}
+		if !d.meta.value.Namespace.Equal(&d.namespace) {
+			return fmt.Errorf("incompatible namespace (expected: %s got: %s)",
+				d.namespace,
+				d.meta.value.Namespace,
+			)
+		}
+	case badger.ErrKeyNotFound:
+	default:
+		return err
+	}
+
+	// No metadata exists, create some.
+	d.meta.value.Version = dbVersion
+	d.meta.value.Namespace = d.namespace
+	if err = d.meta.save(tx); err != nil {
+		return err
+	}
+
+	return tx.CommitAt(tsMetadata, nil)
 }
 
 func (d *badgerNodeDB) sanityCheckNamespace(ns common.Namespace) error {
@@ -220,13 +156,18 @@ func (d *badgerNodeDB) sanityCheckNamespace(ns common.Namespace) error {
 
 func (d *badgerNodeDB) GetNode(root node.Root, ptr *node.Pointer) (node.Node, error) {
 	if ptr == nil || !ptr.IsClean() {
-		panic("urkel/db/badger: attempted to get invalid pointer from node database")
+		panic("mkvs/badger: attempted to get invalid pointer from node database")
 	}
 	if err := d.sanityCheckNamespace(root.Namespace); err != nil {
 		return nil, err
 	}
+	// If the round is earlier than the earliest round, we don't have the node (it was pruned).
+	// Note that the key can still be present in the database until it gets compacted.
+	if root.Round < d.meta.getEarliestRound() {
+		return nil, api.ErrNodeNotFound
+	}
 
-	tx := d.db.NewTransaction(false)
+	tx := d.db.NewTransactionAt(roundToTs(root.Round), false)
 	defer tx.Discard()
 	item, err := tx.Get(nodeKeyFmt.Encode(&ptr.Hash))
 	switch err {
@@ -237,7 +178,7 @@ func (d *badgerNodeDB) GetNode(root node.Root, ptr *node.Pointer) (node.Node, er
 		d.logger.Error("failed to Get node from backing store",
 			"err", err,
 		)
-		return nil, errors.Wrap(err, "urkel/db/badger: failed to Get node from backing store")
+		return nil, fmt.Errorf("mkvs/badger: failed to Get node from backing store: %w", err)
 	}
 
 	var n node.Node
@@ -249,22 +190,34 @@ func (d *badgerNodeDB) GetNode(root node.Root, ptr *node.Pointer) (node.Node, er
 		d.logger.Error("failed to unmarshal node",
 			"err", err,
 		)
-		return nil, errors.Wrap(err, "urkel/db/badger: failed to unmarshal node")
+		return nil, fmt.Errorf("mkvs/badger: failed to unmarshal node: %w", err)
 	}
 
 	return n, nil
 }
 
 func (d *badgerNodeDB) GetWriteLog(ctx context.Context, startRoot node.Root, endRoot node.Root) (writelog.Iterator, error) {
+	if d.discardWriteLogs {
+		return nil, api.ErrWriteLogNotFound
+	}
 	if !endRoot.Follows(&startRoot) {
 		return nil, api.ErrRootMustFollowOld
 	}
 	if err := d.sanityCheckNamespace(startRoot.Namespace); err != nil {
 		return nil, err
 	}
+	// If the round is earlier than the earliest round, we don't have the roots.
+	if endRoot.Round < d.meta.getEarliestRound() {
+		return nil, api.ErrWriteLogNotFound
+	}
 
-	tx := d.db.NewTransaction(false)
-	defer tx.Discard()
+	tx := d.db.NewTransactionAt(roundToTs(endRoot.Round), false)
+	discardTx := true
+	defer func() {
+		if discardTx {
+			tx.Discard()
+		}
+	}()
 
 	// Start at the end root and search towards the start root. This assumes that the
 	// chains are not long and that there is not a lot of forks as in that case performance
@@ -313,7 +266,7 @@ func (d *badgerNodeDB) GetWriteLog(ctx context.Context, startRoot node.Root, end
 
 				if !writeLogKeyFmt.Decode(item.Key(), &decRound, &decEndRootHash, &decStartRootHash) {
 					// This should not happen as the Badger iterator should take care of it.
-					panic("urkel/db/badger: bad iterator")
+					panic("mkvs/badger: bad iterator")
 				}
 
 				nextItem := wlItem{
@@ -327,7 +280,9 @@ func (d *badgerNodeDB) GetWriteLog(ctx context.Context, startRoot node.Root, end
 				if nextItem.endRootHash.Equal(&startRoot.Hash) {
 					// Path has been found, deserialize and stream write logs.
 					var index int
-					pipeTx := d.db.NewTransaction(false)
+					discardTx = false
+					// Close iterator now as ReviveHashedDBWriteLogs can close the txn immediately.
+					it.Close()
 					return api.ReviveHashedDBWriteLogs(ctx,
 						func() (node.Root, api.HashedDBWriteLog, error) {
 							if index >= len(nextItem.logKeys) {
@@ -341,7 +296,7 @@ func (d *badgerNodeDB) GetWriteLog(ctx context.Context, startRoot node.Root, end
 								Hash:      nextItem.logRoots[index],
 							}
 
-							item, err := pipeTx.Get(key)
+							item, err := tx.Get(key)
 							if err != nil {
 								return node.Root{}, nil, err
 							}
@@ -365,7 +320,7 @@ func (d *badgerNodeDB) GetWriteLog(ctx context.Context, startRoot node.Root, end
 							return leaf.(*node.LeafNode), nil
 						},
 						func() {
-							pipeTx.Discard()
+							tx.Discard()
 						},
 					)
 				}
@@ -385,6 +340,35 @@ func (d *badgerNodeDB) GetWriteLog(ctx context.Context, startRoot node.Root, end
 	return nil, api.ErrWriteLogNotFound
 }
 
+func (d *badgerNodeDB) GetLatestRound(ctx context.Context) (uint64, error) {
+	round, _ := d.meta.getLastFinalizedRound()
+	return round, nil
+}
+
+func (d *badgerNodeDB) GetEarliestRound(ctx context.Context) (uint64, error) {
+	return d.meta.getEarliestRound(), nil
+}
+
+func (d *badgerNodeDB) GetRootsForRound(ctx context.Context, round uint64) (roots []hash.Hash, err error) {
+	// If the round is earlier than the earliest round, we don't have the roots.
+	if round < d.meta.getEarliestRound() {
+		return nil, nil
+	}
+
+	tx := d.db.NewTransactionAt(tsMetadata, false)
+	defer tx.Discard()
+
+	rootsMeta, err := loadRootsMetadata(tx, round)
+	if err != nil {
+		return nil, err
+	}
+
+	for rootHash := range rootsMeta.Roots {
+		roots = append(roots, rootHash)
+	}
+	return
+}
+
 func (d *badgerNodeDB) HasRoot(root node.Root) bool {
 	if err := d.sanityCheckNamespace(root.Namespace); err != nil {
 		return false
@@ -395,34 +379,33 @@ func (d *badgerNodeDB) HasRoot(root node.Root) bool {
 		return true
 	}
 
+	// If the round is earlier than the earliest round, we don't have the root.
+	if root.Round < d.meta.getEarliestRound() {
+		return false
+	}
+
 	var emptyHash hash.Hash
 	emptyHash.Empty()
 
-	err := d.db.View(func(tx *badger.Txn) error {
-		_, err := tx.Get(rootLinkKeyFmt.Encode(root.Round, &root.Hash, &emptyHash))
-		return err
-	})
-	switch err {
-	case nil:
-		return true
-	case badger.ErrKeyNotFound:
-		return false
-	default:
+	tx := d.db.NewTransactionAt(tsMetadata, false)
+	defer tx.Discard()
+
+	rootsMeta, err := loadRootsMetadata(tx, root.Round)
+	if err != nil {
 		panic(err)
 	}
+	return rootsMeta.Roots[root.Hash] != nil
 }
 
-func (d *badgerNodeDB) Finalize(ctx context.Context, namespace common.Namespace, round uint64, roots []hash.Hash) error { // nolint: gocyclo
-	if err := d.sanityCheckNamespace(namespace); err != nil {
-		return err
-	}
+func (d *badgerNodeDB) Finalize(ctx context.Context, round uint64, roots []hash.Hash) error { // nolint: gocyclo
+	d.metaUpdateLock.Lock()
+	defer d.metaUpdateLock.Unlock()
 
-	// We don't need to put the operations into a write transaction as the
-	// content of the node database is based on immutable keys, so multiple
-	// concurrent prunes cannot cause corruption.
-	batch := d.db.NewWriteBatch()
-	defer batch.Cancel()
-	tx := d.db.NewTransaction(false)
+	// Round batch collects removals at the round timestamp.
+	roundBatch := d.db.NewWriteBatchAt(roundToTs(round))
+	defer roundBatch.Cancel()
+	// Transaction is used to read at the round timestamp.
+	tx := d.db.NewTransactionAt(roundToTs(round), true)
 	defer tx.Discard()
 
 	// Make sure that the previous round has been finalized.
@@ -442,143 +425,95 @@ func (d *badgerNodeDB) Finalize(ctx context.Context, namespace common.Namespace,
 		finalizedRoots[rootHash] = true
 	}
 
+	var rootsChanged bool
+	rootsMeta, err := loadRootsMetadata(tx, round)
+	if err != nil {
+		return err
+	}
+
 	for updated := true; updated; {
 		updated = false
 
-		prefix := rootLinkKeyFmt.Encode(round)
-		it := tx.NewIterator(badger.IteratorOptions{Prefix: prefix})
-		defer it.Close()
-
-		for it.Rewind(); it.Valid(); it.Next() {
-			item := it.Item()
-
-			// If next root hash is among the finalized roots, add this root as well.
-			var decRound uint64
-			var rootHash hash.Hash
-			var nextRoot hash.Hash
-
-			if !rootLinkKeyFmt.Decode(item.Key(), &decRound, &rootHash, &nextRoot) {
-				// This should not happen as the Badger iterator should take care of it.
-				panic("urkel/db/badger: bad iterator")
-			}
-
-			if nextRoot.IsEmpty() {
+		for rootHash, derivedRoots := range rootsMeta.Roots {
+			if len(derivedRoots) == 0 {
 				continue
 			}
-			if !finalizedRoots[rootHash] && finalizedRoots[nextRoot] {
-				finalizedRoots[rootHash] = true
-				updated = true
+
+			for _, nextRoot := range derivedRoots {
+				if !finalizedRoots[rootHash] && finalizedRoots[nextRoot] {
+					finalizedRoots[rootHash] = true
+					updated = true
+				}
 			}
 		}
 	}
 
-	// Go through all roots and either commit GC updates or prune them based on
-	// whether they are included in the finalized roots or not.
-	prefix := rootLinkKeyFmt.Encode(round)
-	it := tx.NewIterator(badger.IteratorOptions{Prefix: prefix})
-	defer it.Close()
-
+	// Go through all roots and prune them based on whether they are finalized or not.
 	maybeLoneNodes := make(map[hash.Hash]bool)
 	notLoneNodes := make(map[hash.Hash]bool)
 
-	for it.Rewind(); it.Valid(); it.Next() {
-		var decRound uint64
-		var rootHash hash.Hash
-		var nextRoot hash.Hash
-
-		if !rootLinkKeyFmt.Decode(it.Item().Key(), &decRound, &rootHash, &nextRoot) {
-			// This should not happen as the Badger iterator should take care of it.
-			panic("urkel/db/badger: bad iterator")
-		}
-		// Skip all actual links to avoid processing the same root multiple times.
-		if !nextRoot.IsEmpty() {
-			// We still need to remove the links for non-finalized roots.
-			if !finalizedRoots[rootHash] {
-				if err := batch.Delete(it.Item().KeyCopy(nil)); err != nil {
-					return err
-				}
-			}
-			continue
-		}
-
-		rootGcUpdatesKey := rootGcUpdatesKeyFmt.Encode(round, &rootHash)
-		rootAddedNodesKey := rootAddedNodesKeyFmt.Encode(round, &rootHash)
+	for rootHash := range rootsMeta.Roots {
+		// TODO: Consider colocating updated nodes with the root metadata.
+		rootUpdatedNodesKey := rootUpdatedNodesKeyFmt.Encode(round, &rootHash)
 
 		// Load hashes of nodes added during this round for this root.
-		item, err := tx.Get(rootAddedNodesKey)
+		item, err := tx.Get(rootUpdatedNodesKey)
 		if err != nil {
-			panic("urkel/db/badger: corrupted root added nodes index")
+			panic("mkvs/badger: corrupted root added nodes index")
 		}
 
-		var addedNodes rootAddedNodes
+		var updatedNodes []updatedNode
 		err = item.Value(func(data []byte) error {
-			return cbor.Unmarshal(data, &addedNodes)
+			return cbor.Unmarshal(data, &updatedNodes)
 		})
 		if err != nil {
-			panic("urkel/db/badger: corrupted root added nodes index")
+			panic("mkvs/badger: corrupted root updated nodes index")
 		}
 
 		if finalizedRoots[rootHash] {
-			// Commit garbage collection index updates for any finalized roots.
-			item, err = tx.Get(rootGcUpdatesKey)
-			if err != nil {
-				panic("urkel/db/badger: corrupted root gc updates index")
-			}
-
-			var gcUpdates rootGcUpdates
-			err = item.Value(func(data []byte) error {
-				return cbor.Unmarshal(data, &gcUpdates)
-			})
-			if err != nil {
-				panic("urkel/db/badger: corrupted root gc updates index")
-			}
-
-			for _, u := range gcUpdates {
-				key := gcIndexKeyFmt.Encode(u.EndRound, u.StartRound, &u.Node)
-				if err = batch.Set(key, []byte("")); err != nil {
-					return err
-				}
-			}
-
 			// Make sure not to remove any nodes shared with finalized roots.
-			for _, h := range addedNodes {
-				notLoneNodes[h] = true
+			for _, n := range updatedNodes {
+				if n.Removed {
+					maybeLoneNodes[n.Hash] = true
+				} else {
+					notLoneNodes[n.Hash] = true
+				}
 			}
 		} else {
 			// Remove any non-finalized roots. It is safe to remove these nodes
 			// as they can never be resurrected due to the round being part of the
 			// node hash as long as we make sure that these nodes are not shared
 			// with any finalized roots added in the same round.
-			for _, h := range addedNodes {
-				maybeLoneNodes[h] = true
+			for _, n := range updatedNodes {
+				if !n.Removed {
+					maybeLoneNodes[n.Hash] = true
+				}
 			}
-			if err = batch.Delete(it.Item().KeyCopy(nil)); err != nil {
-				return err
-			}
+
+			delete(rootsMeta.Roots, rootHash)
+			rootsChanged = true
 
 			// Remove write logs for the non-finalized root.
-			if err = func() error {
-				rootWriteLogsPrefix := writeLogKeyFmt.Encode(round, &rootHash)
-				wit := tx.NewIterator(badger.IteratorOptions{Prefix: rootWriteLogsPrefix})
-				defer wit.Close()
+			if !d.discardWriteLogs {
+				if err = func() error {
+					rootWriteLogsPrefix := writeLogKeyFmt.Encode(round, &rootHash)
+					wit := tx.NewIterator(badger.IteratorOptions{Prefix: rootWriteLogsPrefix})
+					defer wit.Close()
 
-				for wit.Rewind(); wit.Valid(); wit.Next() {
-					if err = batch.Delete(wit.Item().KeyCopy(nil)); err != nil {
-						return err
+					for wit.Rewind(); wit.Valid(); wit.Next() {
+						if err = roundBatch.Delete(wit.Item().KeyCopy(nil)); err != nil {
+							return err
+						}
 					}
+					return nil
+				}(); err != nil {
+					return err
 				}
-				return nil
-			}(); err != nil {
-				return err
 			}
 		}
 
-		// GC updates no longer needed after finalization.
-		if err = batch.Delete(rootGcUpdatesKey); err != nil {
-			return err
-		}
-		// Set of added nodes no longer needed after finalization.
-		if err = batch.Delete(rootAddedNodesKey); err != nil {
+		// Set of updated nodes no longer needed after finalization.
+		if err = tx.Delete(rootUpdatedNodesKey); err != nil {
 			return err
 		}
 	}
@@ -590,105 +525,62 @@ func (d *badgerNodeDB) Finalize(ctx context.Context, namespace common.Namespace,
 		}
 
 		key := nodeKeyFmt.Encode(&h)
-		if err := batch.Delete(key); err != nil {
+		if err := roundBatch.Delete(key); err != nil {
 			return err
 		}
 	}
 
-	// Update last finalized round. This is done at the end as Badger may
-	// split the batch into multiple transactions.
-	if err := batch.Set(finalizedKeyFmt.Encode(), cbor.Marshal(round)); err != nil {
-		return err
-	}
-
 	// Commit batch.
-	if err := batch.Flush(); err != nil {
+	if err := roundBatch.Flush(); err != nil {
 		return err
 	}
 
-	// Update cached last finalized round.
-	d.meta.setLastFinalizedRound(round)
+	// Save roots metadata if changed.
+	if rootsChanged {
+		if err := rootsMeta.save(tx); err != nil {
+			return fmt.Errorf("mkvs/badger: failed to save roots metadata: %w", err)
+		}
+	}
 
+	// Update last finalized round.
+	if err := d.meta.setLastFinalizedRound(tx, round); err != nil {
+		return fmt.Errorf("mkvs/badger: failed to set last finalized round: %w", err)
+	}
+
+	if err := tx.CommitAt(tsMetadata, nil); err != nil {
+		return fmt.Errorf("mkvs/badger: failed to commit metadata: %w", err)
+	}
 	return nil
 }
 
-func (d *badgerNodeDB) Prune(ctx context.Context, namespace common.Namespace, round uint64) (int, error) {
-	if err := d.sanityCheckNamespace(namespace); err != nil {
-		return 0, err
-	}
-
-	// We don't need to put the operations into a write transaction as the
-	// content of the node database is based on immutable keys, so multiple
-	// concurrent prunes cannot cause corruption.
-	batch := d.db.NewWriteBatch()
-	defer batch.Cancel()
-	tx := d.db.NewTransaction(false)
-	defer tx.Discard()
+func (d *badgerNodeDB) Prune(ctx context.Context, round uint64) error {
+	d.metaUpdateLock.Lock()
+	defer d.metaUpdateLock.Unlock()
 
 	// Make sure that the round that we try to prune has been finalized.
 	lastFinalizedRound, exists := d.meta.getLastFinalizedRound()
 	if !exists || lastFinalizedRound < round {
-		return 0, api.ErrNotFinalized
+		return api.ErrNotFinalized
+	}
+	// Make sure that the round that we are trying to prune is the earliest round.
+	if round != d.meta.getEarliestRound() {
+		return api.ErrNotEarliest
 	}
 
-	prevRound, err := getPreviousRound(tx, round)
+	// Remove all roots in round.
+	batch := d.db.NewWriteBatchAt(roundToTs(round))
+	defer batch.Cancel()
+	tx := d.db.NewTransactionAt(roundToTs(round), true)
+	defer tx.Discard()
+
+	rootsMeta, err := loadRootsMetadata(tx, round)
 	if err != nil {
-		return 0, err
+		return err
 	}
-
-	pruneHashes := make(map[hash.Hash]bool)
-
-	// Iterate over all lifetimes that end in the passed round.
-	prefix := gcIndexKeyFmt.Encode(round)
-	it := tx.NewIterator(badger.IteratorOptions{Prefix: prefix})
-	defer it.Close()
-
-	for it.Rewind(); it.Valid(); it.Next() {
-		var endRound uint64
-		var startRound uint64
-		var h hash.Hash
-
-		if !gcIndexKeyFmt.Decode(it.Item().Key(), &endRound, &startRound, &h) {
-			// This should not happen as the Badger iterator should take care of it.
-			panic("urkel/db/badger: bad iterator")
-		}
-
-		if err = batch.Delete(it.Item().KeyCopy(nil)); err != nil {
-			return 0, err
-		}
-
-		if startRound > prevRound || startRound == endRound {
-			// Either start round is after the previous round or the node starts and
-			// terminates in the same round. Prune the node(s).
-			pruneHashes[h] = true
-		} else {
-			// Since the current round is being pruned, the lifetime ends at the
-			// previous round.
-			if err = batch.Set(gcIndexKeyFmt.Encode(prevRound, startRound, &h), []byte("")); err != nil {
-				return 0, err
-			}
-		}
-	}
-
-	// Prune all roots in round.
-	prefix = rootLinkKeyFmt.Encode(round)
-	it = tx.NewIterator(badger.IteratorOptions{Prefix: prefix})
-	defer it.Close()
 
 	maybeLoneRoots := make(map[hash.Hash]bool)
-	for it.Rewind(); it.Valid(); it.Next() {
-		item := it.Item()
-
-		var decRound uint64
-		var rootHash hash.Hash
-		var nextRoot hash.Hash
-
-		if !rootLinkKeyFmt.Decode(item.Key(), &decRound, &rootHash, &nextRoot) {
-			// This should not happen as the iterator should take care of it.
-			panic("urkel/db/badger: bad iterator")
-		}
-
-		if nextRoot.IsEmpty() {
+	for rootHash, derivedRoots := range rootsMeta.Roots {
+		if len(derivedRoots) == 0 {
 			// Need to only set the flag iff the flag has not already been set
 			// to either value before.
 			if _, ok := maybeLoneRoots[rootHash]; !ok {
@@ -697,10 +589,6 @@ func (d *badgerNodeDB) Prune(ctx context.Context, namespace common.Namespace, ro
 		} else {
 			maybeLoneRoots[rootHash] = false
 		}
-
-		if err = batch.Delete(item.KeyCopy(nil)); err != nil {
-			return 0, err
-		}
 	}
 	for rootHash, isLone := range maybeLoneRoots {
 		if !isLone {
@@ -708,47 +596,66 @@ func (d *badgerNodeDB) Prune(ctx context.Context, namespace common.Namespace, ro
 		}
 
 		// Traverse the root and prune all items created in this round.
-		root := node.Root{Namespace: namespace, Round: round, Hash: rootHash}
-		err = api.Visit(ctx, d, root, func(ctx context.Context, n node.Node) bool {
+		root := node.Root{Namespace: d.namespace, Round: round, Hash: rootHash}
+		var innerErr error
+		err := api.Visit(ctx, d, root, func(ctx context.Context, n node.Node) bool {
 			if n.GetCreatedRound() == round {
-				pruneHashes[n.GetHash()] = true
+				h := n.GetHash()
+				if innerErr = batch.Delete(nodeKeyFmt.Encode(&h)); innerErr != nil {
+					return false
+				}
 			}
 			return true
 		})
-		if err != nil {
-			return 0, err
+		if innerErr != nil {
+			return innerErr
 		}
+		if err != nil {
+			return err
+		}
+	}
+
+	// Delete roots metadata.
+	if err := tx.Delete(rootsMetadataKeyFmt.Encode(round)); err != nil {
+		return fmt.Errorf("mkvs/badger: failed to remove roots metadata: %w", err)
 	}
 
 	// Prune all write logs in round.
-	prefix = writeLogKeyFmt.Encode(round)
-	it = tx.NewIterator(badger.IteratorOptions{Prefix: prefix})
-	defer it.Close()
+	if !d.discardWriteLogs {
+		wtx := d.db.NewTransactionAt(roundToTs(round), false)
+		defer wtx.Discard()
 
-	for it.Rewind(); it.Valid(); it.Next() {
-		if err = batch.Delete(it.Item().KeyCopy(nil)); err != nil {
-			return 0, err
-		}
-	}
+		prefix := writeLogKeyFmt.Encode(round)
+		it := wtx.NewIterator(badger.IteratorOptions{Prefix: prefix})
+		defer it.Close()
 
-	// Prune all collected hashes.
-	var pruned int
-	for h := range pruneHashes {
-		if err = batch.Delete(nodeKeyFmt.Encode(&h)); err != nil {
-			return 0, err
+		for it.Rewind(); it.Valid(); it.Next() {
+			if err := batch.Delete(it.Item().KeyCopy(nil)); err != nil {
+				return err
+			}
 		}
-		pruned++
 	}
 
 	// Commit batch.
 	if err := batch.Flush(); err != nil {
-		return 0, err
+		return fmt.Errorf("mkvs/badger: failed to flush batch: %w", err)
 	}
 
-	return pruned, nil
+	// Update metadata.
+	if err := d.meta.setEarliestRound(tx, round+1); err != nil {
+		return fmt.Errorf("mkvs/badger: failed to set earliest round: %w", err)
+	}
+	if err := tx.CommitAt(tsMetadata, nil); err != nil {
+		return fmt.Errorf("mkvs/badger: failed to commit: %w", err)
+	}
+
+	// Discard everything invalidated at or below given round.
+	d.db.SetDiscardTs(roundToTs(round + 1))
+
+	return nil
 }
 
-func (d *badgerNodeDB) NewBatch(oldRoot node.Root, chunk bool) api.Batch {
+func (d *badgerNodeDB) NewBatch(oldRoot node.Root, round uint64, chunk bool) api.Batch {
 	// WARNING: There is a maximum batch size and maximum batch entry count.
 	// Both of these things are derived from the MaxTableSize option.
 	//
@@ -758,10 +665,15 @@ func (d *badgerNodeDB) NewBatch(oldRoot node.Root, chunk bool) api.Batch {
 
 	return &badgerBatch{
 		db:      d,
-		bat:     d.db.NewWriteBatch(),
+		bat:     d.db.NewWriteBatchAt(roundToTs(round)),
 		oldRoot: oldRoot,
 		chunk:   chunk,
 	}
+}
+
+func (d *badgerNodeDB) Size() (int64, error) {
+	lsm, vlog := d.db.Size()
+	return lsm + vlog, nil
 }
 
 func (d *badgerNodeDB) Close() {
@@ -776,49 +688,6 @@ func (d *badgerNodeDB) Close() {
 	})
 }
 
-func getPreviousRound(tx *badger.Txn, round uint64) (uint64, error) {
-	if round == 0 {
-		return 0, nil
-	}
-
-	it := tx.NewIterator(badger.IteratorOptions{
-		Reverse: true,
-		Prefix:  rootLinkKeyFmt.Encode(),
-	})
-	defer it.Close()
-	// When iterating in reverse, seek moves us to the given key or to the previous
-	// key in case the given key does not exist. So this will give us either the
-	// queried round or the previous round.
-	it.Seek(rootLinkKeyFmt.Encode(round))
-	if !it.Valid() {
-		// No previous round.
-		return 0, nil
-	}
-
-	// Try to decode the current or previous round as a linkKeyFmt.
-	var decRound uint64
-	if !rootLinkKeyFmt.Decode(it.Item().Key(), &decRound) {
-		// No previous round.
-		return 0, nil
-	}
-
-	if decRound == round {
-		// Same round, we need to move the iterator and decode again.
-		it.Next()
-		if !it.Valid() {
-			// No previous round.
-			return 0, nil
-		}
-
-		if !rootLinkKeyFmt.Decode(it.Item().Key(), &decRound) {
-			// No previous round.
-			return 0, nil
-		}
-	}
-
-	return decRound, nil
-}
-
 type badgerBatch struct {
 	api.BaseBatch
 
@@ -830,8 +699,7 @@ type badgerBatch struct {
 
 	writeLog     writelog.WriteLog
 	annotations  writelog.Annotations
-	removedNodes []node.Node
-	addedNodes   rootAddedNodes
+	updatedNodes []updatedNode
 }
 
 func (ba *badgerBatch) MaybeStartSubtree(subtree api.Subtree, depth node.Depth, subtreeRoot *node.Pointer) api.Subtree {
@@ -843,7 +711,10 @@ func (ba *badgerBatch) MaybeStartSubtree(subtree api.Subtree, depth node.Depth, 
 
 func (ba *badgerBatch) PutWriteLog(writeLog writelog.WriteLog, annotations writelog.Annotations) error {
 	if ba.chunk {
-		return fmt.Errorf("urkel/db/badger: cannot put write log in chunk mode")
+		return fmt.Errorf("mkvs/badger: cannot put write log in chunk mode")
+	}
+	if ba.db.discardWriteLogs {
+		return nil
 	}
 
 	ba.writeLog = writeLog
@@ -853,14 +724,22 @@ func (ba *badgerBatch) PutWriteLog(writeLog writelog.WriteLog, annotations write
 
 func (ba *badgerBatch) RemoveNodes(nodes []node.Node) error {
 	if ba.chunk {
-		return fmt.Errorf("urkel/db/badger: cannot remove nodes in chunk mode")
+		return fmt.Errorf("mkvs/badger: cannot remove nodes in chunk mode")
 	}
 
-	ba.removedNodes = nodes
+	for _, n := range nodes {
+		ba.updatedNodes = append(ba.updatedNodes, updatedNode{
+			Removed: true,
+			Hash:    n.GetHash(),
+		})
+	}
 	return nil
 }
 
 func (ba *badgerBatch) Commit(root node.Root) error {
+	ba.db.metaUpdateLock.Lock()
+	defer ba.db.metaUpdateLock.Unlock()
+
 	if err := ba.db.sanityCheckNamespace(root.Namespace); err != nil {
 		return err
 	}
@@ -868,97 +747,72 @@ func (ba *badgerBatch) Commit(root node.Root) error {
 		return api.ErrRootMustFollowOld
 	}
 
-	// Create a separate transaction for reading values. Note that since we are
-	// not doing updates in the same transaction this could cause read/write
-	// conflicts. We don't care about those due to our storage structure as all
-	// writes would write the same or compatible values.
-	tx := ba.db.db.NewTransaction(false)
-	defer tx.Discard()
-
-	// Make sure that the round that we try to commit into has not yet been
-	// finalized.
+	// Make sure that the round that we try to commit into has not yet been finalized.
 	lastFinalizedRound, exists := ba.db.meta.getLastFinalizedRound()
 	if exists && lastFinalizedRound >= root.Round {
 		return api.ErrAlreadyFinalized
 	}
 
-	// Get previous round.
-	prevRound, err := getPreviousRound(tx, root.Round)
+	// Update the set of roots for this round.
+	tx := ba.db.db.NewTransactionAt(roundToTs(root.Round), true)
+	defer tx.Discard()
+
+	rootsMeta, err := loadRootsMetadata(tx, root.Round)
 	if err != nil {
 		return err
 	}
 
-	// Create root with an empty next link.
-	var emptyHash hash.Hash
-	emptyHash.Empty()
-	if err = ba.bat.Set(rootLinkKeyFmt.Encode(root.Round, &root.Hash, &emptyHash), []byte("")); err != nil {
-		return errors.Wrap(err, "urkel/db/badger: set returned error")
+	if rootsMeta.Roots[root.Hash] != nil {
+		// Root already exists, no need to do anything since if the hash matches, everything will
+		// be identical and we would just be duplicating work.
+		//
+		// If we are importing a chunk, there can be multiple commits for the same root.
+		if !ba.chunk {
+			ba.Reset()
+			return ba.BaseBatch.Commit(root)
+		}
+	} else {
+		// Create root with no derived roots.
+		rootsMeta.Roots[root.Hash] = []hash.Hash{}
+
+		if err = rootsMeta.save(tx); err != nil {
+			return fmt.Errorf("mkvs/badger: failed to save roots metadata: %w", err)
+		}
 	}
 
 	if ba.chunk {
 		// Skip most of metadata updates if we are just importing chunks.
-		key := rootGcUpdatesKeyFmt.Encode(root.Round, &root.Hash)
-		if err = ba.bat.Set(key, cbor.Marshal(rootGcUpdates{})); err != nil {
-			return errors.Wrap(err, "urkel/db/badger: set returned error")
-		}
-		key = rootAddedNodesKeyFmt.Encode(root.Round, &root.Hash)
-		if err = ba.bat.Set(key, cbor.Marshal(rootAddedNodes{})); err != nil {
-			return errors.Wrap(err, "urkel/db/badger: set returned error")
+		key := rootUpdatedNodesKeyFmt.Encode(root.Round, &root.Hash)
+		if err = tx.Set(key, cbor.Marshal([]updatedNode{})); err != nil {
+			return fmt.Errorf("mkvs/badger: set returned error: %w", err)
 		}
 	} else {
 		// Update the root link for the old root.
 		if !ba.oldRoot.Hash.IsEmpty() {
-			if prevRound != ba.oldRoot.Round && ba.oldRoot.Round != root.Round {
+			if ba.oldRoot.Round < ba.db.meta.getEarliestRound() && ba.oldRoot.Round != root.Round {
 				return api.ErrPreviousRoundMismatch
 			}
 
-			key := rootLinkKeyFmt.Encode(ba.oldRoot.Round, &ba.oldRoot.Hash, &emptyHash)
-			_, err = tx.Get(key)
-			switch err {
-			case nil:
-			case badger.ErrKeyNotFound:
-				return api.ErrRootNotFound
-			default:
+			var oldRootsMeta *rootsMetadata
+			oldRootsMeta, err = loadRootsMetadata(tx, ba.oldRoot.Round)
+			if err != nil {
 				return err
 			}
 
-			key = rootLinkKeyFmt.Encode(ba.oldRoot.Round, &ba.oldRoot.Hash, &root.Hash)
-			if err = ba.bat.Set(key, []byte("")); err != nil {
-				return errors.Wrap(err, "urkel/db/badger: set returned error")
+			if _, ok := oldRootsMeta.Roots[ba.oldRoot.Hash]; !ok {
+				return api.ErrRootNotFound
+			}
+
+			oldRootsMeta.Roots[ba.oldRoot.Hash] = append(oldRootsMeta.Roots[ba.oldRoot.Hash], root.Hash)
+			if err = oldRootsMeta.save(tx); err != nil {
+				return fmt.Errorf("mkvs/badger: failed to save old roots metadata: %w", err)
 			}
 		}
 
-		// Mark removed nodes for garbage collection. Updates against the GC index
-		// are only applied in case this root is finalized.
-		var gcUpdates rootGcUpdates
-		for _, n := range ba.removedNodes {
-			// Node lives from the round it was created in up to the previous round.
-			//
-			// NOTE: The node will never be resurrected as the round number is part
-			//       of the node hash.
-			endRound := prevRound
-			if ba.oldRoot.Round == root.Round {
-				// If the previous root is in the same round, the node needs to end
-				// in the same round instead.
-				endRound = root.Round
-			}
-
-			h := n.GetHash()
-			gcUpdates = append(gcUpdates, rootGcUpdate{
-				EndRound:   endRound,
-				StartRound: n.GetCreatedRound(),
-				Node:       h,
-			})
-		}
-		key := rootGcUpdatesKeyFmt.Encode(root.Round, &root.Hash)
-		if err = ba.bat.Set(key, cbor.Marshal(gcUpdates)); err != nil {
-			return errors.Wrap(err, "urkel/db/badger: set returned error")
-		}
-
-		// Store added nodes (only needed until the round is finalized).
-		key = rootAddedNodesKeyFmt.Encode(root.Round, &root.Hash)
-		if err = ba.bat.Set(key, cbor.Marshal(ba.addedNodes)); err != nil {
-			return errors.Wrap(err, "urkel/db/badger: set returned error")
+		// Store updated nodes (only needed until the round is finalized).
+		key := rootUpdatedNodesKeyFmt.Encode(root.Round, &root.Hash)
+		if err = tx.Set(key, cbor.Marshal(ba.updatedNodes)); err != nil {
+			return fmt.Errorf("mkvs/badger: set returned error: %w", err)
 		}
 
 		// Store write log.
@@ -966,20 +820,25 @@ func (ba *badgerBatch) Commit(root node.Root) error {
 			log := api.MakeHashedDBWriteLog(ba.writeLog, ba.annotations)
 			bytes := cbor.Marshal(log)
 			key := writeLogKeyFmt.Encode(root.Round, &root.Hash, &ba.oldRoot.Hash)
-			if err := ba.bat.Set(key, bytes); err != nil {
-				return errors.Wrap(err, "urkel/db/badger: set new write log returned error")
+			if err = ba.bat.Set(key, bytes); err != nil {
+				return fmt.Errorf("mkvs/badger: set new write log returned error: %w", err)
 			}
 		}
 	}
 
-	if err := ba.bat.Flush(); err != nil {
+	// Flush node updates.
+	if err = ba.bat.Flush(); err != nil {
+		return fmt.Errorf("mkvs/badger: failed to flush batch: %w", err)
+	}
+
+	// Commit root metadata updates. This is done last, so in case we fail, we can still retry.
+	if err = tx.CommitAt(tsMetadata, nil); err != nil {
 		return err
 	}
 
 	ba.writeLog = nil
 	ba.annotations = nil
-	ba.removedNodes = nil
-	ba.addedNodes = nil
+	ba.updatedNodes = nil
 
 	return ba.BaseBatch.Commit(root)
 }
@@ -988,8 +847,7 @@ func (ba *badgerBatch) Reset() {
 	ba.bat.Cancel()
 	ba.writeLog = nil
 	ba.annotations = nil
-	ba.removedNodes = nil
-	ba.addedNodes = nil
+	ba.updatedNodes = nil
 }
 
 type badgerSubtree struct {
@@ -1003,7 +861,7 @@ func (s *badgerSubtree) PutNode(depth node.Depth, ptr *node.Pointer) error {
 	}
 
 	h := ptr.Node.GetHash()
-	s.batch.addedNodes = append(s.batch.addedNodes, h)
+	s.batch.updatedNodes = append(s.batch.updatedNodes, updatedNode{Hash: h})
 	if err = s.batch.bat.Set(nodeKeyFmt.Encode(&h), data); err != nil {
 		return err
 	}

--- a/go/storage/mkvs/urkel/db/badger/helpers.go
+++ b/go/storage/mkvs/urkel/db/badger/helpers.go
@@ -1,0 +1,11 @@
+package badger
+
+// Timestamp at which database metadata is stored. This needs to be 1 so that we can discard any
+// invalid/removed cruft while still keeping everything else even if pruning is not enabled.
+const tsMetadata = 1
+
+// roundToTs convers a MKVS round to a badger timestamp.
+func roundToTs(round uint64) uint64 {
+	// Round 0 starts at timestamp after metadata.
+	return tsMetadata + 1 + round
+}

--- a/go/storage/mkvs/urkel/db/badger/metadata.go
+++ b/go/storage/mkvs/urkel/db/badger/metadata.go
@@ -1,0 +1,127 @@
+package badger
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/dgraph-io/badger/v2"
+
+	"github.com/oasislabs/oasis-core/go/common"
+	"github.com/oasislabs/oasis-core/go/common/cbor"
+	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
+)
+
+// serializedMetadata is the on-disk serialized metadata.
+type serializedMetadata struct {
+	// Version is the database schema version.
+	Version uint64 `json:"version"`
+	// Namespace is the namespace this database is for.
+	Namespace common.Namespace `json:"namespace"`
+
+	// EarliestRound is the earliest round.
+	EarliestRound uint64 `json:"earliest_round"`
+	// LastFinalizedRound is the last finalized round.
+	LastFinalizedRound *uint64 `json:"last_finalized_round"`
+}
+
+// metadata is the database metadata.
+type metadata struct {
+	sync.RWMutex
+
+	value serializedMetadata
+}
+
+func (m *metadata) getEarliestRound() uint64 {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.value.EarliestRound
+}
+
+func (m *metadata) setEarliestRound(tx *badger.Txn, round uint64) error {
+	m.Lock()
+	defer m.Unlock()
+
+	// The earliest round can only increase, not decrease.
+	if round < m.value.EarliestRound {
+		return nil
+	}
+
+	m.value.EarliestRound = round
+	return m.save(tx)
+}
+
+func (m *metadata) getLastFinalizedRound() (uint64, bool) {
+	m.RLock()
+	defer m.RUnlock()
+
+	if m.value.LastFinalizedRound == nil {
+		return 0, false
+	}
+	return *m.value.LastFinalizedRound, true
+}
+
+func (m *metadata) setLastFinalizedRound(tx *badger.Txn, round uint64) error {
+	m.Lock()
+	defer m.Unlock()
+
+	if m.value.LastFinalizedRound != nil && round <= *m.value.LastFinalizedRound {
+		return nil
+	}
+
+	if m.value.LastFinalizedRound == nil {
+		m.value.EarliestRound = round
+	}
+
+	m.value.LastFinalizedRound = &round
+	return m.save(tx)
+}
+
+func (m *metadata) save(tx *badger.Txn) error {
+	return tx.Set(metadataKeyFmt.Encode(), cbor.Marshal(m.value))
+}
+
+// updatedNode is an element of the root updated nodes key.
+//
+// NOTE: Public fields of this structure are part of the on-disk format.
+type updatedNode struct {
+	_ struct{} `cbor:",toarray"` // nolint
+
+	Removed bool
+	Hash    hash.Hash
+}
+
+// rootsMetadata manages the roots metadata for a given round.
+//
+// NOTE: Public fields of this structure are part of the on-disk format.
+type rootsMetadata struct {
+	_ struct{} `cbor:",toarray"`
+
+	// Roots is the map of a root created in a round to any derived roots (in this or later rounds).
+	Roots map[hash.Hash][]hash.Hash
+
+	// round is the round this metadata is for.
+	round uint64
+}
+
+// loadRootsMetadata loads the roots metadata for the given round from the database.
+func loadRootsMetadata(tx *badger.Txn, round uint64) (*rootsMetadata, error) {
+	rootsMeta := &rootsMetadata{round: round}
+	item, err := tx.Get(rootsMetadataKeyFmt.Encode(round))
+	switch err {
+	case nil:
+		if err = item.Value(func(val []byte) error { return cbor.Unmarshal(val, &rootsMeta) }); err != nil {
+			return nil, fmt.Errorf("mkvs/badger: error reading roots metadata: %w", err)
+		}
+	case badger.ErrKeyNotFound:
+		rootsMeta.Roots = make(map[hash.Hash][]hash.Hash)
+	default:
+		return nil, fmt.Errorf("mkvs/badger: error reading roots metadata: %w", err)
+	}
+	return rootsMeta, nil
+}
+
+// save saves the roots metadata to the database.
+func (rm *rootsMetadata) save(tx *badger.Txn) error {
+	return tx.Set(rootsMetadataKeyFmt.Encode(rm.round), cbor.Marshal(rm))
+}


### PR DESCRIPTION
Extracted from #2674
Fixes #2736 

By restricting how Prune behaves (it can now only remove the earliest round) we
can leverage Badger's managed mode to have it manage versions for us. This
avoids the need to track node lifetimes separately.
