### PR TITLE
Include oasis-core-runtime-loader and oasis-net-runner in releases

### DIFF
--- a/.changelog/2780.process.md
+++ b/.changelog/2780.process.md
@@ -1,0 +1,1 @@
+Include oasis-core-runtime-loader and oasis-net-runner in releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,15 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: "1.13.x"
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2020-02-16
+          override: true
       - name: Install oasis-node prerequisites
         run: |
           sudo apt-get update
-          sudo apt-get install make libseccomp-dev
+          sudo apt-get install make libseccomp-dev protobuf-compiler
       - name: Install GoReleaser
         run: |
           cd $(mktemp --directory /tmp/goreleaser.XXXXX)

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ hfuzz_workspace
 
 # Development-linked Workspaces.
 /thirdparty/
+
+# Required for goreleaser to properly generate an archive.
+/oasis-core-runtime-loader

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,8 +30,32 @@ builds:
     goarch:
       - amd64
 
+  - id: oasis-net-runner
+    main: ./oasis-net-runner/net-runner.go
+    binary: oasis-net-runner
+    dir: go/
+    flags:
+      - -trimpath
+    ldflags:
+      # NOTE: At the moment, GoReleaser produces different binaries when
+      # releases are built from different git paths, unless -buildid= is added
+      # to ldflags.
+      # For more details, see: https://github.com/oasislabs/goreleaser/issues/1.
+      - -buildid=
+      - -X github.com/oasislabs/oasis-core/go/common/version.SoftwareVersion={{.Env.VERSION}}
+    goos:
+      - linux
+    goarch:
+      - amd64
+
 archives:
-  - name_template: "{{.Binary}}_{{.Version}}_{{.Os}}_{{.Arch}}"
+  - name_template: "{{replace .ProjectName \" \" \"_\" | tolower}}_{{.Version}}_{{.Os}}_{{.Arch}}"
+    files:
+      - CHANGELOG.md
+      - README.md
+      - LICENSE
+      # NOTE: We assume that the Makefile release target prepares this binary.
+      - oasis-core-runtime-loader
 
 checksum:
   name_template: SHA256SUMS

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,12 @@ tag-next-release: fetch-git
 
 # Prepare release.
 release:
+	@$(ECHO) "$(CYAN)*** Building release version of oasis-core-runtime-loader...$(OFF)"
+	@CARGO_TARGET_DIR=target/default cargo build -p oasis-core-runtime-loader --release
+	@cp target/default/release/oasis-core-runtime-loader .
+	@$(ECHO) "$(CYAN)*** Preparing release archive...$(OFF)"
 	@goreleaser $(GORELEASER_ARGS)
+	@rm oasis-core-runtime-loader
 
 # Develop in a Docker container.
 docker-shell:


### PR DESCRIPTION
Fixes #2780 

The current solution for including Rust artifacts does not seem the best to me, but Goreleaser is slightly awkward. I tested this by running `make release`, probably I also need to change the release workflow to include the Rust compiler.

TODO
* [x] Update release workflow to include the Rust compiler.
* [x] Test updated release workflow.