### PR TITLE
Fix runtime instructions in readme

### DIFF
--- a/.changelog/2793.trivial.md
+++ b/.changelog/2793.trivial.md
@@ -1,0 +1,1 @@
+Fix runtime instructions in readme

--- a/README.md
+++ b/README.md
@@ -300,8 +300,8 @@ client as follows (substituting the socket path from your log output) in a
 different terminal:
 
 ```
-./target/debug/simple-keyvalue-client \
-  --runtime-id 0000000000000000000000000000000000000000000000000000000000000000 \
+./target/default/debug/simple-keyvalue-client \
+  --runtime-id 8000000000000000000000000000000000000000000000000000000000000000 \
   --node-address unix:/tmp/oasis-net-runner530668299/net-runner/network/client-0/internal.sock
 ```
 


### PR DESCRIPTION
Runtime allocation scheme changed in https://github.com/oasislabs/oasis-core/commit/b2ef06d38ad3b82b63d0792301c5fa0cf4228949