### PR TITLE
go/staking/tests: Add escrow and delegations to debug genesis state

### DIFF
--- a/.changelog/2767.internal.md
+++ b/.changelog/2767.internal.md
@@ -1,0 +1,6 @@
+go/staking/tests: Add escrow and delegations to debug genesis state
+
+Introduce `stakingTestsState` that holds the current state of staking
+tests and enable the staking implementation tests
+(`StakingImplementationTest`, `StakingClientImplementationTests`) to always
+use this up-to-date state.

--- a/go/staking/tests/debug/debug_stake.go
+++ b/go/staking/tests/debug/debug_stake.go
@@ -12,7 +12,10 @@ import (
 )
 
 var (
-	DebugStateTestTotalSupply = QtyFromInt(math.MaxInt64)
+	DebugStateTotalSupply            = QtyFromInt(math.MaxInt64)
+	DebugStateSrcGeneralBalance      = QtyFromInt(math.MaxInt64 - 100)
+	DebugStateSrcEscrowActiveBalance = QtyFromInt(100)
+	DebugStateSrcEscrowActiveShares  = QtyFromInt(1000)
 
 	DebugGenesisState = api.Genesis{
 		Parameters: api.ConsensusParameters{
@@ -37,11 +40,24 @@ var (
 			RewardFactorEpochSigned: QtyFromInt(1),
 			// Zero RewardFactorBlockProposed is normal.
 		},
-		TotalSupply: DebugStateTestTotalSupply,
+		TotalSupply: DebugStateTotalSupply,
 		Ledger: map[signature.PublicKey]*api.Account{
 			DebugStateSrcID: &api.Account{
 				General: api.GeneralAccount{
-					Balance: DebugStateTestTotalSupply,
+					Balance: DebugStateSrcGeneralBalance,
+				},
+				Escrow: api.EscrowAccount{
+					Active: api.SharePool{
+						Balance:     DebugStateSrcEscrowActiveBalance,
+						TotalShares: DebugStateSrcEscrowActiveShares,
+					},
+				},
+			},
+		},
+		Delegations: map[signature.PublicKey]map[signature.PublicKey]*api.Delegation{
+			DebugStateSrcID: map[signature.PublicKey]*api.Delegation{
+				DebugStateSrcID: &api.Delegation{
+					Shares: DebugStateSrcEscrowActiveShares,
 				},
 			},
 		},


### PR DESCRIPTION
Extracted from #2748.

Introduce `stakingTestsState` that holds the current state of staking tests.

Since staking tests are run as part of `TestNode` tests which spin up a real node, subsequent tests are run in a modified (i.e. non-genesis) state.

This change enables the staking implementation tests (`StakingImplementationTest`, `StakingClientImplementationTests`) to use a new `stakingTestsState` that is initialized to the current staking state.

Remove `testInitialEnv()` since it has become tautological.

Extract remaining useful checks from the removed `testInitialEnv()`:
- `testThresholds()`,
- `testLastBlockFees()`.