### PR TITLE
 go consensus: shorten gas import

### DIFF
--- a/.changelog/2802.bugfix.md
+++ b/.changelog/2802.bugfix.md
@@ -1,0 +1,3 @@
+go/consensus: Shorten gas import
+
+Switch to more concise `FromUint64`.

--- a/go/consensus/api/transaction/gas.go
+++ b/go/consensus/api/transaction/gas.go
@@ -1,8 +1,6 @@
 package transaction
 
 import (
-	"math/big"
-
 	"github.com/oasislabs/oasis-core/go/common/errors"
 	"github.com/oasislabs/oasis-core/go/common/quantity"
 )
@@ -35,7 +33,7 @@ func (f Fee) GasPrice() *quantity.Quantity {
 	}
 
 	var gasQ quantity.Quantity
-	if err := gasQ.FromBigInt(big.NewInt(int64(f.Gas))); err != nil {
+	if err := gasQ.FromUint64(uint64(f.Gas)); err != nil {
 		// Should never happen.
 		panic(err)
 	}

--- a/go/consensus/api/transaction/gas_test.go
+++ b/go/consensus/api/transaction/gas_test.go
@@ -1,0 +1,22 @@
+package transaction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasislabs/oasis-core/go/common/quantity"
+)
+
+func TestFeeGasPrice(t *testing.T) {
+	// Test large Gas field.
+	var amt quantity.Quantity
+	require.NoError(t, amt.FromUint64(0x9000000000000000), "import amount")
+	gasPrice := Fee{
+		Amount: amt,
+		Gas:    0x9000000000000000,
+	}.GasPrice()
+	var referencePrice quantity.Quantity
+	require.NoError(t, referencePrice.FromUint64(1), "import reference price")
+	require.Zero(t, gasPrice.Cmp(&referencePrice), "price matches")
+}


### PR DESCRIPTION
switch to more concise `FromUint64`