### PR TITLE
txsource/queries: increase the odds of querying the latest height

### DIFF
--- a/.changelog/2787.internal.md
+++ b/.changelog/2787.internal.md
@@ -1,0 +1,1 @@
+txsource/queries: increase the odds of querying the latest height


### PR DESCRIPTION
To test things like: https://github.com/oasislabs/oasis-core/pull/2786

Probably shouldn't have removed this from the initial queries PR in the first place :-)