### PR TITLE
runtime: Add hongfuzz fuzzing targets

### DIFF
--- a/.changelog/2705.internal.md
+++ b/.changelog/2705.internal.md
@@ -1,0 +1,1 @@
+runtime: Add hongfuzz fuzzing targets

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ target/
 **/generated
 /dist/
 /__pycache__/
+hfuzz_target
+hfuzz_workspace
 
 # IDE.
 .idea/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "derive_arbitrary 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arc-swap"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +355,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +541,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "honggfuzz"
+version = "0.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arbitrary 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hostname"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "memoffset"
@@ -849,6 +886,7 @@ dependencies = [
 name = "oasis-core-runtime"
 version = "0.3.0-alpha"
 dependencies = [
+ "arbitrary 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -860,6 +898,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "honggfuzz 0.5.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "intrusive-collections 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "io-context 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1974,6 +2013,7 @@ dependencies = [
 [metadata]
 "checksum aesm-client 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "95a2d87c3d15461218087c46189c0e910d5e9fe2a84f9912f5ea6d831b207f0c"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum arbitrary 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "75153c95fdedd7db9732dfbfc3702324a1627eec91ba56e37cd0ac78314ab2ed"
 "checksum arc-swap 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
@@ -2013,6 +2053,7 @@ dependencies = [
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 "checksum deoxysii 0.2.0 (git+https://github.com/oasislabs/deoxysii-rust)" = "<none>"
+"checksum derive_arbitrary 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "caedd6a71b6d00bdc458ec8ffbfd12689c1ee7ffa69ad9933310aaf2f08f18d8"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)" = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 "checksum enclave-runner 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0babfbb884b23d336fc721d68cd09946d951b71f6165739709a7cc8e4e107b21"
@@ -2035,6 +2076,7 @@ dependencies = [
 "checksum hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
 "checksum hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 "checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+"checksum honggfuzz 0.5.47 (registry+https://github.com/rust-lang/crates.io-index)" = "c3de2c3273ef7735df1c5a72128ca85b1d20105b9aac643cdfd7a6e581311150"
 "checksum hostname 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc5260e6c63877196b6fca5a7fb4eaff751134045ad3415716192baa36f5b9a0"
 "checksum intrusive-collections 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d0153b585ad53d6b7d02519ae83d7a0a5e56ebb0f968b986bddae43f3eed0b9a"
 "checksum io-context 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6deff8086863b4b598829cfe72d405540d1497fe997f903cc171aade51dae88c"
@@ -2051,6 +2093,7 @@ dependencies = [
 "checksum lru 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "5d8f669d42c72d18514dfca8115689c5f6370a17d980cb5bd777a67f404594c8"
 "checksum match_cfg 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+"checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 "checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,23 +1,4 @@
 //! Oasis Core client library.
-extern crate futures;
-#[cfg(not(target_env = "sgx"))]
-extern crate grpcio;
-extern crate oasis_core_runtime;
-#[cfg(not(target_env = "sgx"))]
-extern crate rustracing;
-#[cfg(not(target_env = "sgx"))]
-extern crate rustracing_jaeger;
-extern crate serde;
-extern crate serde_bytes;
-extern crate serde_cbor;
-extern crate serde_derive;
-#[macro_use]
-extern crate failure;
-extern crate io_context;
-#[cfg(not(target_env = "sgx"))]
-extern crate tokio;
-extern crate tokio_current_thread;
-extern crate tokio_executor;
 
 #[cfg(not(target_env = "sgx"))]
 #[macro_use]

--- a/client/src/rpc/client.rs
+++ b/client/src/rpc/client.rs
@@ -4,7 +4,7 @@ use std::sync::{
     Arc, Mutex,
 };
 
-use failure::Fallible;
+use failure::{Fail, Fallible};
 use futures::{
     future,
     prelude::*,

--- a/client/src/transaction/block_watcher.rs
+++ b/client/src/transaction/block_watcher.rs
@@ -4,6 +4,7 @@ use std::sync::{
     Arc, Mutex,
 };
 
+use failure::Fail;
 use futures::{prelude::*, stream::Fuse, try_ready};
 use tokio::{spawn, sync::watch};
 

--- a/client/src/transaction/client.rs
+++ b/client/src/transaction/client.rs
@@ -1,7 +1,7 @@
 //! Transaction client.
 use std::time::Duration;
 
-use failure::{Error, Fallible};
+use failure::{Error, Fail, Fallible};
 use futures::{future, prelude::*};
 use grpcio::{Channel, Error::RpcFailure, RpcStatus, RpcStatusCode};
 use rustracing::{sampler::AllSampler, tag};

--- a/keymanager-api-common/Cargo.toml
+++ b/keymanager-api-common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oasis-core-keymanager-api-common"
 version = "0.3.0-alpha"
 authors = ["Oasis Labs Inc. <info@oasislabs.com>"]
+edition = "2018"
 
 [dependencies]
 base64 = "0.10.1"

--- a/keymanager-api-common/src/lib.rs
+++ b/keymanager-api-common/src/lib.rs
@@ -1,15 +1,4 @@
 //! Key manager API common types and functions.
-extern crate base64;
-extern crate failure;
-extern crate lazy_static;
-extern crate oasis_core_runtime;
-extern crate rand;
-extern crate rustc_hex;
-extern crate serde;
-extern crate serde_bytes;
-extern crate serde_derive;
-extern crate x25519_dalek;
-
 use failure::Fallible;
 use lazy_static::lazy_static;
 use oasis_core_runtime::common::{cbor, crypto::signature::PublicKey as OasisPublicKey};

--- a/keymanager-client/src/lib.rs
+++ b/keymanager-client/src/lib.rs
@@ -1,20 +1,13 @@
 //! Key manager client.
-extern crate failure;
-extern crate futures;
-#[cfg(not(target_env = "sgx"))]
-extern crate grpcio;
-extern crate io_context;
-extern crate lru;
-extern crate oasis_core_client;
-extern crate oasis_core_keymanager_api;
-extern crate oasis_core_runtime;
 
 pub mod client;
 pub mod mock;
 
 use std::sync::Arc;
 
-use self::{io_context::Context, oasis_core_client::BoxFuture};
+use io_context::Context;
+use oasis_core_client::BoxFuture;
+use oasis_core_keymanager_api;
 
 /// Key manager client interface.
 pub trait KeyManagerClient: Send + Sync {

--- a/keymanager-lib/src/lib.rs
+++ b/keymanager-lib/src/lib.rs
@@ -1,16 +1,3 @@
-extern crate failure;
-extern crate io_context;
-extern crate lazy_static;
-extern crate lru;
-extern crate oasis_core_keymanager_api_common;
-extern crate oasis_core_keymanager_client;
-extern crate oasis_core_runtime;
-extern crate rand;
-extern crate sp800_185;
-extern crate tiny_keccak;
-extern crate x25519_dalek;
-extern crate zeroize;
-
 pub mod context;
 pub mod kdf;
 pub mod policy;

--- a/keymanager-runtime/api/Cargo.toml
+++ b/keymanager-runtime/api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oasis-core-keymanager-api"
 version = "0.3.0-alpha"
 authors = ["Oasis Labs Inc. <info@oasislabs.com>"]
+edition = "2018"
 
 [dependencies]
 base64 = "0.10.1"

--- a/keymanager-runtime/api/src/lib.rs
+++ b/keymanager-runtime/api/src/lib.rs
@@ -1,15 +1,3 @@
-extern crate base64;
-extern crate failure;
-extern crate lazy_static;
-extern crate oasis_core_keymanager_api_common;
-extern crate oasis_core_runtime;
-extern crate rand;
-extern crate rustc_hex;
-extern crate serde;
-extern crate serde_bytes;
-extern crate serde_derive;
-extern crate x25519_dalek;
-
 use std::collections::HashSet;
 
 use oasis_core_runtime::common::crypto::signature::PrivateKey as OasisPrivateKey;

--- a/keymanager-runtime/src/main.rs
+++ b/keymanager-runtime/src/main.rs
@@ -1,9 +1,3 @@
-extern crate failure;
-extern crate lazy_static;
-extern crate oasis_core_keymanager_api;
-extern crate oasis_core_keymanager_lib;
-extern crate oasis_core_runtime;
-
 use std::sync::Arc;
 
 mod methods;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -44,8 +44,18 @@ zeroize = "0.6"
 intrusive-collections = "0.8"
 sha2 = "0.8.1"
 hmac = "0.7.1"
+honggfuzz = "0.5.47"
+arbitrary = { version = "0.4.1", features = ["derive"] }
 
 [dev-dependencies]
 # For storage interoperability tests only.
 grpcio = "0.4.6"
 tempfile = "3.0.7"
+
+[[bin]]
+name = "fuzz-mkvs-proof"
+path = "fuzz/mkvs_proof.rs"
+
+[[bin]]
+name = "fuzz-mkvs-node"
+path = "fuzz/mkvs_node.rs"

--- a/runtime/fuzz/mkvs_node.rs
+++ b/runtime/fuzz/mkvs_node.rs
@@ -1,0 +1,16 @@
+use honggfuzz::fuzz;
+
+use oasis_core_runtime::storage::mkvs::urkel::{marshal::Marshal, NodeBox};
+
+fn main() {
+    loop {
+        fuzz!(|data: &[u8]| {
+            let mut node = NodeBox::default();
+            if node.unmarshal_binary(data).is_err() {
+                return;
+            }
+
+            let _ = node.marshal_binary().unwrap();
+        });
+    }
+}

--- a/runtime/fuzz/mkvs_proof.rs
+++ b/runtime/fuzz/mkvs_proof.rs
@@ -1,0 +1,18 @@
+use honggfuzz::fuzz;
+use io_context::Context;
+
+use oasis_core_runtime::storage::mkvs::urkel::sync::{Proof, ProofVerifier, RawProofEntry};
+
+fn main() {
+    loop {
+        fuzz!(|entries: Vec<Option<RawProofEntry>>| {
+            let proof = Proof {
+                entries,
+                ..Default::default()
+            };
+
+            let pv = ProofVerifier;
+            let _ = pv.verify_proof(Context::background(), proof.untrusted_root, &proof);
+        });
+    }
+}

--- a/runtime/src/storage/mkvs/urkel/mod.rs
+++ b/runtime/src/storage/mkvs/urkel/mod.rs
@@ -8,4 +8,4 @@ pub mod sync;
 #[cfg(test)]
 mod tests;
 
-pub use tree::{Depth, Key, Root, UrkelTree};
+pub use tree::{Depth, Key, NodeBox, Root, UrkelTree};

--- a/runtime/src/storage/mkvs/urkel/sync/proof.rs
+++ b/runtime/src/storage/mkvs/urkel/sync/proof.rs
@@ -1,5 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
+use arbitrary::Arbitrary;
 use failure::{format_err, Fallible};
 use io_context::Context;
 use serde_bytes;
@@ -16,7 +17,7 @@ const PROOF_ENTRY_FULL: u8 = 0x01;
 const PROOF_ENTRY_HASH: u8 = 0x02;
 
 /// A raw proof entry.
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct RawProofEntry(#[serde(with = "serde_bytes")] pub Vec<u8>);
 
 impl AsRef<[u8]> for RawProofEntry {


### PR DESCRIPTION
Fixes #2705 

Also removes `extern crate` declarations which are not needed anymore.