### PR TITLE
go/extra/stats: Update availability formula

### DIFF
--- a/.changelog/2819.internal.md
+++ b/.changelog/2819.internal.md
@@ -1,0 +1,6 @@
+go/extra/stats: Update availability score formula
+
+As per
+<https://docs.oasis.dev/operators/the-quest-rules.html#types-of-challenges>,
+the availability score formula has changed from "Blocks Signed + 50 x Blocks
+Proposed" to "Blocks Signed + 50 x Blocks Proposed in Round 0".


### PR DESCRIPTION
As per https://docs.oasis.dev/operators/the-quest-rules.html#types-of-challenges, the availability score formula has changed from `Blocks Signed + 50 x Blocks Proposed` to `Blocks Signed + 50 x Blocks Proposed in Round 0`.