### PR TITLE
go staking: three-way fee split

### DIFF
--- a/.changelog/2794.breaking.md
+++ b/.changelog/2794.breaking.md
@@ -1,0 +1,16 @@
+go/staking: Three-way fee split
+
+We should give more to the previous block proposer, which is the block
+that first ran the transactions that paid the fees in the
+`LastBlockFees`.
+Currently they only get paid as a voter.
+
+See
+[oasis-core#2794](https://github.com/oasislabs/oasis-core/pull/2794)
+for a description of the new fee split.
+
+Instructions for genesis document maintainers:
+
+1. Rename `fee_split_vote` to `fee_split_weight_vote` and
+   `fee_split_propose` to `fee_split_weight_next_propose` and
+   add `fee_split_weight_propose` in `.staking.params`.

--- a/go/consensus/tendermint/apps/staking/fees.go
+++ b/go/consensus/tendermint/apps/staking/fees.go
@@ -9,7 +9,7 @@ import (
 	stakingState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/staking/state"
 )
 
-// disburseFeesP disburses fees to the proposer and persists the voters' and next proposer's shares.
+// disburseFeesP disburses fees to the proposer and persists the voters' and next proposer's shares of the fees.
 //
 // In case of errors the state may be inconsistent.
 func (app *stakingApplication) disburseFeesP(ctx *abci.Context, stakeState *stakingState.MutableState, proposerEntity *signature.PublicKey, totalFees *quantity.Quantity) error {

--- a/go/consensus/tendermint/apps/staking/fees.go
+++ b/go/consensus/tendermint/apps/staking/fees.go
@@ -43,7 +43,7 @@ func (app *stakingApplication) disburseFeesP(ctx *abci.Context, stakeState *stak
 		return fmt.Errorf("divide feePersistAmt: %w", err)
 	}
 
-	// Persist voters' and next proposer's shares.
+	// Persist voters' and next proposer's shares of the fees.
 	feePersist := quantity.NewQuantity()
 	if err = quantity.Move(feePersist, totalFees, feePersistAmt); err != nil {
 		return fmt.Errorf("move feePersist: %w", err)
@@ -100,8 +100,8 @@ func (app *stakingApplication) disburseFeesVQ(ctx *abci.Context, stakeState *sta
 		return fmt.Errorf("ConsensusParameters: %w", err)
 	}
 
-	// Compute the portion associated with each eligible validator's share, and within that, how much goes to the voter
-	// and how much goes to the next proposer.
+	// Compute the portion associated with each eligible validator's share of the fees, and within that, how much goes
+	// to the voter and how much goes to the next proposer.
 	perValidator := lastBlockFees.Clone()
 	var nEVQ quantity.Quantity
 	if err = nEVQ.FromInt64(int64(numEligibleValidators)); err != nil {

--- a/go/consensus/tendermint/apps/staking/fees.go
+++ b/go/consensus/tendermint/apps/staking/fees.go
@@ -27,19 +27,19 @@ func (app *stakingApplication) disburseFeesP(ctx *abci.Context, stakeState *stak
 	}
 
 	// Compute how much to persist for voters and the next proposer.
-	numPersist := consensusParameters.FeeSplitWeightVote.Clone()
-	if err = numPersist.Add(&consensusParameters.FeeSplitWeightNextPropose); err != nil {
+	weightVQ := consensusParameters.FeeSplitWeightVote.Clone()
+	if err = weightVQ.Add(&consensusParameters.FeeSplitWeightNextPropose); err != nil {
 		return fmt.Errorf("add FeeSplitWeightNextPropose: %w", err)
 	}
-	denom := numPersist.Clone()
-	if err = denom.Add(&consensusParameters.FeeSplitWeightPropose); err != nil {
+	weightPVQ := weightVQ.Clone()
+	if err = weightPVQ.Add(&consensusParameters.FeeSplitWeightPropose); err != nil {
 		return fmt.Errorf("add FeeSplitWeightPropose: %w", err)
 	}
 	feePersistAmt := totalFees.Clone()
-	if err = feePersistAmt.Mul(numPersist); err != nil {
+	if err = feePersistAmt.Mul(weightVQ); err != nil {
 		return fmt.Errorf("multiply feePersistAmt: %w", err)
 	}
-	if feePersistAmt.Quo(denom) != nil {
+	if feePersistAmt.Quo(weightPVQ) != nil {
 		return fmt.Errorf("divide feePersistAmt: %w", err)
 	}
 

--- a/go/consensus/tendermint/apps/staking/fees.go
+++ b/go/consensus/tendermint/apps/staking/fees.go
@@ -60,7 +60,7 @@ func (app *stakingApplication) disburseFeesP(ctx *abci.Context, stakeState *stak
 		stakeState.SetAccount(*proposerEntity, acct)
 	}
 
-	// Put the rest into the common pool.
+	// Put the rest into the common pool (in case there is no proposer entity to pay).
 	if !totalFees.IsZero() {
 		remaining := totalFees.Clone()
 		commonPool, err := stakeState.CommonPool()

--- a/go/consensus/tendermint/apps/staking/staking.go
+++ b/go/consensus/tendermint/apps/staking/staking.go
@@ -59,24 +59,24 @@ func (app *stakingApplication) BeginBlock(ctx *abci.Context, request types.Reque
 	// Look up the proposer's entity.
 	proposingEntity := app.resolveEntityIDFromProposer(regState, request, ctx)
 
-	// Go through all signers of the previous block and resolve entities.
+	// Go through all voters of the previous block and resolve entities.
 	// numEligibleValidators is how many total validators are in the validator set, while
-	// signingEntities is from the validators which actually signed.
+	// votingEntities is from the validators which actually voted.
 	numEligibleValidators := len(request.GetLastCommitInfo().Votes)
-	signingEntities := app.resolveEntityIDsFromVotes(ctx, regState, request.GetLastCommitInfo())
+	votingEntities := app.resolveEntityIDsFromVotes(ctx, regState, request.GetLastCommitInfo())
 
 	// Disburse fees from previous block.
-	if err := app.disburseFeesVQ(ctx, stakeState, proposingEntity, numEligibleValidators, signingEntities); err != nil {
-		return fmt.Errorf("disburse fees signers and next proposer: %w", err)
+	if err := app.disburseFeesVQ(ctx, stakeState, proposingEntity, numEligibleValidators, votingEntities); err != nil {
+		return fmt.Errorf("disburse fees voters and next proposer: %w", err)
 	}
 
 	// Add rewards for proposer.
-	if err := app.rewardBlockProposing(ctx, stakeState, proposingEntity, numEligibleValidators, len(signingEntities)); err != nil {
+	if err := app.rewardBlockProposing(ctx, stakeState, proposingEntity, numEligibleValidators, len(votingEntities)); err != nil {
 		return fmt.Errorf("staking: block proposing reward: %w", err)
 	}
 
 	// Track signing for rewards.
-	if err := app.updateEpochSigning(ctx, stakeState, signingEntities); err != nil {
+	if err := app.updateEpochSigning(ctx, stakeState, votingEntities); err != nil {
 		return fmt.Errorf("staking: failed to update epoch signing info: %w", err)
 	}
 

--- a/go/consensus/tendermint/apps/staking/staking.go
+++ b/go/consensus/tendermint/apps/staking/staking.go
@@ -70,6 +70,9 @@ func (app *stakingApplication) BeginBlock(ctx *abci.Context, request types.Reque
 		return fmt.Errorf("disburse fees voters and next proposer: %w", err)
 	}
 
+	// Save block proposer for fee disbursements.
+	stakingState.SetBlockProposer(ctx, proposingEntity)
+
 	// Add rewards for proposer.
 	if err := app.rewardBlockProposing(ctx, stakeState, proposingEntity, numEligibleValidators, len(votingEntities)); err != nil {
 		return fmt.Errorf("staking: block proposing reward: %w", err)

--- a/go/consensus/tendermint/apps/staking/state/gas.go
+++ b/go/consensus/tendermint/apps/staking/state/gas.go
@@ -100,11 +100,24 @@ func AuthenticateAndPayFees(
 	return nil
 }
 
-// PersistBlockFees persists the accumulated fee balance for the current block.
-func PersistBlockFees(ctx *abci.Context) {
+// BlockFees returns the accumulated fee balance for the current block.
+func BlockFees(ctx *abci.Context) quantity.Quantity {
 	// Fetch accumulated fees in the current block.
-	fees := ctx.BlockContext().Get(feeAccumulatorKey{}).(*feeAccumulator).balance
+	return ctx.BlockContext().Get(feeAccumulatorKey{}).(*feeAccumulator).balance
+}
 
-	state := NewMutableState(ctx.State())
-	state.SetLastBlockFees(&fees)
+// proposerKey is the block context key.
+type proposerKey struct{}
+
+func (pk proposerKey) NewDefault() interface{} {
+	var empty *signature.PublicKey
+	return empty
+}
+
+func SetBlockProposer(ctx *abci.Context, p *signature.PublicKey) {
+	ctx.BlockContext().Set(proposerKey{}, p)
+}
+
+func BlockProposer(ctx *abci.Context) *signature.PublicKey {
+	return ctx.BlockContext().Get(proposerKey{}).(*signature.PublicKey)
 }

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -130,7 +130,7 @@ func TestGenesisChainContext(t *testing.T) {
 	//       on each run.
 	stableDoc.Staking = staking.Genesis{}
 
-	require.Equal(t, "44c92fbc4f9e4fbc9cc09b7c9491a42bd52052246986242c70e69fdd8114b2e9", stableDoc.ChainContext())
+	require.Equal(t, "77bc3d261fd95ff38712293ce9c8b93f20464ab8bc1f99c8f9cdf6aff4706730", stableDoc.ChainContext())
 }
 
 func TestGenesisSanityCheck(t *testing.T) {

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -130,7 +130,7 @@ func TestGenesisChainContext(t *testing.T) {
 	//       on each run.
 	stableDoc.Staking = staking.Genesis{}
 
-	require.Equal(t, "813021fca91663966fa73935b88165713d133ab2073f205050749e5b279fd869", stableDoc.ChainContext())
+	require.Equal(t, "44c92fbc4f9e4fbc9cc09b7c9491a42bd52052246986242c70e69fdd8114b2e9", stableDoc.ChainContext())
 }
 
 func TestGenesisSanityCheck(t *testing.T) {

--- a/go/oasis-node/cmd/genesis/genesis.go
+++ b/go/oasis-node/cmd/genesis/genesis.go
@@ -475,7 +475,7 @@ func AppendStakingState(doc *genesis.Document, state string, l *logging.Logger) 
 	stakingSt := staking.Genesis{
 		Ledger: make(map[signature.PublicKey]*staking.Account),
 	}
-	if err := stakingSt.Parameters.FeeSplitVote.FromInt64(1); err != nil {
+	if err := stakingSt.Parameters.FeeSplitWeightVote.FromInt64(1); err != nil {
 		return fmt.Errorf("couldn't set default fee split: %w", err)
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
@@ -190,6 +190,22 @@ func (sc *gasFeesImpl) runTests(ctx context.Context) error {
 		return err
 	}
 
+	// As of the last time this comment was updated:
+	// - total fees has 150 tokens from genesis common pool
+	// - total fees has 50 tokens from genesis last block fees
+	// - for each of 12 transactions that pay for gas:
+	//   - 10 tokens paid for gas in a block on its own
+	//   - (2+2)/(1+2+2) = 80% => 8 tokens persisted for VQ share
+	//   - 10 - 8 = 2 tokens paid to P
+	//   - VQ share divided into 3 validator portions, for 2 tokens each
+	//   - (2)/(2+2) = 50% => 1 token per validator for Q
+	//   - 2 - 1 = 1 token per validator for V
+	//   - remaining 2 tokens moved to common pool
+	// - 150 + 50 + 12 * 10 = 320 tokens `total_fees`
+	// - 12 * 2 = 24 tokens paid for P role
+	// - 12 * 1 * 3 = 36 tokens paid for V roles
+	// - 12 * 1 * 3 = 36 tokens paid for Q role
+	// - 24 + 36 + 36 = 96 tokens `disbursed_fees`
 	sc.logger.Info("making sure that fees have been disbursed",
 		"total_fees", totalFees,
 		"disbursed_fees", newTotalEntityBalance,

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -535,12 +535,12 @@ type ConsensusParameters struct {
 	DisableDelegation      bool                         `json:"disable_delegation,omitempty"`
 	UndisableTransfersFrom map[signature.PublicKey]bool `json:"undisable_transfers_from,omitempty"`
 
-	// FeeSplitPropose is the proportion of block fee portions that go to the proposer.
-	FeeSplitPropose quantity.Quantity `json:"fee_split_propose"`
-	// FeeSplitVote is the proportion of block fee portions that go to the validator that signs.
-	FeeSplitVote quantity.Quantity `json:"fee_split_vote"`
-	// FeeSplitNextPropose is the proportion of block fee portions that go to the next block's proposer.
-	FeeSplitNextPropose quantity.Quantity `json:"fee_split_next_propose"`
+	// FeeSplitWeightPropose is the proportion of block fee portions that go to the proposer.
+	FeeSplitWeightPropose quantity.Quantity `json:"fee_split_weight_propose"`
+	// FeeSplitWeightVote is the proportion of block fee portions that go to the validator that votes.
+	FeeSplitWeightVote quantity.Quantity `json:"fee_split_weight_vote"`
+	// FeeSplitWeightNextPropose is the proportion of block fee portions that go to the next block's proposer.
+	FeeSplitWeightNextPropose quantity.Quantity `json:"fee_split_weight_next_propose"`
 
 	// RewardFactorEpochSigned is the factor for a reward distributed per epoch to
 	// entities that have signed at least a threshold fraction of the blocks.

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -535,16 +535,12 @@ type ConsensusParameters struct {
 	DisableDelegation      bool                         `json:"disable_delegation,omitempty"`
 	UndisableTransfersFrom map[signature.PublicKey]bool `json:"undisable_transfers_from,omitempty"`
 
-	// (Replicated in staking app `disburseFees` method. Keep both explanations in sync.)
-	// A block's fees are split into $n$ portions, one corresponding to each validator.
-	// For each validator $V$ that signs the block, $V$'s corresponding portion is disbursed between $V$ and the
-	// proposer $P$. The ratio of this split are controlled by `FeeSplitVote` and `FeeSplitPropose`.
-	// Portions corresponding to validators that don't sign the block go to the common pool.
-
-	// FeeSplitVote is the proportion of block fee portions that go to the validator that signs.
-	FeeSplitVote quantity.Quantity `json:"fee_split_vote"`
 	// FeeSplitPropose is the proportion of block fee portions that go to the proposer.
 	FeeSplitPropose quantity.Quantity `json:"fee_split_propose"`
+	// FeeSplitVote is the proportion of block fee portions that go to the validator that signs.
+	FeeSplitVote quantity.Quantity `json:"fee_split_vote"`
+	// FeeSplitNextPropose is the proportion of block fee portions that go to the next block's proposer.
+	FeeSplitNextPropose quantity.Quantity `json:"fee_split_next_propose"`
 
 	// RewardFactorEpochSigned is the factor for a reward distributed per epoch to
 	// entities that have signed at least a threshold fraction of the blocks.

--- a/go/staking/api/api_test.go
+++ b/go/staking/api/api_test.go
@@ -35,9 +35,10 @@ func TestConsensusParameters(t *testing.T) {
 
 	// Degenerate fee split.
 	degenerateFeeSplit := ConsensusParameters{
-		Thresholds:            validThresholds,
-		FeeSplitWeightVote:    mustInitQuantity(t, 0),
-		FeeSplitWeightPropose: mustInitQuantity(t, 0),
+		Thresholds:                validThresholds,
+		FeeSplitWeightPropose:     mustInitQuantity(t, 0),
+		FeeSplitWeightVote:        mustInitQuantity(t, 0),
+		FeeSplitWeightNextPropose: mustInitQuantity(t, 0),
 	}
 	require.Error(degenerateFeeSplit.SanityCheck(), "consensus parameters with degenerate fee split should be invalid")
 }

--- a/go/staking/api/api_test.go
+++ b/go/staking/api/api_test.go
@@ -26,8 +26,8 @@ func TestConsensusParameters(t *testing.T) {
 		KindRuntimeKeyManager: *quantity.NewQuantity(),
 	}
 	validThresholdsParams := ConsensusParameters{
-		Thresholds:   validThresholds,
-		FeeSplitVote: mustInitQuantity(t, 1),
+		Thresholds:         validThresholds,
+		FeeSplitWeightVote: mustInitQuantity(t, 1),
 	}
 	require.NoError(validThresholdsParams.SanityCheck(), "consensus parameters with valid thresholds should be valid")
 
@@ -35,9 +35,9 @@ func TestConsensusParameters(t *testing.T) {
 
 	// Degenerate fee split.
 	degenerateFeeSplit := ConsensusParameters{
-		Thresholds:      validThresholds,
-		FeeSplitVote:    mustInitQuantity(t, 0),
-		FeeSplitPropose: mustInitQuantity(t, 0),
+		Thresholds:            validThresholds,
+		FeeSplitWeightVote:    mustInitQuantity(t, 0),
+		FeeSplitWeightPropose: mustInitQuantity(t, 0),
 	}
 	require.Error(degenerateFeeSplit.SanityCheck(), "consensus parameters with degenerate fee split should be invalid")
 }

--- a/go/staking/api/sanity_check.go
+++ b/go/staking/api/sanity_check.go
@@ -23,14 +23,17 @@ func (p *ConsensusParameters) SanityCheck() error {
 	}
 
 	// Fee splits.
-	if !p.FeeSplitWeightVote.IsValid() {
-		return fmt.Errorf("fee split vote has invalid value")
-	}
 	if !p.FeeSplitWeightPropose.IsValid() {
-		return fmt.Errorf("fee split propose has invalid value")
+		return fmt.Errorf("fee split weight propose has invalid value")
 	}
-	if p.FeeSplitWeightVote.IsZero() && p.FeeSplitWeightPropose.IsZero() {
-		return fmt.Errorf("fee split proportions are both zero")
+	if !p.FeeSplitWeightVote.IsValid() {
+		return fmt.Errorf("fee split weight vote has invalid value")
+	}
+	if !p.FeeSplitWeightNextPropose.IsValid() {
+		return fmt.Errorf("fee split weight next propose has invalid value")
+	}
+	if p.FeeSplitWeightPropose.IsZero() && p.FeeSplitWeightVote.IsZero() && p.FeeSplitWeightNextPropose.IsZero() {
+		return fmt.Errorf("fee split proportions are all zero")
 	}
 
 	return nil

--- a/go/staking/api/sanity_check.go
+++ b/go/staking/api/sanity_check.go
@@ -23,13 +23,13 @@ func (p *ConsensusParameters) SanityCheck() error {
 	}
 
 	// Fee splits.
-	if !p.FeeSplitVote.IsValid() {
+	if !p.FeeSplitWeightVote.IsValid() {
 		return fmt.Errorf("fee split vote has invalid value")
 	}
-	if !p.FeeSplitPropose.IsValid() {
+	if !p.FeeSplitWeightPropose.IsValid() {
 		return fmt.Errorf("fee split propose has invalid value")
 	}
-	if p.FeeSplitVote.IsZero() && p.FeeSplitPropose.IsZero() {
+	if p.FeeSplitWeightVote.IsZero() && p.FeeSplitWeightPropose.IsZero() {
 		return fmt.Errorf("fee split proportions are both zero")
 	}
 

--- a/go/staking/tests/debug/debug_stake.go
+++ b/go/staking/tests/debug/debug_stake.go
@@ -33,7 +33,7 @@ var (
 				},
 			},
 			MinDelegationAmount:     QtyFromInt(10),
-			FeeSplitVote:            QtyFromInt(1),
+			FeeSplitWeightVote:      QtyFromInt(1),
 			RewardFactorEpochSigned: QtyFromInt(1),
 			// Zero RewardFactorBlockProposed is normal.
 		},

--- a/tests/fixture-data/gas-fees-runtimes/staking-genesis.json
+++ b/tests/fixture-data/gas-fees-runtimes/staking-genesis.json
@@ -1,7 +1,8 @@
 {
   "params": {
-    "fee_split_vote": "1",
-    "fee_split_propose": "1"
+    "fee_split_weight_propose": "2",
+    "fee_split_weight_vote": "1",
+    "fee_split_weight_next_propose": "1"
   },
   "total_supply": "90000000",
   "ledger": {

--- a/tests/fixture-data/gas-fees/staking-genesis.json
+++ b/tests/fixture-data/gas-fees/staking-genesis.json
@@ -7,8 +7,9 @@
       "add_escrow": 10,
       "reclaim_escrow": 10
     },
+    "fee_split_propose": "2",
     "fee_split_vote": "1",
-    "fee_split_propose": "1"
+    "fee_split_next_propose": "1"
   },
   "total_supply": "1200",
   "common_pool": "150",

--- a/tests/fixture-data/gas-fees/staking-genesis.json
+++ b/tests/fixture-data/gas-fees/staking-genesis.json
@@ -7,9 +7,9 @@
       "add_escrow": 10,
       "reclaim_escrow": 10
     },
-    "fee_split_weight_propose": "2",
-    "fee_split_weight_vote": "1",
-    "fee_split_weight_next_propose": "1"
+    "fee_split_weight_propose": "1",
+    "fee_split_weight_vote": "2",
+    "fee_split_weight_next_propose": "2"
   },
   "total_supply": "1200",
   "common_pool": "150",

--- a/tests/fixture-data/gas-fees/staking-genesis.json
+++ b/tests/fixture-data/gas-fees/staking-genesis.json
@@ -7,9 +7,9 @@
       "add_escrow": 10,
       "reclaim_escrow": 10
     },
-    "fee_split_propose": "2",
-    "fee_split_vote": "1",
-    "fee_split_next_propose": "1"
+    "fee_split_weight_propose": "2",
+    "fee_split_weight_vote": "1",
+    "fee_split_weight_next_propose": "1"
   },
   "total_supply": "1200",
   "common_pool": "150",

--- a/tests/fixture-data/txsource/staking-genesis.json
+++ b/tests/fixture-data/txsource/staking-genesis.json
@@ -7,8 +7,9 @@
       "rate_change_interval": 10
     },
     "debonding_interval": 2,
-    "fee_split_propose": "1",
-    "fee_split_vote": "1",
+    "fee_split_weight_propose": "2",
+    "fee_split_weight_vote": "1",
+    "fee_split_weight_next_propose": "1",
     "gas_costs": {
       "add_escrow": 10,
       "burn": 10,


### PR DESCRIPTION
We should give more to the previous block proposer, which is the block that first ran the transactions that paid the fees in the `LastBlockFees`. Currently they only get paid as a voter.

# Proposed design

## Summary

The fee for block $h$ is split into $k$ portions, where $k$ is the number of validators at block $h$, one for each of those validators.
Each portion is split by constant weights into a _proposer share_, a _voter share_, and a _next proposer share_.
At the end of block $h$, pay the proposer share of all portions to the proposer of block $h$.
At the beginning of block $h+1$, for each portion where its validator's vote is included in block $h+1$, pay the voter share to the validator and pay the next proposer share to the proposer of block $h+1$.

## Changes to genesis document

In `.staking.params`:

- Changed: `fee_split_*` is renamed to `fee_split_weight_*`
- Added: `fee_split_weight_next_propose`, a `quantity.Quantity`
- Changed: `fee_split_weight_propose` controls the proposer share (previously controlled the next proposer share)

Setting idea:

- `fee_split_weight_propose`: 2
- `fee_split_weight_vote`: 1
- `fee_split_weight_next_propose`: 1

## Changes to block context

- Added: `proposerEntityKey`, the _block proposer_, with the entity of the proposer (needed to remember the proposer from `BeginBlock` for use in `EndBlock`)

## Changes to ABCI state

- Changed: `lastBlockFeesKeyFmt`, the _last block fees_, now stores only the voter shares and next proposer shares

## Algorithms

In cases where resolving an entity ID from a node address fails, skip movements to its balance.

In `BeginBlock`:

- Get the proposer address $A_p$ from the request
- Get the last commit number $k$ of validators from the request
- Get the address $V$ of nodes that voted from the request
- Resolve entity ID $I_p$ from node address $A_p$
- Get $f_{v,q}$ from the last block fees
- Compute a portion size $s=f_{v,q}/k$ (rounds down) where $k$ is the number of validators
- Compute a share size $s_q=s*w_q/(w_v+w_q)$ (rounds down)
- Compute a share size $s_v=s-s_q$
- For each voter address $v_i \in V$:
  - Resolve the entity ID $I_v_i$ from node address $v_i$
  - Move $s_v$ from the last block fees to $I_v_i$'s general balance
- Move $s_q*|V|$ from the last block fees to $I_p$'s general balance
- Move the remaining amount from the last block fees to the common pool
- Store $I_p$ as the block proposer

In `EndBlock`:

- Compute a portion of the fee $f_{v,q}=f*(w_v+w_q)/(w_p+w_v+w_q)$ (rounds down) where $f$ is the accumulated fee, $w_p$ is the proposer share, $w_v$ is the voter share, and $w_q$ is the next proposer share
- Move $f_{v,q}$ from the fee accumulator to the last block fees
- Get $I_p$ from the block proposer
- Move the remaining amount from the fee accumulator to $I_p$'s general balance
- Move the remaining amount from the fee accumulator to the common pool (in case resolving $I_p$ failed)
