### PR TITLE
go/common/crypto/signature/signer/composite: Initial import

### DIFF
--- a/.changelog/2684.feature.md
+++ b/.changelog/2684.feature.md
@@ -1,0 +1,8 @@
+go/common/crypto/signature/signer/composite: Initial import
+
+This adds a composite signer factory that can aggregate multiple signer
+factories.  This could be used (for example), to use multiple signer
+backends simultaneously, depending on the key role.
+
+Eg: The P2P link signer could use a local file, while the consensus
+signer can be backed by a remote HSM.

--- a/go/common/crypto/signature/signer.go
+++ b/go/common/crypto/signature/signer.go
@@ -3,8 +3,10 @@ package signature
 import (
 	"crypto/sha512"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -161,7 +163,22 @@ const (
 	SignerConsensus
 
 	// If you add to this, also add the new roles to SignerRoles.
+	maxSignerRole = SignerConsensus
 )
+
+func (role *SignerRole) FromString(str string) error {
+	i, err := strconv.Atoi(str)
+	if err != nil {
+		return fmt.Errorf("signature: unknown signer role: '%v'", str)
+	}
+
+	sRole := SignerRole(i)
+	if sRole == SignerUnknown || sRole > maxSignerRole {
+		return fmt.Errorf("signature: invalid signer role: '%v'", str)
+	}
+	*role = sRole
+	return nil
+}
 
 // SignerFactoryCtor is an SignerFactory constructor.
 type SignerFactoryCtor func(interface{}, ...SignerRole) (SignerFactory, error)

--- a/go/common/crypto/signature/signers/composite/composite_signer.go
+++ b/go/common/crypto/signature/signers/composite/composite_signer.go
@@ -1,0 +1,75 @@
+// Package composite provides a composite signer.
+package composite
+
+import (
+	"errors"
+	"io"
+
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+)
+
+// SignerName is the name used to identify the composite signer.
+const SignerName = "composite"
+
+// FactoryConfig is the composite factory configuration.
+type FactoryConfig map[signature.SignerRole]signature.SignerFactory
+
+// SignerFactory is a SignerFactory that is a composite of multiple other
+// SignerFactory(s).
+type SignerFactory struct {
+	inner FactoryConfig
+}
+
+// EnsureRole ensures that the SignerFactory is configured for the given
+// role.
+func (sf *SignerFactory) EnsureRole(role signature.SignerRole) error {
+	for k := range sf.inner {
+		if k == role {
+			return nil
+		}
+	}
+	return signature.ErrRoleMismatch
+}
+
+// Generate will generate and persist an new private key corresponding to
+// the provided role, and return a Signer ready for use.
+func (sf *SignerFactory) Generate(role signature.SignerRole, rng io.Reader) (signature.Signer, error) {
+	factory, ok := sf.inner[role]
+	if !ok {
+		return nil, signature.ErrRoleMismatch
+	}
+	return factory.Generate(role, rng)
+}
+
+// Load will load the private key corresponding to the role, and return a Signer
+// ready for use.
+func (sf *SignerFactory) Load(role signature.SignerRole) (signature.Signer, error) {
+	factory, ok := sf.inner[role]
+	if !ok {
+		return nil, signature.ErrRoleMismatch
+	}
+	return factory.Load(role)
+}
+
+// NewFactory creates a new factory with the specified roles, with the
+// specified pre-created SignerFactory(s).
+func NewFactory(config interface{}, roles ...signature.SignerRole) (signature.SignerFactory, error) {
+	cfg, ok := config.(FactoryConfig)
+	if !ok {
+		return nil, errors.New("signature/signer/composite: invalid composite signer configuration provided")
+	}
+	sf := &SignerFactory{
+		inner: make(FactoryConfig),
+	}
+
+	// Treat the roles vector as canonical.
+	for _, v := range roles {
+		factory, ok := cfg[v]
+		if !ok || factory == nil {
+			return nil, signature.ErrRoleMismatch
+		}
+		sf.inner[v] = factory
+	}
+
+	return sf, nil
+}

--- a/go/common/crypto/signature/signers/composite/composite_signer_test.go
+++ b/go/common/crypto/signature/signers/composite/composite_signer_test.go
@@ -1,0 +1,58 @@
+package composite
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/file"
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/memory"
+)
+
+func TestCompositeSigner(t *testing.T) {
+	require := require.New(t)
+
+	testRoles := []signature.SignerRole{
+		signature.SignerEntity,
+		signature.SignerP2P,
+	}
+
+	cfg := FactoryConfig{
+		signature.SignerEntity: memory.NewFactory(),
+		signature.SignerP2P:    nil,
+	}
+
+	_, err := NewFactory(cfg, testRoles...)
+	require.Equal(signature.ErrRoleMismatch, err, "config/role mismatch")
+
+	fileFac, err := file.NewFactory("/whatever", testRoles...)
+	require.NoError(err, "new file factory")
+	cfg[signature.SignerP2P] = fileFac
+
+	sf, err := NewFactory(cfg, testRoles...)
+	require.NoError(err, "new factory")
+
+	for _, v := range signature.SignerRoles {
+		err = sf.EnsureRole(v)
+		if cfg[v] != nil {
+			require.NoError(err, "EnsureRole: configured")
+		} else {
+			require.Equal(signature.ErrRoleMismatch, err, "EnsureRole: not configured")
+		}
+	}
+
+	signer, err := sf.Generate(signature.SignerEntity, rand.Reader)
+	require.NoError(err, "Generate: memory")
+	require.IsType(&memory.Signer{}, signer, "Generate: configured")
+
+	_, err = sf.Generate(signature.SignerConsensus, rand.Reader)
+	require.Equal(signature.ErrRoleMismatch, err, "Generate: not configured")
+
+	_, err = sf.Load(signature.SignerEntity)
+	require.Equal(signature.ErrNotExist, err, "Load: configured") // memory can't load
+
+	_, err = sf.Load(signature.SignerConsensus)
+	require.Equal(signature.ErrRoleMismatch, err, "Load: not configured")
+}

--- a/go/common/crypto/signature/signers/memory/memory_signer.go
+++ b/go/common/crypto/signature/signers/memory/memory_signer.go
@@ -10,6 +10,9 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 )
 
+// SignerName is the name used to identify the memory backed signer.
+const SignerName = "memory"
+
 var (
 	_ signature.SignerFactory = (*Factory)(nil)
 	_ signature.Signer        = (*Signer)(nil)

--- a/go/oasis-node/cmd/common/signer/signer_test.go
+++ b/go/oasis-node/cmd/common/signer/signer_test.go
@@ -1,0 +1,54 @@
+package signer
+
+import (
+	"crypto/rand"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+	fileSigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/file"
+	memorySigner "github.com/oasislabs/oasis-core/go/common/crypto/signature/signers/memory"
+)
+
+func TestCompositeCtor(t *testing.T) {
+	require := require.New(t)
+
+	dataDir, err := ioutil.TempDir("", "oasis-node-test_signer_")
+	require.NoError(err, "TempDir")
+	defer os.RemoveAll(dataDir)
+
+	viper.Set(cfgSignerCompositeBackends, "1:ledger,2:file,4:memory")
+	defer viper.Set(cfgSignerCompositeBackends, "")
+
+	testingAllowMemory = true
+
+	sf, err := doNewComposite(dataDir, signature.SignerEntity, signature.SignerNode, signature.SignerConsensus)
+	require.NoError(err, "doNewComposite")
+
+	err = sf.EnsureRole(signature.SignerEntity)
+	require.NoError(err, "EnsureRole: ledger")
+
+	err = sf.EnsureRole(signature.SignerNode)
+	require.NoError(err, "EnsureRole: file")
+
+	err = sf.EnsureRole(signature.SignerP2P)
+	require.Equal(signature.ErrRoleMismatch, err, "EnsureRole: not configured")
+
+	err = sf.EnsureRole(signature.SignerConsensus)
+	require.NoError(err, "EnsureRole: memory")
+
+	// Can't actually generate with the ledger backend, because most systems
+	// do not have that garbage.
+
+	signer, err := sf.Generate(signature.SignerNode, rand.Reader)
+	require.NoError(err, "Generate: file")
+	require.IsType(&fileSigner.Signer{}, signer, "Generate: file")
+
+	signer2, err := sf.Generate(signature.SignerConsensus, rand.Reader)
+	require.NoError(err, "Generate: memory")
+	require.IsType(&memorySigner.Signer{}, signer2, "Generate: memory")
+}


### PR DESCRIPTION
This adds a composite signer factory that can aggregate multiple signer
factories.  This could be used (for example), to use multiple signer
backends simultaneously, depending on the key role.

Eg: The P2P link signer could use a local file, while the consensus
signer can be backed by a remote HSM.

Fixes 2684.