### PR TITLE
go/staking: Use uint16 for limits in CommissionScheduleRules

### DIFF
--- a/.changelog/2809.bugfix.md
+++ b/.changelog/2809.bugfix.md
@@ -1,0 +1,1 @@
+go/consensus/tendermint/apps/staking: Propagate error in initTotalSupply

--- a/.changelog/2810.bugfix.md
+++ b/.changelog/2810.bugfix.md
@@ -1,0 +1,1 @@
+go/staking: Use uint16 for limits in CommissionScheduleRules

--- a/go/consensus/tendermint/apps/staking/genesis.go
+++ b/go/consensus/tendermint/apps/staking/genesis.go
@@ -137,16 +137,19 @@ func (app *stakingApplication) initLedger(ctx *abci.Context, state *stakingState
 	return nil
 }
 
-func (app *stakingApplication) initTotalSupply(ctx *abci.Context, state *stakingState.MutableState, st *staking.Genesis, totalSupply *quantity.Quantity) {
+func (app *stakingApplication) initTotalSupply(ctx *abci.Context, state *stakingState.MutableState, st *staking.Genesis, totalSupply *quantity.Quantity) error {
 	if totalSupply.Cmp(&st.TotalSupply) != 0 {
 		ctx.Logger().Error("InitChain: total supply mismatch",
 			"expected", st.TotalSupply,
 			"actual", totalSupply,
 		)
+		return fmt.Errorf("staking: total supply mismatch (expected: %s actual: %s)", st.TotalSupply, totalSupply)
 	}
 
 	state.SetCommonPool(&st.CommonPool)
 	state.SetTotalSupply(totalSupply)
+
+	return nil
 }
 
 func (app *stakingApplication) initDelegations(ctx *abci.Context, state *stakingState.MutableState, st *staking.Genesis) error {
@@ -271,7 +274,9 @@ func (app *stakingApplication) InitChain(ctx *abci.Context, request types.Reques
 		return err
 	}
 
-	app.initTotalSupply(ctx, state, st, &totalSupply)
+	if err := app.initTotalSupply(ctx, state, st, &totalSupply); err != nil {
+		return err
+	}
 
 	if err := app.initDelegations(ctx, state, st); err != nil {
 		return err

--- a/go/oasis-node/cmd/debug/txsource/workload/commission.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/commission.go
@@ -168,7 +168,7 @@ func (c *commission) doAmendCommissionSchedule(ctx context.Context, rng *rand.Ra
 
 	// Generate bound steps.
 	// [1, maxBoundSteps]
-	nBoundSteps := rng.Intn(maxBoundSteps) + 1
+	nBoundSteps := rng.Intn(int(maxBoundSteps)) + 1
 	var amendSchedule staking.AmendCommissionSchedule
 	boundEpoch := nextAlignedBoundChangeEpoch
 	for i := 0; i < nBoundSteps; i++ {
@@ -240,7 +240,7 @@ func (c *commission) doAmendCommissionSchedule(ctx context.Context, rng *rand.Ra
 		break
 	}
 	// [1, maxRateSteps]
-	nMinRateSteps := rng.Intn(maxRateSteps) + 1
+	nMinRateSteps := rng.Intn(int(maxRateSteps)) + 1
 
 	// In some cases we might need more rate steps to satisfy all bound steps.
 	var needMoreRateStpes bool
@@ -304,7 +304,7 @@ func (c *commission) doAmendCommissionSchedule(ctx context.Context, rng *rand.Ra
 	// In some cases the above procedure can produce invalid amendment.
 	// This happens when more than number of allowed amendment rate steps are
 	// needed to satisfy all bound steps.
-	if len(amendSchedule.Amendment.Rates) > maxRateSteps {
+	if len(amendSchedule.Amendment.Rates) > int(maxRateSteps) {
 		c.logger.Debug("To many rate steps needed to satisfy bonds, skipping amendment",
 			"amendment", amendSchedule,
 		)

--- a/go/staking/api/commission.go
+++ b/go/staking/api/commission.go
@@ -15,8 +15,8 @@ var CommissionRateDenominator *quantity.Quantity
 type CommissionScheduleRules struct {
 	RateChangeInterval epochtime.EpochTime `json:"rate_change_interval,omitempty"`
 	RateBoundLead      epochtime.EpochTime `json:"rate_bound_lead,omitempty"`
-	MaxRateSteps       int                 `json:"max_rate_steps,omitempty"`
-	MaxBoundSteps      int                 `json:"max_bound_steps,omitempty"`
+	MaxRateSteps       uint16              `json:"max_rate_steps,omitempty"`
+	MaxBoundSteps      uint16              `json:"max_bound_steps,omitempty"`
 }
 
 type CommissionRateStep struct {
@@ -36,10 +36,10 @@ type CommissionSchedule struct {
 }
 
 func (cs *CommissionSchedule) validateComplexity(rules *CommissionScheduleRules) error {
-	if len(cs.Rates) > rules.MaxRateSteps {
+	if len(cs.Rates) > int(rules.MaxRateSteps) {
 		return fmt.Errorf("rate schedule %d steps exceeds maximum %d", len(cs.Rates), rules.MaxRateSteps)
 	}
-	if len(cs.Bounds) > rules.MaxBoundSteps {
+	if len(cs.Bounds) > int(rules.MaxBoundSteps) {
 		return fmt.Errorf("bound schedule %d steps exceeds maximum %d", len(cs.Bounds), rules.MaxBoundSteps)
 	}
 


### PR DESCRIPTION
Fixes #2810 
Fixes #2809 