### PR TITLE
Changes from fuzzing that we could keep

### DIFF
--- a/.changelog/2789.trivial.md
+++ b/.changelog/2789.trivial.md
@@ -1,0 +1,1 @@
+Changes from fuzzing that we could keep

--- a/go/common/crypto/signature/signature.go
+++ b/go/common/crypto/signature/signature.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/oasislabs/ed25519"
+
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/pem"
 	"github.com/oasislabs/oasis-core/go/common/prettyprint"

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -424,7 +424,12 @@ func (mux *abciMux) InitChain(req types.RequestInitChain) types.ResponseInitChai
 	}()
 
 	// TODO: remove stateKeyGenesisRequest here, see oasis-core#2426
-	b, _ = req.Marshal()
+	b, err = req.Marshal()
+	if err != nil {
+		// It's suspected this wouldn't happen normally, because ABCI is meant to go out
+		// through protobuf anyway, so the request ought to be representable.
+		panic(fmt.Sprintf("InitChain: marshalling RequestInitChain back to protobuf: %v", err))
+	}
 	mux.state.deliverTxTree.Set([]byte(stateKeyGenesisRequest), b)
 	mux.state.checkTxTree.Set([]byte(stateKeyGenesisRequest), b)
 

--- a/go/consensus/tendermint/apps/keymanager/genesis.go
+++ b/go/consensus/tendermint/apps/keymanager/genesis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/tendermint/tendermint/abci/types"
 
@@ -46,7 +47,10 @@ func (app *keymanagerApplication) InitChain(ctx *abci.Context, request types.Req
 
 	var toEmit []*keymanager.Status
 	state := keymanagerState.NewMutableState(ctx.State())
-	for _, v := range st.Statuses {
+	for i, v := range st.Statuses {
+		if v == nil {
+			return fmt.Errorf("InitChain: Status index %d is nil", i)
+		}
 		rt := rtMap[v.ID]
 		if rt == nil {
 			ctx.Logger().Error("InitChain: State for unknown key manager runtime",

--- a/go/consensus/tendermint/apps/registry/genesis.go
+++ b/go/consensus/tendermint/apps/registry/genesis.go
@@ -47,7 +47,10 @@ func (app *registryApplication) InitChain(ctx *abci.Context, request types.Reque
 	}
 	// Register runtimes. First key manager and then compute runtime(s).
 	for _, k := range []registry.RuntimeKind{registry.KindKeyManager, registry.KindCompute} {
-		for _, v := range st.Runtimes {
+		for i, v := range st.Runtimes {
+			if v == nil {
+				return fmt.Errorf("registry: genesis runtime index %d is nil", i)
+			}
 			rt, err := registry.VerifyRegisterRuntimeArgs(&st.Parameters, ctx.Logger(), v, ctx.IsInitChain())
 			if err != nil {
 				return err
@@ -67,7 +70,10 @@ func (app *registryApplication) InitChain(ctx *abci.Context, request types.Reque
 			}
 		}
 	}
-	for _, v := range st.SuspendedRuntimes {
+	for i, v := range st.SuspendedRuntimes {
+		if v == nil {
+			return fmt.Errorf("registry: genesis suspended runtime index %d is nil", i)
+		}
 		ctx.Logger().Debug("InitChain: Registering genesis suspended runtime",
 			"runtime_owner", v.Signature.PublicKey,
 		)
@@ -86,7 +92,10 @@ func (app *registryApplication) InitChain(ctx *abci.Context, request types.Reque
 			return errors.Wrap(err, "registry: failed to suspend runtime at genesis")
 		}
 	}
-	for _, v := range st.Nodes {
+	for i, v := range st.Nodes {
+		if v == nil {
+			return fmt.Errorf("registry: genesis node index %d is nil", i)
+		}
 		// The node signer isn't guaranteed to be the owner, and in most cases
 		// will just be the node self signing.
 		ctx.Logger().Debug("InitChain: Registering genesis node",
@@ -107,6 +116,9 @@ func (app *registryApplication) InitChain(ctx *abci.Context, request types.Reque
 	}
 	var ns []*nodeStatus
 	for k, v := range st.NodeStatuses {
+		if v == nil {
+			return fmt.Errorf("registry: genesis node status %s is nil", k)
+		}
 		ns = append(ns, &nodeStatus{k, v})
 	}
 	// Make sure that we apply node status updates in a canonical order.

--- a/go/consensus/tendermint/apps/registry/genesis.go
+++ b/go/consensus/tendermint/apps/registry/genesis.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -29,7 +30,10 @@ func (app *registryApplication) InitChain(ctx *abci.Context, request types.Reque
 	state := registryState.NewMutableState(ctx.State())
 	state.SetConsensusParameters(&st.Parameters)
 
-	for _, v := range st.Entities {
+	for i, v := range st.Entities {
+		if v == nil {
+			return fmt.Errorf("registry: genesis entity index %d is nil", i)
+		}
 		ctx.Logger().Debug("InitChain: Registering genesis entity",
 			"entity", v.Signature.PublicKey,
 		)

--- a/go/consensus/tendermint/apps/roothash/roothash.go
+++ b/go/consensus/tendermint/apps/roothash/roothash.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tendermint/tendermint/abci/types"
 
-	beacon "github.com/oasislabs/oasis-core/go/beacon/api"
 	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
@@ -44,8 +43,6 @@ type timerContext struct {
 
 type rootHashApplication struct {
 	state abci.ApplicationState
-
-	beacon beacon.Backend
 }
 
 func (app *rootHashApplication) Name() string {
@@ -723,8 +720,6 @@ func (app *rootHashApplication) tryFinalizeBlock(
 }
 
 // New constructs a new roothash application instance.
-func New(beacon beacon.Backend) abci.Application {
-	return &rootHashApplication{
-		beacon: beacon,
-	}
+func New() abci.Application {
+	return &rootHashApplication{}
 }

--- a/go/consensus/tendermint/apps/staking/genesis.go
+++ b/go/consensus/tendermint/apps/staking/genesis.go
@@ -159,6 +159,9 @@ func (app *stakingApplication) initDelegations(ctx *abci.Context, state *staking
 	for escrowID, delegations := range st.Delegations {
 		delegationShares := quantity.NewQuantity()
 		for delegatorID, delegation := range delegations {
+			if delegation == nil {
+				return fmt.Errorf("staking: genesis delegation to %s from %s is nil", escrowID, delegatorID)
+			}
 			if err := delegationShares.Add(&delegation.Shares); err != nil {
 				ctx.Logger().Error("InitChain: failed to add delegation shares",
 					"err", err,
@@ -203,6 +206,9 @@ func (app *stakingApplication) initDebondingDelegations(ctx *abci.Context, state
 		debondingShares := quantity.NewQuantity()
 		for delegatorID, delegations := range delegators {
 			for idx, delegation := range delegations {
+				if delegation == nil {
+					return fmt.Errorf("staking: genesis debonding delegation to %s from %s index %d is nil", escrowID, delegatorID, idx)
+				}
 				if err := debondingShares.Add(&delegation.Shares); err != nil {
 					ctx.Logger().Error("InitChain: failed to add debonding delegation shares",
 						"err", err,

--- a/go/consensus/tendermint/apps/staking/genesis.go
+++ b/go/consensus/tendermint/apps/staking/genesis.go
@@ -74,6 +74,9 @@ func (app *stakingApplication) initLedger(ctx *abci.Context, state *stakingState
 	var ups []ledgerUpdate
 	for k, v := range st.Ledger {
 		id := k
+		if v == nil {
+			return fmt.Errorf("staking/tendermint: genesis ledger account %s is nil", k)
+		}
 
 		if !v.General.Balance.IsValid() {
 			ctx.Logger().Error("InitChain: invalid genesis general balance",

--- a/go/consensus/tendermint/roothash/roothash.go
+++ b/go/consensus/tendermint/roothash/roothash.go
@@ -13,7 +13,6 @@ import (
 	tmrpctypes "github.com/tendermint/tendermint/rpc/core/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 
-	beacon "github.com/oasislabs/oasis-core/go/beacon/api"
 	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/crash"
@@ -453,11 +452,10 @@ func (tb *tendermintBackend) worker(ctx context.Context) { // nolint: gocyclo
 func New(
 	ctx context.Context,
 	dataDir string,
-	beac beacon.Backend,
 	service service.TendermintService,
 ) (api.Backend, error) {
 	// Initialize and register the tendermint service component.
-	a := app.New(beac)
+	a := app.New()
 	if err := service.RegisterApplication(a); err != nil {
 		return nil, err
 	}

--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -784,7 +784,7 @@ func (t *tendermintService) initialize() error {
 	}
 	t.svcMgr.RegisterCleanupOnly(t.scheduler, "scheduler backend")
 
-	if t.roothash, err = tmroothash.New(t.ctx, t.dataDir, t.beacon, t); err != nil {
+	if t.roothash, err = tmroothash.New(t.ctx, t.dataDir, t); err != nil {
 		t.Logger.Error("roothash: failed to initialize roothash backend",
 			"err", err,
 		)


### PR DESCRIPTION
- nil pointer dereferences in processing genesis document
- unused beacon reference
- imports spacing convention
- new cert and private key import/export without going out to file