### PR TITLE
go/consensus/tendermint: Use our notion of latest height

### DIFF
--- a/.changelog/2786.bugfix.md
+++ b/.changelog/2786.bugfix.md
@@ -1,0 +1,5 @@
+go/consensus/tendermint: Use our notion of latest height
+
+Do not let Tendermint determine the latest height as that completely ignores
+ABCI processing so it can return a block for which local state does not yet
+exist.

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -265,6 +265,11 @@ func (a *ApplicationServer) EstimateGas(caller signature.PublicKey, tx *transact
 	return a.mux.EstimateGas(caller, tx)
 }
 
+// BlockHeight returns the last committed block height.
+func (a *ApplicationServer) BlockHeight() int64 {
+	return a.mux.state.BlockHeight()
+}
+
 // NewApplicationServer returns a new ApplicationServer, using the provided
 // directory to persist state.
 func NewApplicationServer(ctx context.Context, upgrader upgrade.Backend, cfg *ApplicationConfig) (*ApplicationServer, error) {


### PR DESCRIPTION
Do not let Tendermint determine the latest height as that completely ignores
ABCI processing so it can return a block for which local state does not yet
exist.