### PR TITLE
go/runtime/client: use history for GetBlock(latest)

### DIFF
--- a/.changelog/2795.bugfix.md
+++ b/.changelog/2795.bugfix.md
@@ -1,0 +1,5 @@
+go/runtime/client: use history for GetBlock(latest)
+
+Using history for all GetBlock requests prevents the case where the latest
+block would already be available but not yet in history, leading to
+inconsistent results compared to querying by specific block number.

--- a/go/roothash/api/history.go
+++ b/go/roothash/api/history.go
@@ -32,4 +32,7 @@ type BlockHistory interface {
 
 	// GetBlock returns the block at a specific round.
 	GetBlock(ctx context.Context, round uint64) (*block.Block, error)
+
+	// GetLatestBlock returns the block at latest round.
+	GetLatestBlock(ctx context.Context) (*block.Block, error)
 }

--- a/go/runtime/client/client.go
+++ b/go/runtime/client/client.go
@@ -216,16 +216,17 @@ func (c *runtimeClient) WatchBlocks(ctx context.Context, runtimeID common.Namesp
 
 // Implements api.RuntimeClient.
 func (c *runtimeClient) GetBlock(ctx context.Context, request *api.GetBlockRequest) (*block.Block, error) {
-	if request.Round == api.RoundLatest {
-		return c.common.consensus.RootHash().GetLatestBlock(ctx, request.RuntimeID, consensus.HeightLatest)
-	}
-
 	rt, err := c.common.runtimeRegistry.GetRuntime(request.RuntimeID)
 	if err != nil {
 		return nil, err
 	}
 
-	return rt.History().GetBlock(ctx, request.Round)
+	switch request.Round {
+	case api.RoundLatest:
+		return rt.History().GetLatestBlock(ctx)
+	default:
+		return rt.History().GetBlock(ctx, request.Round)
+	}
 }
 
 func (c *runtimeClient) getTxnTree(blk *block.Block) *transaction.Tree {

--- a/go/runtime/client/tests/tester.go
+++ b/go/runtime/client/tests/tester.go
@@ -83,6 +83,10 @@ func testQuery(
 	require.NoError(t, err, "GetBlock")
 	require.EqualValues(t, 4, blk.Header.Round)
 
+	blkLatest, err := c.GetBlock(ctx, &api.GetBlockRequest{RuntimeID: runtimeID, Round: api.RoundLatest})
+	require.NoError(t, err, "GetBlock(RoundLatest)")
+	require.EqualValues(t, 4, blkLatest.Header.Round)
+
 	// Out of bounds block round.
 	_, err = c.GetBlock(ctx, &api.GetBlockRequest{RuntimeID: runtimeID, Round: 5})
 	require.Error(t, err, "GetBlock")

--- a/go/runtime/history/history.go
+++ b/go/runtime/history/history.go
@@ -76,6 +76,10 @@ func (h *nopHistory) GetBlock(ctx context.Context, round uint64) (*block.Block, 
 	return nil, errNopHistory
 }
 
+func (h *nopHistory) GetLatestBlock(ctx context.Context) (*block.Block, error) {
+	return nil, errNopHistory
+}
+
 func (h *nopHistory) Pruner() Pruner {
 	pruner, _ := NewNonePruner()(nil)
 	return pruner
@@ -137,6 +141,19 @@ func (h *runtimeHistory) LastConsensusHeight() (int64, error) {
 
 func (h *runtimeHistory) GetBlock(ctx context.Context, round uint64) (*block.Block, error) {
 	annBlk, err := h.db.getBlock(round)
+	if err != nil {
+		return nil, err
+	}
+
+	return annBlk.Block, nil
+}
+
+func (h *runtimeHistory) GetLatestBlock(ctx context.Context) (*block.Block, error) {
+	meta, err := h.db.metadata()
+	if err != nil {
+		return nil, err
+	}
+	annBlk, err := h.db.getBlock(meta.LastRound)
 	if err != nil {
 		return nil, err
 	}

--- a/go/runtime/history/history_test.go
+++ b/go/runtime/history/history_test.go
@@ -41,6 +41,10 @@ func TestHistory(t *testing.T) {
 	require.Error(err, "GetBlock should fail for non-indexed block")
 	require.Equal(roothash.ErrNotFound, err)
 
+	_, err = history.GetLatestBlock(context.Background())
+	require.Error(err, "GetLatestBlock should fail for no indexed block")
+	require.Equal(roothash.ErrNotFound, err)
+
 	err = history.ConsensusCheckpoint(42)
 	require.NoError(err, "ConsensusCheckpoint")
 	err = history.ConsensusCheckpoint(40)
@@ -82,6 +86,10 @@ func TestHistory(t *testing.T) {
 	require.NoError(err, "GetBlock")
 	require.Equal(&putBlk, gotBlk, "GetBlock should return the correct block")
 
+	gotLatestBlk, err := history.GetLatestBlock(context.Background())
+	require.NoError(err, "GetLatestBlock")
+	require.Equal(&putBlk, gotLatestBlk, "GetLatestBlock should return the correct block")
+
 	// Close history and try to reopen and continue.
 	history.Close()
 
@@ -102,6 +110,10 @@ func TestHistory(t *testing.T) {
 	gotBlk, err = history.GetBlock(context.Background(), 10)
 	require.NoError(err, "GetBlock")
 	require.Equal(&putBlk, gotBlk, "GetBlock should return the correct block")
+
+	gotLatestBlk, err = history.GetLatestBlock(context.Background())
+	require.NoError(err, "GetLatestBlock")
+	require.Equal(&putBlk, gotLatestBlk, "GetLatestBlock should return the correct block")
 }
 
 type testPruneHandler struct {


### PR DESCRIPTION
Using history for all GetBlock requests prevents the case where the latest
block would already be available but not yet in history, leading to
inconsistent results compared to querying by specific block number.