### PR TITLE
go/txsource/queries: get runtime earliest round from runtime state

### DIFF
--- a/.changelog/2796.feature.md
+++ b/.changelog/2796.feature.md
@@ -1,0 +1,1 @@
+go/runtime/client: expose GetGenesisBlock method in runtime client

--- a/.changelog/2796.internal.md
+++ b/.changelog/2796.internal.md
@@ -1,0 +1,1 @@
+go/txsource/queries: obtain earliest runtime round from runtime genesis

--- a/go/oasis-node/cmd/debug/txsource/workload/queries.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/queries.go
@@ -439,11 +439,11 @@ func (q *queries) Run(gracefulExit context.Context, rng *rand.Rand, conn *grpc.C
 		)
 		return fmt.Errorf("Runtime unmarshal: %w", err)
 	}
-	rtState, ok := doc.RootHash.RuntimeStates[q.runtimeID]
-	if !ok {
-		return fmt.Errorf("Missing runtime genesis state for runtime: %s", q.runtimeID)
+	resp, err := q.runtime.GetGenesisBlock(ctx, q.runtimeID)
+	if err != nil {
+		return fmt.Errorf("Error querying runtime genesis block: %w", err)
 	}
-	q.runtimeGenesisRound = rtState.Round
+	q.runtimeGenesisRound = resp.Header.Round
 
 	for {
 		block, err := q.consensus.GetBlock(ctx, consensus.HeightLatest)

--- a/go/runtime/client/api/api.go
+++ b/go/runtime/client/api/api.go
@@ -35,6 +35,9 @@ type RuntimeClient interface {
 	// SubmitTx submits a transaction to the runtime transaction scheduler.
 	SubmitTx(ctx context.Context, request *SubmitTxRequest) ([]byte, error)
 
+	// GetGenesisBlock returns the genesis block.
+	GetGenesisBlock(ctx context.Context, runtimeID common.Namespace) (*block.Block, error)
+
 	// GetBlock fetches the given runtime block.
 	GetBlock(ctx context.Context, request *GetBlockRequest) (*block.Block, error)
 

--- a/go/runtime/client/client.go
+++ b/go/runtime/client/client.go
@@ -215,6 +215,11 @@ func (c *runtimeClient) WatchBlocks(ctx context.Context, runtimeID common.Namesp
 }
 
 // Implements api.RuntimeClient.
+func (c *runtimeClient) GetGenesisBlock(ctx context.Context, runtimeID common.Namespace) (*block.Block, error) {
+	return c.common.consensus.RootHash().GetGenesisBlock(ctx, runtimeID, consensus.HeightLatest)
+}
+
+// Implements api.RuntimeClient.
 func (c *runtimeClient) GetBlock(ctx context.Context, request *api.GetBlockRequest) (*block.Block, error) {
 	rt, err := c.common.runtimeRegistry.GetRuntime(request.RuntimeID)
 	if err != nil {

--- a/go/runtime/client/tests/tester.go
+++ b/go/runtime/client/tests/tester.go
@@ -61,6 +61,11 @@ func testQuery(
 	err := c.WaitBlockIndexed(ctx, &api.WaitBlockIndexedRequest{RuntimeID: runtimeID, Round: 4})
 	require.NoError(t, err, "WaitBlockIndexed")
 
+	// Fetch genesis block.
+	genBlk, err := c.GetGenesisBlock(ctx, runtimeID)
+	require.NoError(t, err, "GetGenesisBlock")
+	require.EqualValues(t, 0, genBlk.Header.Round, "GetGenesisBlock should have Round: 0")
+
 	// Based on SubmitTx and the mock worker.
 	testInput := []byte("octopus")
 	testOutput := testInput
@@ -163,4 +168,10 @@ func testQuery(
 	// Check for values from TestNode/TransactionSchedulerWorker/QueueCall
 	require.EqualValues(t, []byte("hello world"), results[0].Input)
 	require.EqualValues(t, []byte("hello world"), results[0].Output)
+
+	// Query genesis block again.
+	genBlk2, err := c.GetGenesisBlock(ctx, runtimeID)
+	require.NoError(t, err, "GetGenesisBlock2")
+	require.EqualValues(t, genBlk, genBlk2, "GetGenesisBlock should match previous GetGenesisBlock")
+
 }


### PR DESCRIPTION
Another option would be adding support for querying "earliest" round to the runtime client (which could also include runtime pruning), not sure which option we prefer.