### PR TITLE
storage: Rename "round" to "version"

### DIFF
--- a/.changelog/2734.breaking.md
+++ b/.changelog/2734.breaking.md
@@ -1,0 +1,8 @@
+storage: Rename "round" to "version"
+
+Previously the MKVS used the term "round" to mean a monotonically increasing
+version number. This choice was due to the fact that it was initially used to
+only store runtime state which has a concept of rounds.
+
+As we expand its use it makes more sense to generalize this and call it
+version.

--- a/client/src/transaction/snapshot.rs
+++ b/client/src/transaction/snapshot.rs
@@ -71,7 +71,7 @@ impl Clone for BlockSnapshot {
         let mkvs = UrkelTree::make()
             .with_root(Root {
                 namespace: self.block.header.namespace,
-                round: self.block.header.round,
+                version: self.block.header.round,
                 hash: self.block.header.state_root,
             })
             .new(Box::new(read_syncer.clone()));
@@ -91,7 +91,7 @@ impl BlockSnapshot {
         let mkvs = UrkelTree::make()
             .with_root(Root {
                 namespace: block.header.namespace,
-                round: block.header.round,
+                version: block.header.round,
                 hash: block.header.state_root,
             })
             .new(Box::new(read_syncer.clone()));

--- a/go/common/version/version.go
+++ b/go/common/version/version.go
@@ -59,11 +59,11 @@ var (
 	// the runtime.
 	//
 	// NOTE: This version must be synced with runtime/src/common/version.rs.
-	RuntimeProtocol = Version{Major: 0, Minor: 12, Patch: 0}
+	RuntimeProtocol = Version{Major: 0, Minor: 13, Patch: 0}
 
 	// CommitteeProtocol versions the P2P protocol used by the
 	// committee members.
-	CommitteeProtocol = Version{Major: 0, Minor: 8, Patch: 0}
+	CommitteeProtocol = Version{Major: 0, Minor: 9, Patch: 0}
 
 	// ConsensusProtocol versions all data structures and processing used by
 	// the epochtime, beacon, registry, roothash, etc. modules that are
@@ -71,7 +71,7 @@ var (
 	//
 	// NOTE: Any change in the major or minor versions are considered
 	//       breaking changes for the protocol.
-	ConsensusProtocol = Version{Major: 0, Minor: 23, Patch: 0}
+	ConsensusProtocol = Version{Major: 0, Minor: 24, Patch: 0}
 
 	// Tendermint exposes the tendermint core version.
 	Tendermint = parseSemVerStr(version.TMCoreSemVer)

--- a/go/oasis-node/cmd/debug/byzantine/executor.go
+++ b/go/oasis-node/cmd/debug/byzantine/executor.go
@@ -62,7 +62,7 @@ func (cbc *computeBatchContext) openTrees(ctx context.Context, rs syncer.ReadSyn
 	var err error
 	cbc.ioTree = transaction.NewTree(rs, storage.Root{
 		Namespace: cbc.bd.Header.Namespace,
-		Round:     cbc.bd.Header.Round + 1,
+		Version:   cbc.bd.Header.Round + 1,
 		Hash:      cbc.bd.IORoot,
 	})
 
@@ -73,7 +73,7 @@ func (cbc *computeBatchContext) openTrees(ctx context.Context, rs syncer.ReadSyn
 
 	cbc.stateTree = urkel.NewWithRoot(rs, nil, storage.Root{
 		Namespace: cbc.bd.Header.Namespace,
-		Round:     cbc.bd.Header.Round,
+		Version:   cbc.bd.Header.Round,
 		Hash:      cbc.bd.Header.StateRoot,
 	})
 

--- a/go/oasis-node/cmd/debug/storage/export.go
+++ b/go/oasis-node/cmd/debug/storage/export.go
@@ -101,7 +101,7 @@ func exportRuntime(dataDir, destDir string, id common.Namespace, rtg *registry.R
 
 	root := storageAPI.Root{
 		Namespace: id,
-		Round:     rtg.Round,
+		Version:   rtg.Round,
 		Hash:      rtg.StateRoot,
 	}
 	tree := urkel.NewWithRoot(storageBackend, nil, root)
@@ -110,7 +110,7 @@ func exportRuntime(dataDir, destDir string, id common.Namespace, rtg *registry.R
 
 	fn := fmt.Sprintf("storage-dump-%v-%d.json",
 		root.Namespace.String(),
-		root.Round,
+		root.Version,
 	)
 	fn = filepath.Join(destDir, fn)
 	return exportIterator(fn, &root, it)

--- a/go/oasis-node/cmd/debug/storage/storage.go
+++ b/go/oasis-node/cmd/debug/storage/storage.go
@@ -210,7 +210,7 @@ func doCheckRoots(cmd *cobra.Command, args []string) {
 
 		stateRoot := node.Root{
 			Namespace: id,
-			Round:     i,
+			Version:   i,
 			Hash:      blk.Header.StateRoot,
 		}
 		if !oldStateRoot.Hash.Equal(&stateRoot.Hash) {
@@ -218,10 +218,10 @@ func doCheckRoots(cmd *cobra.Command, args []string) {
 		}
 		oldStateRoot = stateRoot
 
-		emptyRoot.Round = i
+		emptyRoot.Version = i
 		ioRoot := node.Root{
 			Namespace: id,
-			Round:     i,
+			Version:   i,
 			Hash:      blk.Header.IORoot,
 		}
 		if !ioRoot.Hash.IsEmpty() {

--- a/go/oasis-node/cmd/storage/benchmark/benchmark.go
+++ b/go/oasis-node/cmd/storage/benchmark/benchmark.go
@@ -124,7 +124,7 @@ func doBenchmark(cmd *cobra.Command, args []string) { // nolint: gocyclo
 		// This will store the new Urkel tree root for later lookups.
 		var newRoot storageAPI.Root
 		newRoot.Namespace = ns
-		newRoot.Round = 1
+		newRoot.Version = 1
 		newRoot.Hash.Empty()
 
 		// Apply.

--- a/go/oasis-test-runner/scenario/e2e/storage_sync.go
+++ b/go/oasis-test-runner/scenario/e2e/storage_sync.go
@@ -130,7 +130,7 @@ func (sc *storageSyncImpl) Run(childEnv *env.Env) error {
 			return fmt.Errorf("failed to get block %d: %w", checkpoint, err)
 		}
 		for _, cp := range cps {
-			if cp.Root.Round != blk.Header.Round {
+			if cp.Root.Version != blk.Header.Round {
 				continue
 			}
 			var found bool

--- a/go/roothash/api/block/header.go
+++ b/go/roothash/api/block/header.go
@@ -113,7 +113,7 @@ func (h *Header) StorageRoots() (roots []storage.Root) {
 	} {
 		roots = append(roots, storage.Root{
 			Namespace: h.Namespace,
-			Round:     h.Round,
+			Version:   h.Round,
 			Hash:      rootHash,
 		})
 	}

--- a/go/roothash/tests/tester.go
+++ b/go/roothash/tests/tester.go
@@ -251,7 +251,7 @@ func (s *runtimeState) testSuccessfulRound(t *testing.T, backend api.Backend, co
 	// Generate a dummy I/O root.
 	ioRoot := storageAPI.Root{
 		Namespace: child.Header.Namespace,
-		Round:     child.Header.Round + 1,
+		Version:   child.Header.Round + 1,
 	}
 	ioRoot.Hash.Empty()
 

--- a/go/runtime/client/client.go
+++ b/go/runtime/client/client.go
@@ -231,7 +231,7 @@ func (c *runtimeClient) GetBlock(ctx context.Context, request *api.GetBlockReque
 func (c *runtimeClient) getTxnTree(blk *block.Block) *transaction.Tree {
 	ioRoot := storage.Root{
 		Namespace: blk.Header.Namespace,
-		Round:     blk.Header.Round,
+		Version:   blk.Header.Round,
 		Hash:      blk.Header.IORoot,
 	}
 
@@ -312,8 +312,8 @@ func (c *runtimeClient) GetTxs(ctx context.Context, request *api.GetTxsRequest) 
 	}
 
 	ioRoot := storage.Root{
-		Round: request.Round,
-		Hash:  request.IORoot,
+		Version: request.Round,
+		Hash:    request.IORoot,
 	}
 	copy(ioRoot.Namespace[:], request.RuntimeID[:])
 

--- a/go/runtime/client/watcher.go
+++ b/go/runtime/client/watcher.go
@@ -61,7 +61,7 @@ func (w *blockWatcher) checkBlock(blk *block.Block) {
 	ctx := w.common.ctx
 	ioRoot := storage.Root{
 		Namespace: blk.Header.Namespace,
-		Round:     blk.Header.Round,
+		Version:   blk.Header.Round,
 		Hash:      blk.Header.IORoot,
 	}
 

--- a/go/runtime/tagindexer/tagindexer.go
+++ b/go/runtime/tagindexer/tagindexer.go
@@ -81,7 +81,7 @@ func (s *Service) worker() {
 
 					ioRoot := storage.Root{
 						Namespace: blk.Header.Namespace,
-						Round:     blk.Header.Round,
+						Version:   blk.Header.Round,
 						Hash:      blk.Header.IORoot,
 					}
 

--- a/go/runtime/transaction/transaction.go
+++ b/go/runtime/transaction/transaction.go
@@ -414,5 +414,5 @@ func (t *Tree) GetTags(ctx context.Context) (Tags, error) {
 // Commit commits the updates to the underlying Merkle tree and returns the
 // write log and root hash.
 func (t *Tree) Commit(ctx context.Context) (writelog.WriteLog, hash.Hash, error) {
-	return t.tree.Commit(ctx, t.ioRoot.Namespace, t.ioRoot.Round)
+	return t.tree.Commit(ctx, t.ioRoot.Namespace, t.ioRoot.Version)
 }

--- a/go/runtime/transaction/transaction_test.go
+++ b/go/runtime/transaction/transaction_test.go
@@ -136,7 +136,7 @@ func TestTransaction(t *testing.T) {
 	// Apply write log to tree and check if everything is still there.
 	err = store.ApplyWriteLog(ctx, writelog.NewStaticIterator(writeLog))
 	require.NoError(t, err, "ApplyWriteLog")
-	_, storeRootHash, err := store.Commit(ctx, emptyRoot.Namespace, emptyRoot.Round)
+	_, storeRootHash, err := store.Commit(ctx, emptyRoot.Namespace, emptyRoot.Version)
 	require.NoError(t, err, "Commit")
 	require.EqualValues(t, rootHash, storeRootHash)
 

--- a/go/storage/api/api.go
+++ b/go/storage/api/api.go
@@ -52,19 +52,19 @@ var (
 	// ErrWriteLogNotFound indicates that a write log for the specified storage hashes
 	// couldn't be found.
 	ErrWriteLogNotFound = nodedb.ErrWriteLogNotFound
-	// ErrNotFinalized indicates that the operation requires a round to be finalized
-	// but the round is not yet finalized.
+	// ErrNotFinalized indicates that the operation requires a version to be finalized
+	// but the version is not yet finalized.
 	ErrNotFinalized = nodedb.ErrNotFinalized
-	// ErrAlreadyFinalized indicates that the given round has already been finalized.
+	// ErrAlreadyFinalized indicates that the given version has already been finalized.
 	ErrAlreadyFinalized = nodedb.ErrAlreadyFinalized
-	// ErrRoundNotFound indicates that the given round cannot be found.
-	ErrRoundNotFound = nodedb.ErrRoundNotFound
-	// ErrPreviousRoundMismatch indicates that the round given for the old root does
-	// not match the previous round.
-	ErrPreviousRoundMismatch = nodedb.ErrPreviousRoundMismatch
-	// ErrRoundWentBackwards indicates that the new round is earlier than an already
-	// inserted round.
-	ErrRoundWentBackwards = nodedb.ErrRoundWentBackwards
+	// ErrVersionNotFound indicates that the given version cannot be found.
+	ErrVersionNotFound = nodedb.ErrVersionNotFound
+	// ErrPreviousVersionMismatch indicates that the version given for the old root does
+	// not match the previous version.
+	ErrPreviousVersionMismatch = nodedb.ErrPreviousVersionMismatch
+	// ErrVersionWentBackwards indicates that the new version is earlier than an already
+	// inserted version.
+	ErrVersionWentBackwards = nodedb.ErrVersionWentBackwards
 	// ErrRootNotFound indicates that the given root cannot be found.
 	ErrRootNotFound = nodedb.ErrRootNotFound
 	// ErrRootMustFollowOld indicates that the passed new root does not follow old root.

--- a/go/storage/client/client.go
+++ b/go/storage/client/client.go
@@ -105,7 +105,7 @@ func (b *storageClientBackend) writeWithClient(
 					case status.Code(rerr) == codes.PermissionDenied:
 						// Writes can fail around an epoch transition due to policy errors.
 						return rerr
-					case errors.Is(rerr, api.ErrPreviousRoundMismatch):
+					case errors.Is(rerr, api.ErrPreviousVersionMismatch):
 						// Storage node may not have yet processed the epoch transition.
 						return rerr
 					case errors.Is(rerr, api.ErrRootNotFound):

--- a/go/storage/client/tests/tests.go
+++ b/go/storage/client/tests/tests.go
@@ -51,7 +51,7 @@ func ClientWorkerTests(
 
 	root := api.Root{
 		Namespace: ns,
-		Round:     0,
+		Version:   0,
 		Hash:      rootHash,
 	}
 

--- a/go/storage/mkvs/urkel/cache.go
+++ b/go/storage/mkvs/urkel/cache.go
@@ -419,7 +419,7 @@ func (c *cache) remoteSync(ctx context.Context, ptr *node.Pointer, fetcher readS
 	if c.persistEverythingFromSyncer {
 		// NOTE: This is a dummy batch, we assume that the node database backend is a
 		//       cache-only backend and does not care about correct values.
-		batch = c.db.NewBatch(c.syncRoot, c.syncRoot.Round, false)
+		batch = c.db.NewBatch(c.syncRoot, c.syncRoot.Version, false)
 		dbSubtree = batch.MaybeStartSubtree(nil, 0, subtree)
 	}
 

--- a/go/storage/mkvs/urkel/checkpoint/checkpoint_test.go
+++ b/go/storage/mkvs/urkel/checkpoint/checkpoint_test.go
@@ -47,7 +47,7 @@ func TestFileCheckpointCreator(t *testing.T) {
 	require.NoError(err, "Commit")
 	root := node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      rootHash,
 	}
 
@@ -135,7 +135,7 @@ func TestFileCheckpointCreator(t *testing.T) {
 		err = rs.RestoreChunk(ctx, cm, &buf)
 		require.NoError(err, "RestoreChunk")
 	}
-	err = ndb2.Finalize(ctx, root.Round, []hash.Hash{root.Hash})
+	err = ndb2.Finalize(ctx, root.Version, []hash.Hash{root.Hash})
 	require.NoError(err, "Finalize")
 
 	// Verify that everything has been restored.

--- a/go/storage/mkvs/urkel/checkpoint/chunk.go
+++ b/go/storage/mkvs/urkel/checkpoint/chunk.go
@@ -118,11 +118,11 @@ func restoreChunk(ctx context.Context, ndb db.NodeDB, chunk *ChunkMetadata, r io
 	// Import chunk into the node database.
 	emptyRoot := node.Root{
 		Namespace: chunk.Root.Namespace,
-		Round:     chunk.Root.Round,
+		Version:   chunk.Root.Version,
 	}
 	emptyRoot.Hash.Empty()
 
-	batch := ndb.NewBatch(emptyRoot, chunk.Root.Round, true)
+	batch := ndb.NewBatch(emptyRoot, chunk.Root.Version, true)
 	defer batch.Reset()
 
 	subtree := batch.MaybeStartSubtree(nil, 0, ptr)

--- a/go/storage/mkvs/urkel/checkpoint/file.go
+++ b/go/storage/mkvs/urkel/checkpoint/file.go
@@ -35,7 +35,7 @@ func (fc *fileCreator) CreateCheckpoint(ctx context.Context, root node.Root, chu
 	// Create checkpoint directory.
 	checkpointDir := filepath.Join(
 		fc.dataDir,
-		strconv.FormatUint(root.Round, 10),
+		strconv.FormatUint(root.Version, 10),
 		root.Hash.String(),
 	)
 	if err = common.Mkdir(checkpointDir); err != nil {
@@ -140,7 +140,7 @@ func (fc *fileCreator) GetCheckpoint(ctx context.Context, request *GetCheckpoint
 
 	checkpointFilename := filepath.Join(
 		fc.dataDir,
-		strconv.FormatUint(request.Root.Round, 10),
+		strconv.FormatUint(request.Root.Version, 10),
 		request.Root.Hash.String(),
 		checkpointMetadataFile,
 	)
@@ -164,7 +164,7 @@ func (fc *fileCreator) DeleteCheckpoint(ctx context.Context, request *DeleteChec
 
 	checkpointDir := filepath.Join(
 		fc.dataDir,
-		strconv.FormatUint(request.Root.Round, 10),
+		strconv.FormatUint(request.Root.Version, 10),
 		request.Root.Hash.String(),
 	)
 	if _, err := os.Stat(checkpointDir); err != nil {
@@ -182,7 +182,7 @@ func (fc *fileCreator) GetCheckpointChunk(ctx context.Context, chunk *ChunkMetad
 
 	chunkFilename := filepath.Join(
 		fc.dataDir,
-		strconv.FormatUint(chunk.Root.Round, 10),
+		strconv.FormatUint(chunk.Root.Version, 10),
 		chunk.Root.Hash.String(),
 		chunksDir,
 		strconv.FormatUint(chunk.Index, 10),

--- a/go/storage/mkvs/urkel/db/api/api.go
+++ b/go/storage/mkvs/urkel/db/api/api.go
@@ -21,19 +21,19 @@ var (
 	// ErrWriteLogNotFound indicates that a write log for the specified storage hashes
 	// couldn't be found.
 	ErrWriteLogNotFound = errors.New(ModuleName, 2, "urkel: write log not found in node db")
-	// ErrNotFinalized indicates that the operation requires a round to be finalized
-	// but the round is not yet finalized.
-	ErrNotFinalized = errors.New(ModuleName, 3, "urkel: round is not yet finalized")
-	// ErrAlreadyFinalized indicates that the given round has already been finalized.
-	ErrAlreadyFinalized = errors.New(ModuleName, 4, "urkel: round has already been finalized")
-	// ErrRoundNotFound indicates that the given round cannot be found.
-	ErrRoundNotFound = errors.New(ModuleName, 5, "urkel: round not found")
-	// ErrPreviousRoundMismatch indicates that the round given for the old root does
-	// not match the previous round.
-	ErrPreviousRoundMismatch = errors.New(ModuleName, 6, "urkel: previous round mismatch")
-	// ErrRoundWentBackwards indicates that the new round is earlier than an already
-	// inserted round.
-	ErrRoundWentBackwards = errors.New(ModuleName, 7, "urkel: round went backwards")
+	// ErrNotFinalized indicates that the operation requires a version to be finalized
+	// but the version is not yet finalized.
+	ErrNotFinalized = errors.New(ModuleName, 3, "urkel: version is not yet finalized")
+	// ErrAlreadyFinalized indicates that the given version has already been finalized.
+	ErrAlreadyFinalized = errors.New(ModuleName, 4, "urkel: version has already been finalized")
+	// ErrVersionNotFound indicates that the given version cannot be found.
+	ErrVersionNotFound = errors.New(ModuleName, 5, "urkel: version not found")
+	// ErrPreviousVersionMismatch indicates that the version given for the old root does
+	// not match the previous version.
+	ErrPreviousVersionMismatch = errors.New(ModuleName, 6, "urkel: previous version mismatch")
+	// ErrVersionWentBackwards indicates that the new version is earlier than an already
+	// inserted version.
+	ErrVersionWentBackwards = errors.New(ModuleName, 7, "urkel: version went backwards")
 	// ErrRootNotFound indicates that the given root cannot be found.
 	ErrRootNotFound = errors.New(ModuleName, 8, "urkel: root not found")
 	// ErrRootMustFollowOld indicates that the passed new root does not follow old root.
@@ -41,8 +41,8 @@ var (
 	// ErrBadNamespace indicates that the passed namespace does not match what is
 	// actually contained within the database.
 	ErrBadNamespace = errors.New(ModuleName, 10, "urkel: bad namespace")
-	// ErrNotEarliest indicates that the given round is not the earliest round.
-	ErrNotEarliest = errors.New(ModuleName, 11, "urkel: round is not the earliest round")
+	// ErrNotEarliest indicates that the given version is not the earliest version.
+	ErrNotEarliest = errors.New(ModuleName, 11, "urkel: version is not the earliest version")
 )
 
 // Config is the node database backend configuration.
@@ -71,35 +71,35 @@ type NodeDB interface {
 	// GetWriteLog retrieves a write log between two storage instances from the database.
 	GetWriteLog(ctx context.Context, startRoot node.Root, endRoot node.Root) (writelog.Iterator, error)
 
-	// GetLatestRound returns the most recent round in the node database.
-	GetLatestRound(ctx context.Context) (uint64, error)
+	// GetLatestVersion returns the most recent version in the node database.
+	GetLatestVersion(ctx context.Context) (uint64, error)
 
-	// GetEarliestRound returns the earliest round in the node database.
-	GetEarliestRound(ctx context.Context) (uint64, error)
+	// GetEarliestVersion returns the earliest version in the node database.
+	GetEarliestVersion(ctx context.Context) (uint64, error)
 
-	// GetRootsForRound returns a list of roots stored under the given round.
-	GetRootsForRound(ctx context.Context, round uint64) ([]hash.Hash, error)
+	// GetRootsForVersion returns a list of roots stored under the given version.
+	GetRootsForVersion(ctx context.Context, version uint64) ([]hash.Hash, error)
 
 	// NewBatch starts a new batch.
 	//
 	// The chunk argument specifies whether the given batch is being used to import a chunk of an
 	// existing root. Chunks may contain unresolved pointers (e.g., pointers that point to hashes
-	// which are not present in the database). Committing a chunk batch will prevent the round from
-	// being finalized.
-	NewBatch(oldRoot node.Root, round uint64, chunk bool) Batch
+	// which are not present in the database). Committing a chunk batch will prevent the version
+	// from being finalized.
+	NewBatch(oldRoot node.Root, version uint64, chunk bool) Batch
 
 	// HasRoot checks whether the given root exists.
 	HasRoot(root node.Root) bool
 
-	// Finalize finalizes the specified round. The passed list of roots are the
-	// roots within the round that have been finalized. All non-finalized roots
+	// Finalize finalizes the specified version. The passed list of roots are the
+	// roots within the version that have been finalized. All non-finalized roots
 	// can be discarded.
-	Finalize(ctx context.Context, round uint64, roots []hash.Hash) error
+	Finalize(ctx context.Context, version uint64, roots []hash.Hash) error
 
-	// Prune removes all roots recorded under the given round.
+	// Prune removes all roots recorded under the given version.
 	//
-	// Only the earliest round can be pruned, passing any other round will result in an error.
-	Prune(ctx context.Context, round uint64) error
+	// Only the earliest version can be pruned, passing any other version will result in an error.
+	Prune(ctx context.Context, version uint64) error
 
 	// Size returns the size of the database in bytes.
 	Size() (int64, error)
@@ -185,15 +185,15 @@ func (d *nopNodeDB) GetWriteLog(ctx context.Context, startRoot node.Root, endRoo
 	return nil, ErrWriteLogNotFound
 }
 
-func (d *nopNodeDB) GetLatestRound(ctx context.Context) (uint64, error) {
+func (d *nopNodeDB) GetLatestVersion(ctx context.Context) (uint64, error) {
 	return 0, nil
 }
 
-func (d *nopNodeDB) GetEarliestRound(ctx context.Context) (uint64, error) {
+func (d *nopNodeDB) GetEarliestVersion(ctx context.Context) (uint64, error) {
 	return 0, nil
 }
 
-func (d *nopNodeDB) GetRootsForRound(ctx context.Context, round uint64) ([]hash.Hash, error) {
+func (d *nopNodeDB) GetRootsForVersion(ctx context.Context, version uint64) ([]hash.Hash, error) {
 	return nil, nil
 }
 
@@ -201,11 +201,11 @@ func (d *nopNodeDB) HasRoot(root node.Root) bool {
 	return false
 }
 
-func (d *nopNodeDB) Finalize(ctx context.Context, round uint64, roots []hash.Hash) error {
+func (d *nopNodeDB) Finalize(ctx context.Context, version uint64, roots []hash.Hash) error {
 	return nil
 }
 
-func (d *nopNodeDB) Prune(ctx context.Context, round uint64) error {
+func (d *nopNodeDB) Prune(ctx context.Context, version uint64) error {
 	return nil
 }
 
@@ -221,7 +221,7 @@ type nopBatch struct {
 	BaseBatch
 }
 
-func (d *nopNodeDB) NewBatch(oldRoot node.Root, round uint64, chunk bool) Batch {
+func (d *nopNodeDB) NewBatch(oldRoot node.Root, version uint64, chunk bool) Batch {
 	return &nopBatch{}
 }
 

--- a/go/storage/mkvs/urkel/db/badger/helpers.go
+++ b/go/storage/mkvs/urkel/db/badger/helpers.go
@@ -4,8 +4,8 @@ package badger
 // invalid/removed cruft while still keeping everything else even if pruning is not enabled.
 const tsMetadata = 1
 
-// roundToTs convers a MKVS round to a badger timestamp.
-func roundToTs(round uint64) uint64 {
-	// Round 0 starts at timestamp after metadata.
-	return tsMetadata + 1 + round
+// versionToTs convers a MKVS version to a badger timestamp.
+func versionToTs(version uint64) uint64 {
+	// Version 0 starts at timestamp after metadata.
+	return tsMetadata + 1 + version
 }

--- a/go/storage/mkvs/urkel/iterator_test.go
+++ b/go/storage/mkvs/urkel/iterator_test.go
@@ -64,7 +64,7 @@ func TestIterator(t *testing.T) {
 	})
 
 	var root node.Root
-	_, rootHash, err := tree.Commit(ctx, root.Namespace, root.Round)
+	_, rootHash, err := tree.Commit(ctx, root.Namespace, root.Version)
 	require.NoError(t, err, "Commit")
 	root.Hash = rootHash
 
@@ -199,7 +199,7 @@ func TestIteratorEviction(t *testing.T) {
 	}
 
 	var root node.Root
-	_, rootHash, err := tree.Commit(ctx, root.Namespace, root.Round)
+	_, rootHash, err := tree.Commit(ctx, root.Namespace, root.Version)
 	require.NoError(t, err, "Commit")
 	root.Hash = rootHash
 

--- a/go/storage/mkvs/urkel/node/node_test.go
+++ b/go/storage/mkvs/urkel/node/node_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestSerializationLeafNode(t *testing.T) {
 	leafNode := &LeafNode{
-		Round: 0xDEADBEEF,
-		Key:   []byte("a golden key"),
-		Value: []byte("value"),
+		Version: 0xDEADBEEF,
+		Key:     []byte("a golden key"),
+		Value:   []byte("value"),
 	}
 
 	rawLeafNodeFull, err := leafNode.MarshalBinary()
@@ -26,7 +26,7 @@ func TestSerializationLeafNode(t *testing.T) {
 		require.NoError(t, err, "UnmarshalBinary")
 
 		require.True(t, decodedLeafNode.Clean)
-		require.Equal(t, leafNode.Round, decodedLeafNode.Round)
+		require.Equal(t, leafNode.Version, decodedLeafNode.Version)
 		require.Equal(t, leafNode.Key, decodedLeafNode.Key)
 		require.Equal(t, leafNode.Value, decodedLeafNode.Value)
 	}
@@ -47,7 +47,7 @@ func TestSerializationInternalNode(t *testing.T) {
 	var labelBitLength = Depth(24)
 
 	intNode := &InternalNode{
-		Round:          0xDEADBEEF,
+		Version:        0xDEADBEEF,
 		Label:          label,
 		LabelBitLength: labelBitLength,
 		LeafNode:       &Pointer{Clean: true, Node: leafNode, Hash: leafNode.Hash},
@@ -66,7 +66,7 @@ func TestSerializationInternalNode(t *testing.T) {
 		require.NoError(t, err, "UnmarshalBinary")
 
 		require.True(t, decodedIntNode.Clean)
-		require.Equal(t, intNode.Round, decodedIntNode.Round)
+		require.Equal(t, intNode.Version, decodedIntNode.Version)
 		require.Equal(t, intNode.Label, decodedIntNode.Label)
 		require.Equal(t, intNode.LabelBitLength, decodedIntNode.LabelBitLength)
 		require.Equal(t, intNode.LeafNode.Hash, decodedIntNode.LeafNode.Hash)
@@ -87,9 +87,9 @@ func TestSerializationInternalNode(t *testing.T) {
 
 func TestHashLeafNode(t *testing.T) {
 	leafNode := &LeafNode{
-		Round: 0xDEADBEEF,
-		Key:   []byte("a golden key"),
-		Value: []byte("value"),
+		Version: 0xDEADBEEF,
+		Key:     []byte("a golden key"),
+		Value:   []byte("value"),
 	}
 
 	leafNode.UpdateHash()
@@ -106,7 +106,7 @@ func TestHashInternalNode(t *testing.T) {
 	rightHash.FromBytes([]byte("everyone move to the right"))
 
 	intNode := &InternalNode{
-		Round:          0xDEADBEEF,
+		Version:        0xDEADBEEF,
 		Label:          Key("abc"),
 		LabelBitLength: 23,
 		LeafNode:       &Pointer{Clean: true, Hash: leafNodeHash},
@@ -121,10 +121,10 @@ func TestHashInternalNode(t *testing.T) {
 
 func TestExtractLeafNode(t *testing.T) {
 	leafNode := &LeafNode{
-		Clean: true,
-		Round: 0xDEADBEEF,
-		Key:   []byte("a golden key"),
-		Value: []byte("value"),
+		Clean:   true,
+		Version: 0xDEADBEEF,
+		Key:     []byte("a golden key"),
+		Value:   []byte("value"),
 	}
 
 	exLeafNode := leafNode.Extract().(*LeafNode)
@@ -132,7 +132,7 @@ func TestExtractLeafNode(t *testing.T) {
 	require.False(t, leafNode == exLeafNode, "extracted node must have a different address")
 	require.False(t, &leafNode.Value == &exLeafNode.Value, "extracted value must have a different address")
 	require.Equal(t, true, exLeafNode.Clean, "extracted leaf must be clean")
-	require.Equal(t, leafNode.Round, exLeafNode.Round, "extracted leaf must have the same round")
+	require.Equal(t, leafNode.Version, exLeafNode.Version, "extracted leaf must have the same version")
 	require.EqualValues(t, leafNode.Key, exLeafNode.Key, "extracted leaf must have the same key")
 	require.EqualValues(t, leafNode.Value, exLeafNode.Value, "extracted leaf's value must have the same value")
 }
@@ -144,10 +144,10 @@ func TestExtractInternalNode(t *testing.T) {
 	rightHash.FromBytes([]byte("everyone move to the right"))
 
 	intNode := &InternalNode{
-		Clean: true,
-		Round: 0xDEADBEEF,
-		Left:  &Pointer{Clean: true, Hash: leftHash},
-		Right: &Pointer{Clean: true, Hash: rightHash},
+		Clean:   true,
+		Version: 0xDEADBEEF,
+		Left:    &Pointer{Clean: true, Hash: leftHash},
+		Right:   &Pointer{Clean: true, Hash: rightHash},
 	}
 
 	exIntNode := intNode.Extract().(*InternalNode)
@@ -156,7 +156,7 @@ func TestExtractInternalNode(t *testing.T) {
 	require.False(t, intNode.Left == exIntNode.Left, "extracted left pointer must have a different address")
 	require.False(t, intNode.Right == exIntNode.Right, "extracted right pointer must have a different address")
 	require.Equal(t, true, exIntNode.Clean, "extracted internal node must be clean")
-	require.Equal(t, intNode.Round, exIntNode.Round, "extracted internal node must have the same round")
+	require.Equal(t, intNode.Version, exIntNode.Version, "extracted internal node must have the same version")
 	require.Equal(t, leftHash, exIntNode.Left.Hash, "extracted left pointer must have the same hash")
 	require.Equal(t, true, exIntNode.Left.Clean, "extracted left pointer must be clean")
 	require.Equal(t, rightHash, exIntNode.Right.Hash, "extracted right pointer must have the same hash")

--- a/go/storage/mkvs/urkel/tree.go
+++ b/go/storage/mkvs/urkel/tree.go
@@ -87,7 +87,7 @@ type Tree interface {
 
 	// Commit commits tree updates to the underlying database and returns
 	// the write log and new merkle root.
-	Commit(ctx context.Context, namespace common.Namespace, round uint64) (writelog.WriteLog, hash.Hash, error)
+	Commit(ctx context.Context, namespace common.Namespace, version uint64) (writelog.WriteLog, hash.Hash, error)
 
 	// DumpLocal dumps the tree in the local memory into the given writer.
 	DumpLocal(ctx context.Context, w io.Writer, maxDepth node.Depth)

--- a/go/storage/mkvs/urkel/urkel_test.go
+++ b/go/storage/mkvs/urkel/urkel_test.go
@@ -207,7 +207,7 @@ func testBasic(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	// Create a new tree backed by the same database.
 	tree = NewWithRoot(nil, ndb, node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      root,
 	})
 
@@ -232,7 +232,7 @@ func testBasic(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 
 	_, err = tree.CommitKnown(ctx, node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      root,
 	})
 	require.NoError(t, err, "CommitKnown")
@@ -241,7 +241,7 @@ func testBasic(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	bogusRoot.FromBytes([]byte("bogus root"))
 	_, err = tree.CommitKnown(ctx, node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      bogusRoot,
 	})
 	require.Error(t, err, "CommitKnown")
@@ -637,7 +637,7 @@ func testSyncerRootEmptyLabelNeedsDeref(t *testing.T, ndb db.NodeDB, factory Nod
 
 	root := node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      rootHash,
 	}
 
@@ -698,7 +698,7 @@ func testSyncerRemove(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 
 	root := node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      roots[len(roots)-1],
 	}
 	stats := syncer.NewStatsCollector(tree)
@@ -733,7 +733,7 @@ func testSyncerInsert(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 
 	root := node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      rootHash,
 	}
 	stats := syncer.NewStatsCollector(tree)
@@ -779,7 +779,7 @@ func testSyncerNilNodes(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	}
 	remote := NewWithRoot(wire, nil, node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      root,
 	})
 
@@ -940,11 +940,11 @@ func testOnCommitHooks(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	emptyRoot.Empty()
 	root := node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      emptyRoot,
 	}
 
-	batch := ndb.NewBatch(root, root.Round, false)
+	batch := ndb.NewBatch(root, root.Version, false)
 	defer batch.Reset()
 
 	var calls []int
@@ -970,47 +970,47 @@ func testHasRoot(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	// Test that an empty root is always implicitly present.
 	root := node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 	}
 	root.Hash.Empty()
 	require.True(t, ndb.HasRoot(root), "HasRoot should return true on empty root")
 
-	// Create a root in round 0.
+	// Create a root in version 0.
 	ctx := context.Background()
 	tree := New(nil, ndb)
 	err := tree.Insert(ctx, []byte("foo"), []byte("bar"))
 	require.NoError(t, err, "Insert")
 	_, rootHash1, err := tree.Commit(ctx, testNs, 0)
 	require.NoError(t, err, "Commit")
-	// Finalize round 0.
+	// Finalize version 0.
 	err = ndb.Finalize(ctx, 0, []hash.Hash{rootHash1})
 	require.NoError(t, err, "Finalize")
 
 	// Make sure that HasRoot returns true.
 	root = node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      rootHash1,
 	}
 	require.True(t, ndb.HasRoot(root), "HasRoot should return true for existing root")
 	root.Hash.FromBytes([]byte("invalid root"))
 	require.False(t, ndb.HasRoot(root), "HasRoot should return false for non-existing root")
 
-	// Create a different root in round 1.
+	// Create a different root in version 1.
 	tree = New(nil, ndb)
 	err = tree.Insert(ctx, []byte("goo"), []byte("bar"))
 	require.NoError(t, err, "Insert")
 	_, rootHash2, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
-	// Finalize round 1.
+	// Finalize version 1.
 	err = ndb.Finalize(ctx, 1, []hash.Hash{rootHash2})
 	require.NoError(t, err, "Finalize")
 
-	// Make sure that HasRoot for root hash from round 0 but with
-	// round 1 passed returns false.
+	// Make sure that HasRoot for root hash from version 0 but with
+	// version 1 passed returns false.
 	root = node.Root{
 		Namespace: testNs,
-		Round:     1,
+		Version:   1,
 		Hash:      rootHash1,
 	}
 	require.False(t, ndb.HasRoot(root), "HasRoot should return false for non-existing root")
@@ -1028,7 +1028,7 @@ func testMergeWriteLog(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 
 	emptyRoot := node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 	}
 	emptyRoot.Hash.Empty()
 
@@ -1041,7 +1041,7 @@ func testMergeWriteLog(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 
 	root1 := node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      rootHash1,
 	}
 
@@ -1059,7 +1059,7 @@ func testMergeWriteLog(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 
 	root2 := node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      rootHash2,
 	}
 
@@ -1090,7 +1090,7 @@ func testMergeWriteLog(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 
 	root3 := node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      rootHash3,
 	}
 
@@ -1105,57 +1105,57 @@ func testPruneBasic(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	ctx := context.Background()
 	tree := New(nil, ndb)
 
-	// Create some keys in round 0.
+	// Create some keys in version 0.
 	err := tree.Insert(ctx, []byte("foo"), []byte("bar"))
 	require.NoError(t, err, "Insert")
 	err = tree.Insert(ctx, []byte("moo"), []byte("bar"))
 	require.NoError(t, err, "Insert")
 	_, rootHash1, err := tree.Commit(ctx, testNs, 0)
 	require.NoError(t, err, "Commit")
-	// Test that we cannot prune non-finalized rounds.
+	// Test that we cannot prune non-finalized versions.
 	err = ndb.Prune(ctx, 0)
-	require.Error(t, err, "Prune should fail for non-finalized rounds")
+	require.Error(t, err, "Prune should fail for non-finalized versions")
 	require.Equal(t, db.ErrNotFinalized, err)
-	// Finalize round 0.
+	// Finalize version 0.
 	err = ndb.Finalize(ctx, 0, []hash.Hash{rootHash1})
 	require.NoError(t, err, "Finalize")
 
-	// Remove key in round 1.
+	// Remove key in version 1.
 	err = tree.Remove(ctx, []byte("foo"))
 	require.NoError(t, err, "Remove")
 	err = tree.Insert(ctx, []byte("another"), []byte("value"))
 	require.NoError(t, err, "Insert")
 	_, rootHash2, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
-	// Test that we cannot prune non-finalized rounds.
+	// Test that we cannot prune non-finalized versions.
 	err = ndb.Prune(ctx, 1)
-	require.Error(t, err, "Prune should fail for non-finalized rounds")
+	require.Error(t, err, "Prune should fail for non-finalized versions")
 	require.Equal(t, db.ErrNotFinalized, err)
-	// Finalize round 1.
+	// Finalize version 1.
 	err = ndb.Finalize(ctx, 1, []hash.Hash{rootHash2})
 	require.NoError(t, err, "Finalize")
 
-	// Add some keys in round 2.
+	// Add some keys in version 2.
 	err = tree.Insert(ctx, []byte("blah"), []byte("ugh"))
 	require.NoError(t, err, "Insert")
 	_, rootHash3, err := tree.Commit(ctx, testNs, 2)
 	require.NoError(t, err, "Commit")
-	// Test that we cannot prune non-finalized rounds.
+	// Test that we cannot prune non-finalized versions.
 	err = ndb.Prune(ctx, 2)
-	require.Error(t, err, "Prune should fail for non-finalized rounds")
+	require.Error(t, err, "Prune should fail for non-finalized versions")
 	require.Equal(t, db.ErrNotFinalized, err)
-	// Finalize round 2.
+	// Finalize version 2.
 	err = ndb.Finalize(ctx, 2, []hash.Hash{rootHash3})
 	require.NoError(t, err, "Finalize")
 
-	earliestRound, err := ndb.GetEarliestRound(ctx)
-	require.NoError(t, err, "GetEarliestRound")
-	require.EqualValues(t, 0, earliestRound, "earliest round should be correct")
-	latestRound, err := ndb.GetLatestRound(ctx)
-	require.NoError(t, err, "GetLatestRound")
-	require.EqualValues(t, 2, latestRound, "latest round should be correct")
+	earliestVersion, err := ndb.GetEarliestVersion(ctx)
+	require.NoError(t, err, "GetEarliestVersion")
+	require.EqualValues(t, 0, earliestVersion, "earliest version should be correct")
+	latestVersion, err := ndb.GetLatestVersion(ctx)
+	require.NoError(t, err, "GetLatestVersion")
+	require.EqualValues(t, 2, latestVersion, "latest version should be correct")
 
-	// Prune round 0.
+	// Prune version 0.
 	err = ndb.Prune(ctx, 0)
 	require.NoError(t, err, "Prune")
 
@@ -1164,15 +1164,15 @@ func testPruneBasic(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	ndb = factory()
 	defer ndb.Close()
 
-	earliestRound, err = ndb.GetEarliestRound(ctx)
-	require.NoError(t, err, "GetEarliestRound")
-	require.EqualValues(t, 1, earliestRound, "earliest round should be correct")
-	latestRound, err = ndb.GetLatestRound(ctx)
-	require.NoError(t, err, "GetLatestRound")
-	require.EqualValues(t, 2, latestRound, "latest round should be correct")
+	earliestVersion, err = ndb.GetEarliestVersion(ctx)
+	require.NoError(t, err, "GetEarliestVersion")
+	require.EqualValues(t, 1, earliestVersion, "earliest version should be correct")
+	latestVersion, err = ndb.GetLatestVersion(ctx)
+	require.NoError(t, err, "GetLatestVersion")
+	require.EqualValues(t, 2, latestVersion, "latest version should be correct")
 
-	// Keys must still be available in round 2.
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 2, Hash: rootHash3})
+	// Keys must still be available in version 2.
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 2, Hash: rootHash3})
 	value, err := tree.Get(ctx, []byte("blah"))
 	require.NoError(t, err, "Get")
 	require.EqualValues(t, []byte("ugh"), value)
@@ -1187,21 +1187,21 @@ func testPruneBasic(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	require.NoError(t, err, "Get")
 	require.Nil(t, value, "removed key must be gone")
 
-	// Round 0 must be gone.
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 0, Hash: rootHash1})
+	// Version 0 must be gone.
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 0, Hash: rootHash1})
 	_, err = tree.Get(ctx, []byte("foo"))
 	require.Error(t, err, "Get")
 }
 
-func testPruneManyRounds(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
+func testPruneManyVersions(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	ctx := context.Background()
 	tree := New(nil, ndb)
 
-	const numRounds = 50
-	const numPairsPerRound = 50
+	const numVersions = 50
+	const numPairsPerVersion = 50
 
-	for r := 0; r < numRounds; r++ {
-		for p := 0; p < numPairsPerRound; p++ {
+	for r := 0; r < numVersions; r++ {
+		for p := 0; p < numPairsPerVersion; p++ {
 			key := []byte(fmt.Sprintf("key %d/%d", r, p))
 			value := []byte(fmt.Sprintf("value %d/%d", r, p))
 			err := tree.Insert(ctx, key, value)
@@ -1214,8 +1214,8 @@ func testPruneManyRounds(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 		require.NoError(t, err, "Finalize")
 	}
 
-	// Prune all rounds except the last one.
-	for r := 0; r < numRounds-1; r++ {
+	// Prune all versions except the last one.
+	for r := 0; r < numVersions-1; r++ {
 		err := ndb.Prune(ctx, uint64(r))
 		require.NoError(t, err, "Prune")
 	}
@@ -1226,8 +1226,8 @@ func testPruneManyRounds(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	defer ndb.Close()
 
 	// Check that the latest version has all the keys.
-	for r := 0; r < numRounds; r++ {
-		for p := 0; p < numPairsPerRound; p++ {
+	for r := 0; r < numVersions; r++ {
+		for p := 0; p < numPairsPerVersion; p++ {
 			key := []byte(fmt.Sprintf("key %d/%d", r, p))
 			value, err := tree.Get(ctx, key)
 			require.NoError(t, err, "Get")
@@ -1237,10 +1237,10 @@ func testPruneManyRounds(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 }
 
 // countCreatedNodes counts the number of nodes that have been created in the same
-// round as the root is in and have not been previously seen.
+// version as the root is in and have not been previously seen.
 func countCreatedNodes(t *testing.T, ndb db.NodeDB, root node.Root, seenNodes map[hash.Hash]bool) (nodes int) {
 	err := db.Visit(context.Background(), ndb, root, func(ctx context.Context, n node.Node) bool {
-		if n.GetCreatedRound() == root.Round && !seenNodes[n.GetHash()] {
+		if n.GetCreatedVersion() == root.Version && !seenNodes[n.GetHash()] {
 			seenNodes[n.GetHash()] = true
 			nodes++
 		}
@@ -1253,7 +1253,7 @@ func countCreatedNodes(t *testing.T, ndb db.NodeDB, root node.Root, seenNodes ma
 func testPruneForkedRoots(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	ctx := context.Background()
 
-	// Create a root in round 0.
+	// Create a root in version 0.
 	tree := New(nil, ndb)
 	err := tree.Insert(ctx, []byte("foo"), []byte("bar"))
 	require.NoError(t, err, "Insert")
@@ -1261,12 +1261,12 @@ func testPruneForkedRoots(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	require.NoError(t, err, "Insert")
 	_, rootHashR0_1, err := tree.Commit(ctx, testNs, 0)
 	require.NoError(t, err, "Commit")
-	// Finalize round 0.
+	// Finalize version 0.
 	err = ndb.Finalize(ctx, 0, []hash.Hash{rootHashR0_1})
 	require.NoError(t, err, "Finalize")
 
-	// Create a derived root A in round 1.
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 0, Hash: rootHashR0_1})
+	// Create a derived root A in version 1.
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 0, Hash: rootHashR0_1})
 	err = tree.Insert(ctx, []byte("dr"), []byte("A"))
 	require.NoError(t, err, "Insert")
 	err = tree.Remove(ctx, []byte("moo"))
@@ -1274,44 +1274,44 @@ func testPruneForkedRoots(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	_, rootHashR1_1, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
 
-	// Create a derived root B in round 1.
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 0, Hash: rootHashR0_1})
+	// Create a derived root B in version 1.
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 0, Hash: rootHashR0_1})
 	err = tree.Insert(ctx, []byte("dr"), []byte("B"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR1_2, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
 
-	// Finalize round 1. Only derived root B was finalized, so derived root A
+	// Finalize version 1. Only derived root B was finalized, so derived root A
 	// should be discarded.
 	err = ndb.Finalize(ctx, 1, []hash.Hash{rootHashR1_2})
 	require.NoError(t, err, "Finalize")
 
 	// Make sure that the write log for the discarded root is gone.
-	rootR0_1 := node.Root{Namespace: testNs, Round: 0, Hash: rootHashR0_1}
-	rootR1_1 := node.Root{Namespace: testNs, Round: 1, Hash: rootHashR1_1}
-	rootR1_2 := node.Root{Namespace: testNs, Round: 1, Hash: rootHashR1_2}
+	rootR0_1 := node.Root{Namespace: testNs, Version: 0, Hash: rootHashR0_1}
+	rootR1_1 := node.Root{Namespace: testNs, Version: 1, Hash: rootHashR1_1}
+	rootR1_2 := node.Root{Namespace: testNs, Version: 1, Hash: rootHashR1_2}
 	_, err = ndb.GetWriteLog(ctx, rootR0_1, rootR1_1)
 	require.Error(t, err, "GetWriteLog")
 	// Make sure that the write log for the non-discarded root exists.
 	_, err = ndb.GetWriteLog(ctx, rootR0_1, rootR1_2)
 	require.NoError(t, err, "GetWriteLog")
 
-	// Create a derived root C from derived root B in round 2.
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 1, Hash: rootHashR1_2})
+	// Create a derived root C from derived root B in version 2.
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 1, Hash: rootHashR1_2})
 	err = tree.Insert(ctx, []byte("yet"), []byte("another"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR2_1, err := tree.Commit(ctx, testNs, 2)
 	require.NoError(t, err, "Commit")
-	// Finalize round 2.
+	// Finalize version 2.
 	err = ndb.Finalize(ctx, 2, []hash.Hash{rootHashR2_1})
 	require.NoError(t, err, "Finalize")
 
-	// Prune round 1 (should fail as it is not the earliest round).
+	// Prune version 1 (should fail as it is not the earliest version).
 	err = ndb.Prune(ctx, 1)
 	require.Error(t, err, "Prune")
 	require.Equal(t, db.ErrNotEarliest, err)
 
-	// Prune rounds 0 and 1.
+	// Prune versions 0 and 1.
 	err = ndb.Prune(ctx, 0)
 	require.NoError(t, err, "Prune")
 	err = ndb.Prune(ctx, 1)
@@ -1324,18 +1324,18 @@ func testPruneForkedRoots(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 
 	// Make sure all the keys are there.
 	for _, root := range []struct {
-		Round uint64
-		Hash  hash.Hash
-		Keys  []string
+		Version uint64
+		Hash    hash.Hash
+		Keys    []string
 	}{
 		{2, rootHashR2_1, []string{"foo", "moo", "dr", "yet"}},
 	} {
-		tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: root.Round, Hash: root.Hash})
+		tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: root.Version, Hash: root.Hash})
 
 		for _, key := range root.Keys {
 			value, err := tree.Get(ctx, []byte(key))
-			require.NoError(t, err, "Get(%d, %s)", root.Round, key)
-			require.NotNil(t, value, "value should exist (%d, %s)", root.Round, key)
+			require.NoError(t, err, "Get(%d, %s)", root.Version, key)
+			require.NotNil(t, value, "value should exist (%d, %s)", root.Version, key)
 		}
 	}
 }
@@ -1373,7 +1373,7 @@ func testPruneLoneRootsShared(t *testing.T, ndb db.NodeDB, factory NodeDBFactory
 	require.NoError(t, err, "Finalize")
 
 	// Check that the shared nodes are still there.
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 0, Hash: rootHash1})
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 0, Hash: rootHash1})
 	value, err := tree.Get(ctx, []byte("foo"))
 	require.NoError(t, err, "Get")
 	require.EqualValues(t, []byte("bar"), value)
@@ -1394,7 +1394,7 @@ func testPruneLoneRootsShared2(t *testing.T, ndb db.NodeDB, factory NodeDBFactor
 	}
 	batches := []struct {
 		Namespace common.Namespace
-		Round     uint64
+		Version   uint64
 		SrcRoot   string
 		DstRoot   string
 		Finalized bool
@@ -1402,7 +1402,7 @@ func testPruneLoneRootsShared2(t *testing.T, ndb db.NodeDB, factory NodeDBFactor
 	}{
 		{
 			Namespace: testNs,
-			Round:     4,
+			Version:   4,
 			SrcRoot:   "xnK40e9W7Sirh8NiLFEUBpvdOte4+XN0mNDAHs7wlno=",
 			DstRoot:   "lBnLyljpBdIweInarStbMkAGn8qq2sftGfJJWsvHCTk=",
 			Items: []item{
@@ -1419,7 +1419,7 @@ func testPruneLoneRootsShared2(t *testing.T, ndb db.NodeDB, factory NodeDBFactor
 		},
 		{
 			Namespace: testNs,
-			Round:     4,
+			Version:   4,
 			SrcRoot:   "lBnLyljpBdIweInarStbMkAGn8qq2sftGfJJWsvHCTk=",
 			DstRoot:   "XeNxDPHiY0PAQI5vFxFNxjwgAj++Sf0kCohpaUvImUg=",
 			Finalized: true,
@@ -1441,7 +1441,7 @@ func testPruneLoneRootsShared2(t *testing.T, ndb db.NodeDB, factory NodeDBFactor
 		},
 		{
 			Namespace: testNs,
-			Round:     4,
+			Version:   4,
 			SrcRoot:   "lBnLyljpBdIweInarStbMkAGn8qq2sftGfJJWsvHCTk=",
 			DstRoot:   "rgbZz2sV2QlI/XG/+GiQoYlDpmxrMbY/hFs6PhTu1hA=",
 			Items: []item{
@@ -1476,7 +1476,7 @@ func testPruneLoneRootsShared2(t *testing.T, ndb db.NodeDB, factory NodeDBFactor
 
 		tree := NewWithRoot(nil, ndb, node.Root{
 			Namespace: batch.Namespace,
-			Round:     batch.Round,
+			Version:   batch.Version,
 			Hash:      srcRootHash,
 		})
 		defer tree.Close()
@@ -1491,7 +1491,7 @@ func testPruneLoneRootsShared2(t *testing.T, ndb db.NodeDB, factory NodeDBFactor
 			require.NoError(t, err, "Insert")
 		}
 
-		_, rootHash, err := tree.Commit(ctx, batch.Namespace, batch.Round)
+		_, rootHash, err := tree.Commit(ctx, batch.Namespace, batch.Version)
 		require.NoError(t, err, "Commit")
 
 		dstRootHashRaw, err := base64.StdEncoding.DecodeString(batch.DstRoot)
@@ -1506,12 +1506,12 @@ func testPruneLoneRootsShared2(t *testing.T, ndb db.NodeDB, factory NodeDBFactor
 		}
 	}
 
-	err := ndb.Finalize(ctx, batches[0].Round, finalizedRoots)
+	err := ndb.Finalize(ctx, batches[0].Version, finalizedRoots)
 	require.NoError(t, err, "Finalize")
 
 	tree := NewWithRoot(nil, ndb, node.Root{
 		Namespace: batches[0].Namespace,
-		Round:     batches[0].Round,
+		Version:   batches[0].Version,
 		Hash:      finalizedRoots[0],
 	})
 	defer tree.Close()
@@ -1529,7 +1529,7 @@ func testPruneLoneRootsShared2(t *testing.T, ndb db.NodeDB, factory NodeDBFactor
 func testPruneLoneRoots(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	ctx := context.Background()
 
-	// Create a root in round 0.
+	// Create a root in version 0.
 	tree := New(nil, ndb)
 	err := tree.Insert(ctx, []byte("foo"), []byte("bar"))
 	require.NoError(t, err, "Insert")
@@ -1538,105 +1538,105 @@ func testPruneLoneRoots(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	_, rootHashR0_1, err := tree.Commit(ctx, testNs, 0)
 	require.NoError(t, err, "Commit")
 
-	// Create another root in round 0.
+	// Create another root in version 0.
 	tree = New(nil, ndb)
 	err = tree.Insert(ctx, []byte("goo"), []byte("blah"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR0_2, err := tree.Commit(ctx, testNs, 0)
 	require.NoError(t, err, "Commit")
 
-	// Create yet another root in round 0.
+	// Create yet another root in version 0.
 	tree = New(nil, ndb)
 	err = tree.Insert(ctx, []byte("yet"), []byte("another"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR0_3, err := tree.Commit(ctx, testNs, 0)
 	require.NoError(t, err, "Commit")
 
-	// Create yet another root in round 0.
+	// Create yet another root in version 0.
 	tree = New(nil, ndb)
 	err = tree.Insert(ctx, []byte("yet2"), []byte("another2"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR0_4, err := tree.Commit(ctx, testNs, 0)
 	require.NoError(t, err, "Commit")
 
-	// Finalize round 0.
+	// Finalize version 0.
 	err = ndb.Finalize(ctx, 0, []hash.Hash{rootHashR0_1, rootHashR0_2, rootHashR0_3, rootHashR0_4})
 	require.NoError(t, err, "Finalize")
 
-	// Create a distinct root in round 1.
+	// Create a distinct root in version 1.
 	seenNodes := make(map[hash.Hash]bool)
 	tree = New(nil, ndb)
 	err = tree.Insert(ctx, []byte("different"), []byte("boo"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR1_1, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
-	nodesR1_1 := countCreatedNodes(t, ndb, node.Root{Namespace: testNs, Round: 1, Hash: rootHashR1_1}, seenNodes)
+	nodesR1_1 := countCreatedNodes(t, ndb, node.Root{Namespace: testNs, Version: 1, Hash: rootHashR1_1}, seenNodes)
 	require.EqualValues(t, 1, nodesR1_1)
 
-	// Create a derived root in round 1.
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 0, Hash: rootHashR0_2})
+	// Create a derived root in version 1.
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 0, Hash: rootHashR0_2})
 	err = tree.Insert(ctx, []byte("different2"), []byte("boo"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR1_2, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
 
-	// Create two linked roots inside round 1 which will not be referenced
-	// in subsequent rounds and so should be garbage collected.
+	// Create two linked roots inside version 1 which will not be referenced
+	// in subsequent versions and so should be garbage collected.
 	tree = New(nil, ndb)
 	err = tree.Insert(ctx, []byte("first"), []byte("am i"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR1_3, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
-	nodesR1_3 := countCreatedNodes(t, ndb, node.Root{Namespace: testNs, Round: 1, Hash: rootHashR1_3}, seenNodes)
+	nodesR1_3 := countCreatedNodes(t, ndb, node.Root{Namespace: testNs, Version: 1, Hash: rootHashR1_3}, seenNodes)
 	require.EqualValues(t, 1, nodesR1_3)
 
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 1, Hash: rootHashR1_3})
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 1, Hash: rootHashR1_3})
 	err = tree.Insert(ctx, []byte("second"), []byte("i am"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR1_4, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
-	nodesR1_4 := countCreatedNodes(t, ndb, node.Root{Namespace: testNs, Round: 1, Hash: rootHashR1_4}, seenNodes)
+	nodesR1_4 := countCreatedNodes(t, ndb, node.Root{Namespace: testNs, Version: 1, Hash: rootHashR1_4}, seenNodes)
 	require.EqualValues(t, 2, nodesR1_4)
 
-	// Create three linked roots inside round 1 where the first root is
-	// derived from a root in round 0, the second root is derived from
+	// Create three linked roots inside version 1 where the first root is
+	// derived from a root in version 0, the second root is derived from
 	// the first root and the third root is derived from the second root
-	// (both in the same round). All three should be garbage collected
-	// as they are not referenced in subsequent rounds.
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 0, Hash: rootHashR0_3})
+	// (both in the same version). All three should be garbage collected
+	// as they are not referenced in subsequent versions.
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 0, Hash: rootHashR0_3})
 	err = tree.Insert(ctx, []byte("first"), []byte("am i"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR1_5, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 1, Hash: rootHashR1_5})
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 1, Hash: rootHashR1_5})
 	err = tree.Insert(ctx, []byte("second"), []byte("i am"))
 	require.NoError(t, err, "Insert")
 	err = tree.Remove(ctx, []byte("yet"))
 	require.NoError(t, err, "Remove")
 	_, rootHashR1_6, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 1, Hash: rootHashR1_6})
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 1, Hash: rootHashR1_6})
 	err = tree.Insert(ctx, []byte("third"), []byte("i am not"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR1_7, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
 
-	// Create three linked roots inside round 1 where the first root is
-	// derived from a root in round 0, the second root is derived from
+	// Create three linked roots inside version 1 where the first root is
+	// derived from a root in version 0, the second root is derived from
 	// the first root and the third root is derived from the second root
-	// (both in the same round). The third root is then referenced in round
+	// (both in the same version). The third root is then referenced in version
 	// 2 so only intermediate nodes should be garbage collected.
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 0, Hash: rootHashR0_4})
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 0, Hash: rootHashR0_4})
 	err = tree.Insert(ctx, []byte("first2"), []byte("am i"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR1_8, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 1, Hash: rootHashR1_8})
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 1, Hash: rootHashR1_8})
 	err = tree.Insert(ctx, []byte("second2"), []byte("i am"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR1_9, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 1, Hash: rootHashR1_9})
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 1, Hash: rootHashR1_9})
 	err = tree.Insert(ctx, []byte("third2"), []byte("i am not"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR1_10, err := tree.Commit(ctx, testNs, 1)
@@ -1644,36 +1644,36 @@ func testPruneLoneRoots(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	// After these commits, 3 nodes are only referenced in intermediate roots
 	// and should be garbage collected.
 
-	// Finalize round 1.
+	// Finalize version 1.
 	err = ndb.Finalize(ctx, 1, []hash.Hash{rootHashR1_1, rootHashR1_2, rootHashR1_4, rootHashR1_7, rootHashR1_10})
 	require.NoError(t, err, "Finalize")
 
-	// Create a distinct root in round 2.
+	// Create a distinct root in version 2.
 	tree = New(nil, ndb)
 	err = tree.Insert(ctx, []byte("blah"), []byte("brah"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR2_1, err := tree.Commit(ctx, testNs, 2)
 	require.NoError(t, err, "Commit")
 
-	// Create a derived root in round 2.
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 1, Hash: rootHashR1_2})
+	// Create a derived root in version 2.
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 1, Hash: rootHashR1_2})
 	err = tree.Insert(ctx, []byte("foo"), []byte("boo"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR2_2, err := tree.Commit(ctx, testNs, 2)
 	require.NoError(t, err, "Commit")
 
-	// Create another derived root in round 2.
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 1, Hash: rootHashR1_10})
+	// Create another derived root in version 2.
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 1, Hash: rootHashR1_10})
 	err = tree.Insert(ctx, []byte("foo2"), []byte("boo"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR2_3, err := tree.Commit(ctx, testNs, 2)
 	require.NoError(t, err, "Commit")
 
-	// Finalize round 2.
+	// Finalize version 2.
 	err = ndb.Finalize(ctx, 2, []hash.Hash{rootHashR2_1, rootHashR2_2, rootHashR2_3})
 	require.NoError(t, err, "Finalize")
 
-	// Prune rounds 0 and 1, all of the lone root's node should have been removed.
+	// Prune versions 0 and 1, all of the lone root's node should have been removed.
 	err = ndb.Prune(ctx, 0)
 	require.NoError(t, err, "Prune")
 	err = ndb.Prune(ctx, 1)
@@ -1684,22 +1684,22 @@ func testPruneLoneRoots(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	ndb = factory()
 	defer ndb.Close()
 
-	// Check that roots in round 0 and 2 are still there.
+	// Check that roots in version 0 and 2 are still there.
 	for _, root := range []struct {
-		Round uint64
-		Hash  hash.Hash
-		Keys  []string
+		Version uint64
+		Hash    hash.Hash
+		Keys    []string
 	}{
 		{2, rootHashR2_1, []string{"blah"}},
 		{2, rootHashR2_2, []string{"goo", "different2", "foo"}},
 		{2, rootHashR2_3, []string{"yet2", "first2", "second2", "third2", "foo2"}},
 	} {
-		tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: root.Round, Hash: root.Hash})
+		tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: root.Version, Hash: root.Hash})
 
 		for _, key := range root.Keys {
 			value, err := tree.Get(ctx, []byte(key))
-			require.NoError(t, err, "Get(%d, %s)", root.Round, key)
-			require.NotNil(t, value, "value should exist (%d, %s)", root.Round, key)
+			require.NoError(t, err, "Get(%d, %s)", root.Version, key)
+			require.NotNil(t, value, "value should exist (%d, %s)", root.Version, key)
 		}
 	}
 }
@@ -1707,69 +1707,69 @@ func testPruneLoneRoots(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 func testErrors(t *testing.T, ndb db.NodeDB, factory NodeDBFactory) {
 	ctx := context.Background()
 
-	// Commit root for round 0.
+	// Commit root for version 0.
 	tree := New(nil, ndb)
 	err := tree.Insert(ctx, []byte("foo"), []byte("bar"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR0_1, err := tree.Commit(ctx, testNs, 0)
 	require.NoError(t, err, "Commit")
 
-	// Commit root for round 1.
+	// Commit root for version 1.
 	tree = New(nil, ndb)
 	err = tree.Insert(ctx, []byte("another"), []byte("bar"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR1_1, err := tree.Commit(ctx, testNs, 1)
 	require.NoError(t, err, "Commit")
 
-	// Commit root for round 2.
+	// Commit root for version 2.
 	tree = New(nil, ndb)
 	err = tree.Insert(ctx, []byte("another2"), []byte("bar"))
 	require.NoError(t, err, "Insert")
 	_, rootHashR2_1, err := tree.Commit(ctx, testNs, 2)
 	require.NoError(t, err, "Commit")
 
-	// Commit for non-following round should fail.
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 2, Hash: rootHashR2_1})
+	// Commit for non-following version should fail.
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 2, Hash: rootHashR2_1})
 	err = tree.Insert(ctx, []byte("moo"), []byte("moo"))
 	require.NoError(t, err, "Insert")
 	_, _, err = tree.Commit(ctx, testNs, 100)
-	require.Error(t, err, "Commit should fail for non-following round")
+	require.Error(t, err, "Commit should fail for non-following version")
 	require.Equal(t, db.ErrRootMustFollowOld, err)
 
 	// Commit with mismatched old root should fail.
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 99, Hash: rootHashR1_1})
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 99, Hash: rootHashR1_1})
 	err = tree.Insert(ctx, []byte("moo"), []byte("moo"))
 	require.NoError(t, err, "Insert")
 	_, _, err = tree.Commit(ctx, testNs, 100)
-	require.Error(t, err, "Commit should fail for mismatched round")
+	require.Error(t, err, "Commit should fail for mismatched version")
 	require.Equal(t, db.ErrRootNotFound, err)
 
 	// Commit with non-existent old root should fail.
 	var bogusRoot hash.Hash
 	bogusRoot.FromBytes([]byte("bogus root"))
-	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Round: 0, Hash: bogusRoot})
+	tree = NewWithRoot(nil, ndb, node.Root{Namespace: testNs, Version: 0, Hash: bogusRoot})
 	_, _, err = tree.Commit(ctx, testNs, 1)
 	require.Error(t, err, "Commit should fail for invalid root")
 	require.Equal(t, db.ErrRootNotFound, err)
 
-	// Finalizing a round twice should fail.
+	// Finalizing a version twice should fail.
 	err = ndb.Finalize(ctx, 0, []hash.Hash{rootHashR0_1})
 	require.NoError(t, err, "Finalize")
 	err = ndb.Finalize(ctx, 0, []hash.Hash{rootHashR0_1})
-	require.Error(t, err, "Finalize should fail as round is already finalized")
+	require.Error(t, err, "Finalize should fail as version is already finalized")
 	require.Equal(t, db.ErrAlreadyFinalized, err)
 
-	// Finalize of round 2 should fail as round 1 is not finalized.
+	// Finalize of version 2 should fail as version 1 is not finalized.
 	err = ndb.Finalize(ctx, 2, []hash.Hash{rootHashR2_1})
-	require.Error(t, err, "Finalize should fail as previous round not finalized")
+	require.Error(t, err, "Finalize should fail as previous version not finalized")
 	require.Equal(t, db.ErrNotFinalized, err)
 
-	// Commit into an already finalized round should fail.
+	// Commit into an already finalized version should fail.
 	tree = New(nil, ndb)
 	err = tree.Insert(ctx, []byte("already finalized"), []byte("woohoo"))
 	require.NoError(t, err, "Insert")
 	_, _, err = tree.Commit(ctx, testNs, 0)
-	require.Error(t, err, "Commit should fail for already finalized round")
+	require.Error(t, err, "Commit should fail for already finalized version")
 	require.Equal(t, db.ErrAlreadyFinalized, err)
 
 	// Commit for a different namespace should fail.
@@ -1919,7 +1919,7 @@ func testBackend(
 		{"MergeWriteLog", testMergeWriteLog},
 		{"HasRoot", testHasRoot},
 		{"PruneBasic", testPruneBasic},
-		{"PruneManyRounds", testPruneManyRounds},
+		{"PruneManyVersions", testPruneManyVersions},
 		{"PruneLoneRoots", testPruneLoneRoots},
 		{"PruneLoneRootsShared", testPruneLoneRootsShared},
 		{"PruneLoneRootsShared2", testPruneLoneRootsShared2},
@@ -2079,7 +2079,7 @@ func generatePopulatedTree(t *testing.T, ndb db.NodeDB) ([][]byte, [][]byte, nod
 
 	root := node.Root{
 		Namespace: testNs,
-		Round:     0,
+		Version:   0,
 		Hash:      rootHash,
 	}
 	return keys, values, root, tree

--- a/go/storage/tests/tester.go
+++ b/go/storage/tests/tester.go
@@ -162,7 +162,7 @@ func testBasic(t *testing.T, localBackend api.LocalBackend, backend api.Backend,
 
 	newRoot := api.Root{
 		Namespace: namespace,
-		Round:     round,
+		Version:   round,
 		Hash:      receiptBody.Roots[0],
 	}
 
@@ -203,7 +203,7 @@ func testBasic(t *testing.T, localBackend api.LocalBackend, backend api.Backend,
 	// Get the write log, it should be the same as what we stuffed in.
 	root := api.Root{
 		Namespace: namespace,
-		Round:     round,
+		Version:   round,
 		Hash:      rootHash,
 	}
 	it, err := backend.GetDiff(ctx, &api.GetDiffRequest{StartRoot: root, EndRoot: newRoot})
@@ -300,7 +300,7 @@ func testMerge(t *testing.T, backend api.Backend, namespace common.Namespace, ro
 		}
 
 		// Generate expected root hash.
-		tree := urkel.NewWithRoot(backend, nil, api.Root{Namespace: namespace, Round: dstRound, Hash: baseRoot})
+		tree := urkel.NewWithRoot(backend, nil, api.Root{Namespace: namespace, Version: dstRound, Hash: baseRoot})
 		defer tree.Close()
 		err := tree.ApplyWriteLog(ctx, writelog.NewStaticIterator(writeLog))
 		require.NoError(t, err, "ApplyWriteLog")
@@ -356,7 +356,7 @@ func testMerge(t *testing.T, backend api.Backend, namespace common.Namespace, ro
 
 	// Make sure that the merged root is the same as applying all write logs against
 	// the base root.
-	tree := urkel.NewWithRoot(backend, nil, api.Root{Namespace: namespace, Round: round, Hash: roots[0]})
+	tree := urkel.NewWithRoot(backend, nil, api.Root{Namespace: namespace, Version: round, Hash: roots[0]})
 	defer tree.Close()
 	for _, writeLog := range writeLogs[1:] {
 		err = tree.ApplyWriteLog(ctx, writelog.NewStaticIterator(writeLog))

--- a/go/worker/common/host/mock.go
+++ b/go/worker/common/host/mock.go
@@ -63,7 +63,7 @@ func (h *mockHost) MakeRequest(ctx context.Context, body *protocol.Body) (<-chan
 
 			emptyRoot := urkelNode.Root{
 				Namespace: rq.Block.Header.Namespace,
-				Round:     rq.Block.Header.Round + 1,
+				Version:   rq.Block.Header.Round + 1,
 			}
 			emptyRoot.Hash.Empty()
 

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -272,7 +272,7 @@ func (n *Node) queueBatchBlocking(
 	// Fetch inputs from storage.
 	ioRoot := storage.Root{
 		Namespace: hdr.Namespace,
-		Round:     hdr.Round + 1,
+		Version:   hdr.Round + 1,
 		Hash:      ioRootHash,
 	}
 	txs := transaction.NewTree(n.commonNode.Storage, ioRoot)

--- a/go/worker/compute/txnscheduler/committee/node.go
+++ b/go/worker/compute/txnscheduler/committee/node.go
@@ -380,7 +380,7 @@ func (n *Node) Dispatch(committeeID hash.Hash, batch transaction.RawBatch) error
 	// tags will be added later by the executor nodes).
 	emptyRoot := storage.Root{
 		Namespace: lastHeader.Namespace,
-		Round:     lastHeader.Round + 1,
+		Version:   lastHeader.Round + 1,
 	}
 	emptyRoot.Hash.Empty()
 

--- a/go/worker/compute/txnscheduler/tests/tester.go
+++ b/go/worker/compute/txnscheduler/tests/tester.go
@@ -118,7 +118,7 @@ blockLoop:
 			ctx := context.Background()
 			tree := transaction.NewTree(st, storage.Root{
 				Namespace: blk.Header.Namespace,
-				Round:     blk.Header.Round,
+				Version:   blk.Header.Round,
 				Hash:      blk.Header.IORoot,
 			})
 			defer tree.Close()

--- a/go/worker/storage/committee/checkpointer.go
+++ b/go/worker/storage/committee/checkpointer.go
@@ -87,12 +87,12 @@ func (c *checkpointer) maybeCheckpoint(ctx context.Context, rt *registry.Runtime
 	var cpRounds []uint64
 	cpsByRound := make(map[uint64][]storage.Root)
 	for _, cp := range cps {
-		if cpsByRound[cp.Root.Round] == nil {
-			cpRounds = append(cpRounds, cp.Root.Round)
+		if cpsByRound[cp.Root.Version] == nil {
+			cpRounds = append(cpRounds, cp.Root.Version)
 		}
-		cpsByRound[cp.Root.Round] = append(cpsByRound[cp.Root.Round], cp.Root)
-		if len(cpsByRound[cp.Root.Round]) == 2 && cp.Root.Round > lastCheckpointRound {
-			lastCheckpointRound = cp.Root.Round
+		cpsByRound[cp.Root.Version] = append(cpsByRound[cp.Root.Version], cp.Root)
+		if len(cpsByRound[cp.Root.Version]) == 2 && cp.Root.Version > lastCheckpointRound {
+			lastCheckpointRound = cp.Root.Version
 		}
 	}
 	sort.Slice(cpRounds, func(i, j int) bool { return cpRounds[i] < cpRounds[j] })

--- a/go/worker/storage/committee/node.go
+++ b/go/worker/storage/committee/node.go
@@ -127,12 +127,12 @@ func summaryFromBlock(blk *block.Block) *blockSummary {
 		Round:     blk.Header.Round,
 		IORoot: urkelNode.Root{
 			Namespace: blk.Header.Namespace,
-			Round:     blk.Header.Round,
+			Version:   blk.Header.Round,
 			Hash:      blk.Header.IORoot,
 		},
 		StateRoot: urkelNode.Root{
 			Namespace: blk.Header.Namespace,
-			Round:     blk.Header.Round,
+			Version:   blk.Header.Round,
 			Hash:      blk.Header.StateRoot,
 		},
 	}
@@ -543,9 +543,9 @@ mainLoop:
 			if lastDiff.fetched {
 				_, err = n.localStorage.Apply(n.ctx, &storageApi.ApplyRequest{
 					Namespace: lastDiff.thisRoot.Namespace,
-					SrcRound:  lastDiff.prevRoot.Round,
+					SrcRound:  lastDiff.prevRoot.Version,
 					SrcRoot:   lastDiff.prevRoot.Hash,
-					DstRound:  lastDiff.thisRoot.Round,
+					DstRound:  lastDiff.thisRoot.Version,
 					DstRoot:   lastDiff.thisRoot.Hash,
 					WriteLog:  lastDiff.writeLog,
 				})
@@ -607,9 +607,9 @@ mainLoop:
 					Round:     lastFullyAppliedRound + 1,
 				}
 				dummy.IORoot.Empty()
-				dummy.IORoot.Round = lastFullyAppliedRound + 1
+				dummy.IORoot.Version = lastFullyAppliedRound + 1
 				dummy.StateRoot.Empty()
-				dummy.StateRoot.Round = lastFullyAppliedRound + 1
+				dummy.StateRoot.Version = lastFullyAppliedRound + 1
 				hashCache[lastFullyAppliedRound] = &dummy
 			}
 			// Determine if we need to fetch any old block summaries. In case the first
@@ -663,7 +663,7 @@ mainLoop:
 				this := hashCache[i]
 				prevIORoot := urkelNode.Root{ // IO roots aren't chained, so clear it (but leave cache intact).
 					Namespace: this.IORoot.Namespace,
-					Round:     this.IORoot.Round,
+					Version:   this.IORoot.Version,
 				}
 				prevIORoot.Hash.Empty()
 

--- a/runtime/src/common/version.rs
+++ b/runtime/src/common/version.rs
@@ -66,6 +66,6 @@ impl From<u64> for Version {
 // the worker host.
 pub const PROTOCOL_VERSION: Version = Version {
     major: 0,
-    minor: 12,
+    minor: 13,
     patch: 0,
 };

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -283,7 +283,7 @@ impl Dispatcher {
             protocol,
             Root {
                 namespace: block.header.namespace,
-                round: block.header.round,
+                version: block.header.round,
                 hash: block.header.state_root,
             },
         );
@@ -316,7 +316,7 @@ impl Dispatcher {
                 )
                 .expect("state commit must succeed");
             txn_dispatcher.finalize(new_state_root);
-            cache.root.round = block.header.round + 1;
+            cache.root.version = block.header.round + 1;
             cache.root.hash = new_state_root;
 
             // Generate I/O root. Since we already fetched the inputs we avoid the need
@@ -326,7 +326,7 @@ impl Dispatcher {
                 Box::new(NoopReadSyncer {}),
                 Root {
                     namespace: block.header.namespace,
-                    round: block.header.round + 1,
+                    version: block.header.round + 1,
                     hash: Hash::empty_hash(),
                 },
             );

--- a/runtime/src/storage/mkvs/mod.rs
+++ b/runtime/src/storage/mkvs/mod.rs
@@ -132,7 +132,7 @@ pub trait MKVS: Send + Sync {
         &mut self,
         ctx: Context,
         namespace: Namespace,
-        round: u64,
+        version: u64,
     ) -> Fallible<(WriteLog, Hash)>;
 
     /// Rollback any pending changes.

--- a/runtime/src/storage/mkvs/urkel/interop/mod.rs
+++ b/runtime/src/storage/mkvs/urkel/interop/mod.rs
@@ -10,7 +10,7 @@ mod rpc;
 /// Urkel interoperability driver.
 pub trait Driver {
     /// Apply the given write log to the protocol server.
-    fn apply(&self, write_log: &WriteLog, hash: Hash, namespace: Namespace, round: u64);
+    fn apply(&self, write_log: &WriteLog, hash: Hash, namespace: Namespace, version: u64);
 
     /// Apply the given write log against an existing root on the protocol server.
     fn apply_existing(
@@ -19,7 +19,7 @@ pub trait Driver {
         existing_root: Hash,
         root_hash: Hash,
         namespace: Namespace,
-        round: u64,
+        version: u64,
     );
 }
 

--- a/runtime/src/storage/mkvs/urkel/interop/protocol_server.rs
+++ b/runtime/src/storage/mkvs/urkel/interop/protocol_server.rs
@@ -85,8 +85,8 @@ impl Drop for ProtocolServer {
 }
 
 impl Driver for ProtocolServer {
-    fn apply(&self, write_log: &WriteLog, root_hash: Hash, namespace: Namespace, round: u64) {
-        self.apply_existing(write_log, Hash::empty_hash(), root_hash, namespace, round)
+    fn apply(&self, write_log: &WriteLog, root_hash: Hash, namespace: Namespace, version: u64) {
+        self.apply_existing(write_log, Hash::empty_hash(), root_hash, namespace, version)
     }
 
     fn apply_existing(
@@ -95,14 +95,14 @@ impl Driver for ProtocolServer {
         existing_root: Hash,
         root_hash: Hash,
         namespace: Namespace,
-        round: u64,
+        version: u64,
     ) {
         self.client
             .apply(&rpc::ApplyRequest {
                 namespace,
-                src_round: round,
+                src_round: version,
                 src_root: existing_root,
-                dst_round: round,
+                dst_round: version,
                 dst_root: root_hash,
                 writelog: write_log.clone(),
             })

--- a/runtime/src/storage/mkvs/urkel/tree/mkvs.rs
+++ b/runtime/src/storage/mkvs/urkel/tree/mkvs.rs
@@ -39,11 +39,11 @@ impl MKVS for UrkelTree {
         &mut self,
         ctx: Context,
         namespace: Namespace,
-        round: u64,
+        version: u64,
     ) -> Fallible<(WriteLog, Hash)> {
         let lock = self.lock.clone();
         let _guard = lock.lock().unwrap();
-        UrkelTree::commit(self, ctx, namespace, round)
+        UrkelTree::commit(self, ctx, namespace, version)
     }
 
     fn rollback(&mut self) {

--- a/runtime/src/storage/mkvs/urkel/tree/node_test.rs
+++ b/runtime/src/storage/mkvs/urkel/tree/node_test.rs
@@ -98,7 +98,7 @@ fn test_serialization_internal() {
 #[test]
 fn test_hash_leaf() {
     let mut leaf_node = LeafNode {
-        round: 0xDEADBEEF,
+        version: 0xDEADBEEF,
         key: b"a golden key".to_vec(),
         value: b"value".to_vec(),
         ..Default::default()
@@ -118,7 +118,7 @@ fn test_hash_internal() {
     let right_hash = Hash::digest_bytes(b"everyone move to the right");
 
     let mut int_node = InternalNode {
-        round: 0xDEADBEEF,
+        version: 0xDEADBEEF,
         label: b"abc".to_vec(),
         label_bit_length: 23,
         leaf_node: Rc::new(RefCell::new(NodePointer {

--- a/runtime/src/transaction/tree.rs
+++ b/runtime/src/transaction/tree.rs
@@ -226,7 +226,7 @@ impl Tree {
     /// log and root hash.
     pub fn commit(&mut self, ctx: Context) -> Fallible<(WriteLog, Hash)> {
         self.tree
-            .commit(ctx, self.io_root.namespace, self.io_root.round)
+            .commit(ctx, self.io_root.namespace, self.io_root.version)
     }
 }
 


### PR DESCRIPTION
Previously the MKVS used the term "round" to mean a monotonically increasing
version number. This choice was due to the fact that it was initially used to
only store runtime state which has a concept of rounds.

As we expand its use it makes more sense to generalize this and call it version.