### PR TITLE
go/oasis-test-runner/oasis: Add a keymanager replication test

### DIFF
--- a/.changelog/2843.breaking.6.md
+++ b/.changelog/2843.breaking.6.md
@@ -1,0 +1,8 @@
+keymanager-lib: Bind persisted state to the runtime ID
+
+It is likely prudent to bind the persisted master secret to the runtime
+ID.  This change does so by including the key manager runtime ID as the
+AAD when sealing the master secret.
+
+This is backward incompatible with all current key manager instances as
+the existing persisted master secret will not decrypt.

--- a/.changelog/2843.bugfix.1.md
+++ b/.changelog/2843.bugfix.1.md
@@ -1,0 +1,1 @@
+go/worker/keymanager: Add an enclave rpc handler

--- a/.changelog/2843.bugfix.2.md
+++ b/.changelog/2843.bugfix.2.md
@@ -1,0 +1,1 @@
+go/keymanager/client: Support km->km connections

--- a/.changelog/2843.bugfix.3.md
+++ b/.changelog/2843.bugfix.3.md
@@ -1,0 +1,4 @@
+go/worker/keymanager: Actually allow replication to maybe work
+
+Access control forbidding replication may be more secure, but is not all
+that useful.

--- a/.changelog/2843.feature.4.md
+++ b/.changelog/2843.feature.4.md
@@ -1,0 +1,3 @@
+go/keymanager/api: Add a gRPC endpoint for status queries
+
+Mostly so that the test cases can query statuses.

--- a/.changelog/2843.feature.5.md
+++ b/.changelog/2843.feature.5.md
@@ -1,0 +1,1 @@
+go/oasis-test-runner/oasis: Add a keymanager replication test

--- a/go/consensus/tendermint/keymanager/keymanager.go
+++ b/go/consensus/tendermint/keymanager/keymanager.go
@@ -11,7 +11,6 @@ import (
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 
-	"github.com/oasislabs/oasis-core/go/common"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
@@ -19,6 +18,7 @@ import (
 	app "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/keymanager"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/service"
 	"github.com/oasislabs/oasis-core/go/keymanager/api"
+	registry "github.com/oasislabs/oasis-core/go/registry/api"
 )
 
 type tendermintBackend struct {
@@ -30,13 +30,13 @@ type tendermintBackend struct {
 	notifier *pubsub.Broker
 }
 
-func (tb *tendermintBackend) GetStatus(ctx context.Context, id common.Namespace, height int64) (*api.Status, error) {
-	q, err := tb.querier.QueryAt(ctx, height)
+func (tb *tendermintBackend) GetStatus(ctx context.Context, query *registry.NamespaceQuery) (*api.Status, error) {
+	q, err := tb.querier.QueryAt(ctx, query.Height)
 	if err != nil {
 		return nil, err
 	}
 
-	return q.Status(ctx, id)
+	return q.Status(ctx, query.ID)
 }
 
 func (tb *tendermintBackend) GetStatuses(ctx context.Context, height int64) ([]*api.Status, error) {

--- a/go/keymanager/api/api.go
+++ b/go/keymanager/api/api.go
@@ -77,7 +77,7 @@ type Status struct {
 // Backend is a key manager management implementation.
 type Backend interface {
 	// GetStatus returns a key manager status by key manager ID.
-	GetStatus(context.Context, common.Namespace, int64) (*Status, error)
+	GetStatus(context.Context, *registry.NamespaceQuery) (*Status, error)
 
 	// GetStatuses returns all currently tracked key manager statuses.
 	GetStatuses(context.Context, int64) ([]*Status, error)

--- a/go/keymanager/api/api.go
+++ b/go/keymanager/api/api.go
@@ -139,6 +139,9 @@ func VerifyExtraInfo(logger *logging.Logger, rt *registry.Runtime, nodeRt *node.
 	} else if err := registry.VerifyNodeRuntimeEnclaveIDs(logger, nodeRt, rt, ts); err != nil {
 		return nil, err
 	}
+	if nodeRt.ExtraInfo == nil {
+		return nil, fmt.Errorf("keymanager: missing ExtraInfo")
+	}
 
 	var untrustedSignedInitResponse SignedInitResponse
 	if err := cbor.Unmarshal(nodeRt.ExtraInfo, &untrustedSignedInitResponse); err != nil {

--- a/go/keymanager/api/grpc.go
+++ b/go/keymanager/api/grpc.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/grpc"
+
 	"github.com/oasislabs/oasis-core/go/common/cbor"
+	cmnGrpc "github.com/oasislabs/oasis-core/go/common/grpc"
+	registry "github.com/oasislabs/oasis-core/go/registry/api"
 	enclaverpc "github.com/oasislabs/oasis-core/go/runtime/enclaverpc/api"
 )
 
@@ -12,6 +16,30 @@ var (
 	// Make sure this always matches the appropriate method in
 	// `keymanager-runtime/src/methods.rs`.
 	getPublicKeyRequestMethod = "get_public_key"
+
+	// serviceName is the gRPC service name.
+	serviceName = cmnGrpc.NewServiceName("KeyManager")
+
+	// methodGetStatus is the GetStatus method.
+	methodGetStatus = serviceName.NewMethod("GetStatus", registry.NamespaceQuery{})
+	// methodGetStatuses is the GetStatuses method.
+	methodGetStatuses = serviceName.NewMethod("GetStatuses", int64(0))
+
+	// serviceDesc is the gRPC service descriptor.
+	serviceDesc = grpc.ServiceDesc{
+		ServiceName: string(serviceName),
+		HandlerType: (*Backend)(nil),
+		Methods: []grpc.MethodDesc{
+			{
+				MethodName: methodGetStatus.ShortName(),
+				Handler:    handlerGetStatus,
+			},
+			{
+				MethodName: methodGetStatuses.ShortName(),
+				Handler:    handlerGetStatuses,
+			},
+		},
+	}
 )
 
 type enclaveRPCEndpoint struct {
@@ -39,6 +67,83 @@ func (e *enclaveRPCEndpoint) AccessControlRequired(ctx context.Context, request 
 		// Defer to access control to check the policy.
 		return true, nil
 	}
+}
+
+func handlerGetStatus( //nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var query registry.NamespaceQuery
+	if err := dec(&query); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).GetStatus(ctx, &query)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetStatus.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).GetStatus(ctx, req.(*registry.NamespaceQuery))
+	}
+	return interceptor(ctx, &query, info, handler)
+}
+
+func handlerGetStatuses( //nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	var height int64
+	if err := dec(&height); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(Backend).GetStatuses(ctx, height)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetStatuses.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Backend).GetStatuses(ctx, req.(int64))
+	}
+	return interceptor(ctx, height, info, handler)
+}
+
+// RegisterService registers a new keymanager backend service with the given gRPC server.
+func RegisterService(server *grpc.Server, service Backend) {
+	server.RegisterService(&serviceDesc, service)
+}
+
+// KeymanagerClient is a gRPC keymanager client.
+type KeymanagerClient struct {
+	conn *grpc.ClientConn
+}
+
+func (c *KeymanagerClient) GetStatus(ctx context.Context, query *registry.NamespaceQuery) (*Status, error) {
+	var resp Status
+	if err := c.conn.Invoke(ctx, methodGetStatus.FullName(), query, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *KeymanagerClient) GetStatuses(ctx context.Context, height int64) ([]*Status, error) {
+	var resp []*Status
+	if err := c.conn.Invoke(ctx, methodGetStatuses.FullName(), height, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// NewKeymanagerClient creates a new gRPC keymanager client service.
+func NewKeymanagerClient(c *grpc.ClientConn) *KeymanagerClient {
+	return &KeymanagerClient{c}
 }
 
 func init() {

--- a/go/keymanager/client/client.go
+++ b/go/keymanager/client/client.go
@@ -125,8 +125,14 @@ func (c *Client) worker() {
 		case rt := <-rtCh:
 			kmID = rt.KeyManager
 			if kmID == nil {
-				c.logger.Warn("runtime indicates no key manager is needed")
-				continue
+				if rt.Kind != registry.KindKeyManager {
+					c.logger.Warn("runtime indicates no key manager is needed")
+					continue
+				}
+
+				// We're a key manager client, that's interested in other
+				// instances of ourself.
+				kmID = &rt.ID
 			}
 
 			// Fetch current key manager status.

--- a/go/keymanager/client/client.go
+++ b/go/keymanager/client/client.go
@@ -130,7 +130,10 @@ func (c *Client) worker() {
 			}
 
 			// Fetch current key manager status.
-			st, err := c.backend.GetStatus(c.ctx, *rt.KeyManager, consensus.HeightLatest)
+			st, err := c.backend.GetStatus(c.ctx, &registry.NamespaceQuery{
+				ID:     *kmID,
+				Height: consensus.HeightLatest,
+			})
 			if err != nil {
 				c.logger.Warn("failed to get key manager status",
 					"err", err,

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -111,6 +111,9 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 		Validators: []oasis.ValidatorFixture{
 			oasis.ValidatorFixture{Entity: 1},
 		},
+		KeymanagerPolicies: []oasis.KeymanagerPolicyFixture{
+			oasis.KeymanagerPolicyFixture{Runtime: 0, Serial: 1},
+		},
 		Keymanagers: []oasis.KeymanagerFixture{
 			oasis.KeymanagerFixture{Runtime: 0, Entity: 1},
 		},

--- a/go/oasis-net-runner/fixtures/fixtures_test.go
+++ b/go/oasis-net-runner/fixtures/fixtures_test.go
@@ -20,6 +20,15 @@ func TestDefaultFixture(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, data)
 
+	// As cool as having tests cases is, having to regenerate test data
+	// every single time the default fixture changes is incredibly
+	// annoying.
+	//
+	// May this pearl of wisdom serve as a guiding light for the next
+	// unfortunate victim.
+	//
+	// $ ./oasis-net-runner dump-fixture > /tmp/fuckfuckfuckfuckfuck
+
 	storedData, err := ioutil.ReadFile(defaultFixturePath)
 	require.Nil(t, err)
 	require.NotNil(t, storedData)

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -32,6 +32,7 @@ import (
 	genesisTestHelpers "github.com/oasislabs/oasis-core/go/genesis/tests"
 	"github.com/oasislabs/oasis-core/go/ias"
 	iasAPI "github.com/oasislabs/oasis-core/go/ias/api"
+	keymanagerAPI "github.com/oasislabs/oasis-core/go/keymanager/api"
 	cmdCommon "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/background"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
@@ -185,6 +186,7 @@ func (n *Node) initBackends() error {
 	scheduler.RegisterService(grpcSrv, n.Consensus.Scheduler())
 	registryAPI.RegisterService(grpcSrv, n.Consensus.Registry())
 	stakingAPI.RegisterService(grpcSrv, n.Consensus.Staking())
+	keymanagerAPI.RegisterService(grpcSrv, n.Consensus.KeyManager())
 	consensusAPI.RegisterService(grpcSrv, n.Consensus)
 
 	cmdCommon.Logger().Debug("backends initialized")

--- a/go/oasis-test-runner/cmd/root.go
+++ b/go/oasis-test-runner/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -407,7 +408,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 func doScenario(childEnv *env.Env, sc scenario.Scenario) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("root: panic caught running test case: %v", r)
+			err = fmt.Errorf("root: panic caught running test case: %v: %s", r, debug.Stack())
 		}
 	}()
 
@@ -470,7 +471,7 @@ func doScenario(childEnv *env.Env, sc scenario.Scenario) (err error) {
 func doCleanup(childEnv *env.Env) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("root: panic caught cleaning up test case: %v", r)
+			err = fmt.Errorf("root: panic caught cleaning up test case: %v, %s", r, debug.Stack())
 		}
 	}()
 

--- a/go/oasis-test-runner/oasis/controller.go
+++ b/go/oasis-test-runner/oasis/controller.go
@@ -6,6 +6,7 @@ import (
 	cmnGrpc "github.com/oasislabs/oasis-core/go/common/grpc"
 	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
 	control "github.com/oasislabs/oasis-core/go/control/api"
+	keymanager "github.com/oasislabs/oasis-core/go/keymanager/api"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
 	runtimeClient "github.com/oasislabs/oasis-core/go/runtime/client/api"
 	staking "github.com/oasislabs/oasis-core/go/staking/api"
@@ -23,6 +24,7 @@ type Controller struct {
 	Registry      registry.Backend
 	RuntimeClient runtimeClient.RuntimeClient
 	Storage       storage.Backend
+	Keymanager    *keymanager.KeymanagerClient
 
 	conn *grpc.ClientConn
 }
@@ -52,6 +54,7 @@ func NewController(socketPath string) (*Controller, error) {
 		Registry:        registry.NewRegistryClient(conn),
 		RuntimeClient:   runtimeClient.NewRuntimeClient(conn),
 		Storage:         storage.NewStorageClient(conn),
+		Keymanager:      keymanager.NewKeymanagerClient(conn),
 
 		conn: conn,
 	}, nil

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -3,11 +3,16 @@ package oasis
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 
 	"github.com/pkg/errors"
 
 	"github.com/oasislabs/oasis-core/go/common/node"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/crypto"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
+	kmCmd "github.com/oasislabs/oasis-core/go/oasis-node/cmd/keymanager"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
 )
 
@@ -17,6 +22,124 @@ const (
 
 	keymanagerIdentitySeedTemplate = "ekiden node keymanager %d"
 )
+
+// KeymanagerPolicy is an Oasis key manager policy document.
+type KeymanagerPolicy struct {
+	net *Network
+	dir *env.Dir
+
+	statusArgs []string
+
+	runtime *Runtime
+	serial  int
+}
+
+// KeymanagerPolicyCfg is an Oasis key manager policy document configuration.
+type KeymanagerPolicyCfg struct {
+	Runtime *Runtime
+	Serial  int
+}
+
+func (pol *KeymanagerPolicy) provisionStatusArgs() []string {
+	return pol.statusArgs
+}
+
+func (pol *KeymanagerPolicy) provision() error {
+	if pol.runtime.teeHardware == node.TEEHardwareInvalid {
+		// No policy document.
+		pol.statusArgs = append(pol.statusArgs, "--"+kmCmd.CfgPolicyFile, "")
+	} else {
+		// Policy signed with test keys.
+		policyPath := filepath.Join(pol.dir.String(), kmPolicyFile)
+		policyArgs := []string{
+			"keymanager", "init_policy",
+			"--" + flags.CfgDebugDontBlameOasis,
+			"--" + kmCmd.CfgPolicyFile, policyPath,
+			"--" + kmCmd.CfgPolicyID, pol.runtime.id.String(),
+			"--" + kmCmd.CfgPolicySerial, strconv.Itoa(pol.serial),
+			"--" + kmCmd.CfgPolicyEnclaveID, pol.runtime.mrEnclave.String() + pol.runtime.mrSigner.String(),
+		}
+
+		for _, rt := range pol.net.runtimes {
+			if rt.teeHardware == node.TEEHardwareInvalid || rt.kind != registry.KindCompute {
+				continue
+			}
+
+			arg := fmt.Sprintf("%s=%s%s", rt.id, rt.mrEnclave, rt.mrSigner)
+			policyArgs = append(policyArgs, "--"+kmCmd.CfgPolicyMayQuery, arg)
+		}
+
+		w, err := pol.dir.NewLogWriter("provision-policy.log")
+		if err != nil {
+			return err
+		}
+		defer w.Close()
+
+		if err = pol.net.runNodeBinary(w, policyArgs...); err != nil {
+			pol.net.logger.Error("failed to provision keymanager policy",
+				"err", err,
+			)
+			return errors.Wrap(err, "oasis/keymanager: failed to provision keymanager policy")
+		}
+
+		// Sign policy with test keys.
+		signArgsTpl := []string{
+			"keymanager", "sign_policy",
+			"--" + common.CfgDebugAllowTestKeys,
+			"--" + flags.CfgDebugDontBlameOasis,
+			"--" + kmCmd.CfgPolicyFile, policyPath,
+		}
+		for i := 1; i <= 3; i++ {
+			signatureFile := filepath.Join(pol.dir.String(), fmt.Sprintf("%s.sign.%d", kmPolicyFile, i))
+			signArgs := append([]string{}, signArgsTpl...)
+			signArgs = append(signArgs, []string{
+				"--" + kmCmd.CfgPolicySigFile, signatureFile,
+				"--" + kmCmd.CfgPolicyTestKey, fmt.Sprintf("%d", i),
+			}...)
+			pol.statusArgs = append(pol.statusArgs, "--"+kmCmd.CfgPolicySigFile, signatureFile)
+
+			w, err := pol.dir.NewLogWriter("provision-policy-sign.log")
+			if err != nil {
+				return err
+			}
+			defer w.Close()
+
+			if err = pol.net.runNodeBinary(w, signArgs...); err != nil {
+				pol.net.logger.Error("failed to sign keymanager policy",
+					"err", err,
+				)
+				return errors.Wrap(err, "oasis/keymanager: failed to sign keymanager policy")
+			}
+		}
+
+		pol.statusArgs = append(pol.statusArgs, "--"+kmCmd.CfgPolicyFile, policyPath)
+	}
+
+	return nil
+}
+
+// NewKeymanagerPolicy provisions a new keymanager policy and adds it to the
+// network.
+func (net *Network) NewKeymanagerPolicy(cfg *KeymanagerPolicyCfg) (*KeymanagerPolicy, error) {
+	policyName := fmt.Sprintf("keymanager-policy-%d", cfg.Serial)
+
+	policyDir, err := net.baseDir.NewSubDir(policyName)
+	if err != nil {
+		net.logger.Error("failed to create keymanager policy subdir",
+			"err", err,
+		)
+		return nil, errors.Wrap(err, "oasis/keymanager: failed to create keymanager policy subdir")
+	}
+
+	net.keymanagerPolicy = &KeymanagerPolicy{
+		net:     net,
+		dir:     policyDir,
+		runtime: cfg.Runtime,
+		serial:  cfg.Serial,
+	}
+
+	return net.keymanagerPolicy, nil
+}
 
 // Keymanager is an Oasis key manager.
 type Keymanager struct { // nolint: maligned
@@ -30,6 +153,8 @@ type Keymanager struct { // nolint: maligned
 	tmAddress        string
 	consensusPort    uint16
 	workerClientPort uint16
+
+	mayGenerate bool
 }
 
 // KeymanagerCfg is the Oasis key manager provisioning configuration.
@@ -82,84 +207,16 @@ func (km *Keymanager) provisionGenesis() error {
 		return nil
 	}
 
-	// Provision status and policy. We can only provision this here as we need
+	// Provision status. We can only provision this here as we need
 	// a list of runtimes allowed to query the key manager.
 	statusArgs := []string{
 		"keymanager", "init_status",
-		"--debug.dont_blame_oasis",
-		"--debug.allow_test_keys",
-		"--keymanager.status.id", km.runtime.id.String(),
-		"--keymanager.status.file", filepath.Join(km.dir.String(), kmStatusFile),
+		"--" + common.CfgDebugAllowTestKeys,
+		"--" + flags.CfgDebugDontBlameOasis,
+		"--" + kmCmd.CfgStatusID, km.runtime.id.String(),
+		"--" + kmCmd.CfgStatusFile, filepath.Join(km.dir.String(), kmStatusFile),
 	}
-	if km.runtime.teeHardware == node.TEEHardwareInvalid {
-		// Status without policy.
-		statusArgs = append(statusArgs, "--keymanager.policy.file", "")
-	} else {
-		// Status and policy signed with test keys.
-		kmPolicyPath := filepath.Join(km.dir.String(), kmPolicyFile)
-		policyArgs := []string{
-			"keymanager", "init_policy",
-			"--debug.dont_blame_oasis",
-			"--keymanager.policy.file", kmPolicyPath,
-			"--keymanager.policy.id", km.runtime.id.String(),
-			"--keymanager.policy.serial", "1",
-			"--keymanager.policy.enclave.id", km.runtime.mrEnclave.String() + km.runtime.mrSigner.String(),
-		}
-
-		for _, rt := range km.net.runtimes {
-			if rt.teeHardware == node.TEEHardwareInvalid || rt.kind != registry.KindCompute {
-				continue
-			}
-
-			arg := fmt.Sprintf("%s=%s%s", rt.id, rt.mrEnclave, rt.mrSigner)
-			policyArgs = append(policyArgs, "--keymanager.policy.may.query", arg)
-		}
-
-		w, err := km.dir.NewLogWriter("provision-policy.log")
-		if err != nil {
-			return err
-		}
-		defer w.Close()
-
-		if err = km.net.runNodeBinary(w, policyArgs...); err != nil {
-			km.net.logger.Error("failed to provision keymanager policy",
-				"err", err,
-			)
-			return errors.Wrap(err, "oasis/keymanager: failed to provision keymanager policy")
-		}
-
-		// Sign policy with test keys.
-		signArgsTpl := []string{
-			"keymanager", "sign_policy",
-			"--debug.allow_test_keys",
-			"--debug.dont_blame_oasis",
-			"--keymanager.policy.file", kmPolicyPath,
-		}
-		for i := 1; i <= 3; i++ {
-			signatureFile := filepath.Join(km.dir.String(), fmt.Sprintf("%s.sign.%d", kmPolicyFile, i))
-			signArgs := append([]string{}, signArgsTpl...)
-			signArgs = append(signArgs, []string{
-				"--keymanager.policy.signature.file", signatureFile,
-				"--keymanager.policy.testkey", fmt.Sprintf("%d", i),
-			}...)
-			statusArgs = append(statusArgs, "--keymanager.policy.signature.file", signatureFile)
-
-			w, err := km.dir.NewLogWriter("provision-policy-sign.log")
-			if err != nil {
-				return err
-			}
-			defer w.Close()
-
-			if err = km.net.runNodeBinary(w, signArgs...); err != nil {
-				km.net.logger.Error("failed to sign keymanager policy",
-					"err", err,
-				)
-				return errors.Wrap(err, "oasis/keymanager: failed to sign keymanager policy")
-			}
-		}
-
-		statusArgs = append(statusArgs, "--keymanager.policy.file", kmPolicyPath)
-	}
+	statusArgs = append(statusArgs, km.net.keymanagerPolicy.provisionStatusArgs()...)
 
 	w, err := km.dir.NewLogWriter("provision-status.log")
 	if err != nil {
@@ -206,10 +263,13 @@ func (km *Keymanager) startNode() error {
 		workerKeymanagerRuntimeBinary(km.runtime.binary).
 		workerKeymanagerRuntimeLoader(km.net.cfg.RuntimeLoaderBinary).
 		workerKeymanagerRuntimeID(km.runtime.id).
-		workerKeymanagerMayGenerate().
 		appendNetwork(km.net).
 		appendSeedNodes(km.net).
 		appendEntity(km.entity)
+
+	if km.mayGenerate {
+		args = args.workerKeymanagerMayGenerate()
+	}
 
 	if km.runtime.teeHardware != node.TEEHardwareInvalid {
 		args = args.workerKeymanagerTEEHardware(km.runtime.teeHardware)
@@ -232,12 +292,7 @@ func (km *Keymanager) startNode() error {
 
 // NewKeymanager provisions a new keymanager and adds it to the network.
 func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
-	// XXX: Technically there can be more than one keymanager.
-	if len(net.keymanagers) == 1 {
-		return nil, errors.New("oasis/keymanager: already provisioned")
-	}
-
-	kmName := "keymanager"
+	kmName := fmt.Sprintf("keymanager-%d", len(net.keymanagers))
 
 	kmDir, err := net.baseDir.NewSubDir(kmName)
 	if err != nil {
@@ -247,9 +302,18 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 		return nil, errors.Wrap(err, "oasis/keymanager: failed to create keymanager subdir")
 	}
 
+	// HACK HACK HACK: Not sure how to fit this into the fixture stuff.
+	if net.keymanagerPolicy == nil {
+		if _, err = net.NewKeymanagerPolicy(&KeymanagerPolicyCfg{
+			Runtime: cfg.Runtime,
+			Serial:  1,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
 	// Pre-provision the node identity so that we can update the entity.
-	// TODO: Use proper key manager index when multiple key managers are supported.
-	seed := fmt.Sprintf(keymanagerIdentitySeedTemplate, 0)
+	seed := fmt.Sprintf(keymanagerIdentitySeedTemplate, len(net.keymanagers))
 	publicKey, err := net.provisionNodeIdentity(kmDir, seed, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "oasis/keymanager: failed to provision node identity")
@@ -275,6 +339,7 @@ func (net *Network) NewKeymanager(cfg *KeymanagerCfg) (*Keymanager, error) {
 		tmAddress:        crypto.PublicKeyToTendermint(&publicKey).Address().String(),
 		consensusPort:    net.nextNodePort,
 		workerClientPort: net.nextNodePort + 1,
+		mayGenerate:      len(net.keymanagers) == 0,
 	}
 	km.doStartNode = km.startNode
 	copy(km.NodeID[:], publicKey[:])

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -197,6 +197,8 @@ type Network struct {
 	clients        []*Client
 	byzantine      []*Byzantine
 
+	keymanagerPolicy *KeymanagerPolicy
+
 	seedNode *seedNode
 	iasProxy *iasProxy
 
@@ -737,6 +739,11 @@ func (net *Network) makeGenesis() error {
 	}
 	for _, v := range net.runtimes {
 		args = append(args, v.toGenesisArgs()...)
+	}
+	if net.keymanagerPolicy != nil {
+		if err := net.keymanagerPolicy.provision(); err != nil {
+			return err
+		}
 	}
 	for _, v := range net.keymanagers {
 		if err := v.provisionGenesis(); err != nil {

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -197,7 +197,7 @@ type Network struct {
 	clients        []*Client
 	byzantine      []*Byzantine
 
-	keymanagerPolicy *KeymanagerPolicy
+	keymanagerPolicies []*KeymanagerPolicy
 
 	seedNode *seedNode
 	iasProxy *iasProxy
@@ -740,8 +740,8 @@ func (net *Network) makeGenesis() error {
 	for _, v := range net.runtimes {
 		args = append(args, v.toGenesisArgs()...)
 	}
-	if net.keymanagerPolicy != nil {
-		if err := net.keymanagerPolicy.provision(); err != nil {
+	for _, v := range net.keymanagerPolicies {
+		if err := v.provision(); err != nil {
 			return err
 		}
 	}

--- a/go/oasis-test-runner/scenario/e2e/e2e.go
+++ b/go/oasis-test-runner/scenario/e2e/e2e.go
@@ -91,6 +91,8 @@ func RegisterScenarios() error {
 		SentryEncryption,
 		// Keymanager restart test.
 		KeymanagerRestart,
+		// Keymanager replicate test.
+		KeymanagerReplicate,
 		// Dump/restore test.
 		DumpRestore,
 		// Halt test.

--- a/go/oasis-test-runner/scenario/e2e/keymanager_replicate.go
+++ b/go/oasis-test-runner/scenario/e2e/keymanager_replicate.go
@@ -1,0 +1,145 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/oasislabs/oasis-core/go/common/cbor"
+	keymanager "github.com/oasislabs/oasis-core/go/keymanager/api"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/scenario"
+	registry "github.com/oasislabs/oasis-core/go/registry/api"
+)
+
+// KeymanagerReplicate is the keymanager replication scenario.
+var KeymanagerReplicate scenario.Scenario = newKmReplicateImpl()
+
+type kmReplicateImpl struct {
+	runtimeImpl
+}
+
+func newKmReplicateImpl() scenario.Scenario {
+	// BUG/2885: This should use `simple-keyvalue-enc-client`, but the client
+	// panics when the request goes to the replica.
+	return &kmReplicateImpl{
+		runtimeImpl: *newRuntimeImpl(
+			"keymanager-replication",
+			"simple-keyvalue-client",
+			nil,
+		),
+	}
+}
+
+func (sc *kmReplicateImpl) Clone() scenario.Scenario {
+	return &kmReplicateImpl{
+		runtimeImpl: *sc.runtimeImpl.Clone().(*runtimeImpl),
+	}
+}
+
+func (sc *kmReplicateImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := sc.runtimeImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	// This requires multiple keymanagers.
+	f.Keymanagers = []oasis.KeymanagerFixture{
+		oasis.KeymanagerFixture{Runtime: 0, Entity: 1},
+		oasis.KeymanagerFixture{Runtime: 0, Entity: 1},
+	}
+
+	return f, nil
+}
+
+func (sc *kmReplicateImpl) Run(childEnv *env.Env) error {
+	clientErrCh, cmd, err := sc.runtimeImpl.start(childEnv)
+	if err != nil {
+		return err
+	}
+
+	// Wait for the client to exit.
+	select {
+	case err = <-sc.runtimeImpl.net.Errors():
+		_ = cmd.Process.Kill()
+	case err = <-clientErrCh:
+	}
+	if err != nil {
+		return err
+	}
+
+	// Open a control connection to the replica.
+	if kmLen := len(sc.net.Keymanagers()); kmLen < 2 {
+		return fmt.Errorf("expected more than 1 keymanager, have: %v", kmLen)
+	}
+	replica := sc.net.Keymanagers()[1]
+
+	ctrl, err := oasis.NewController(replica.SocketPath())
+	if err != nil {
+		return err
+	}
+
+	// Extract the replica's ExtraInfo.
+	node, err := ctrl.Registry.GetNode(
+		context.Background(),
+		&registry.IDQuery{
+			ID: replica.NodeID,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	rt := node.GetRuntime(keymanagerID)
+	if rt == nil {
+		return fmt.Errorf("replica is missing keymanager runtime from descriptor")
+	}
+	var signedInitResponse keymanager.SignedInitResponse
+	if err = cbor.Unmarshal(rt.ExtraInfo, &signedInitResponse); err != nil {
+		return fmt.Errorf("failed to unmarshal replica extrainfo")
+	}
+
+	// Grab a state dump and cross check the checksum with that of
+	// the replica.
+	doc, err := ctrl.Consensus.StateToGenesis(context.Background(), 0)
+	if err != nil {
+		return fmt.Errorf("failed to obtain consensus state: %w", err)
+	}
+	if err = func() error {
+		for _, status := range doc.KeyManager.Statuses {
+			if !status.ID.Equal(&keymanagerID) {
+				continue
+			}
+			if !status.IsInitialized {
+				return fmt.Errorf("key manager failed to initialize")
+			}
+			if !bytes.Equal(status.Checksum, signedInitResponse.InitResponse.Checksum) {
+				return fmt.Errorf("key manager failed to replicate, checksum mismatch")
+			}
+			return nil
+		}
+		return fmt.Errorf("consensus state missing km status")
+	}(); err != nil {
+		return err
+	}
+
+	// Since the replica has published an ExtraInfo that shows that it has
+	// the correct master secret checksum, the replication process has
+	// succeeded from the enclave's point of view.
+
+	// Query the node's keymanager consensus endpoint.
+	status, err := ctrl.Keymanager.GetStatus(context.Background(), &registry.NamespaceQuery{
+		ID: keymanagerID,
+	})
+	if err != nil {
+		return err
+	}
+	for _, v := range status.Nodes {
+		// And ensure that the node is present.
+		if v.Equal(replica.NodeID) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("node missing from km status")
+}

--- a/go/oasis-test-runner/scenario/e2e/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime.go
@@ -197,6 +197,9 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 			oasis.ValidatorFixture{Entity: 1},
 			oasis.ValidatorFixture{Entity: 1},
 		},
+		KeymanagerPolicies: []oasis.KeymanagerPolicyFixture{
+			oasis.KeymanagerPolicyFixture{Runtime: 0, Serial: 1},
+		},
 		Keymanagers: []oasis.KeymanagerFixture{
 			oasis.KeymanagerFixture{Runtime: 0, Entity: 1},
 		},

--- a/go/oasis-test-runner/scenario/e2e/upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/upgrade.go
@@ -68,7 +68,7 @@ type nodeUpgradeImpl struct {
 
 func (sc *nodeUpgradeImpl) writeDescriptor(name string, content []byte) (string, error) {
 	filePath := path.Join(sc.net.BasePath(), "upgrade-"+name+".json")
-	if err := ioutil.WriteFile(filePath, content, 0644); err != nil {
+	if err := ioutil.WriteFile(filePath, content, 0644); err != nil { //nolint: gosec
 		sc.logger.Error("can't write descriptor to network directory",
 			"err", err,
 			"name", name,

--- a/go/oasis-test-runner/scenario/e2e/upgrade_cancel.go
+++ b/go/oasis-test-runner/scenario/e2e/upgrade_cancel.go
@@ -126,7 +126,7 @@ func (sc *nodeUpgradeCancelImpl) Run(childEnv *env.Env) error {
 	descriptor := fmt.Sprintf(descriptorTemplate, nodeHash.String())
 
 	filePath := path.Join(sc.net.BasePath(), "upgrade-descriptor.json")
-	if err = ioutil.WriteFile(filePath, []byte(descriptor), 0644); err != nil {
+	if err = ioutil.WriteFile(filePath, []byte(descriptor), 0644); err != nil { //nolint: gosec
 		return fmt.Errorf("can't write descriptor to network directory: %w", err)
 	}
 

--- a/go/worker/common/runtime_host.go
+++ b/go/worker/common/runtime_host.go
@@ -14,6 +14,7 @@ import (
 	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
 	keymanagerApi "github.com/oasislabs/oasis-core/go/keymanager/api"
 	keymanagerClient "github.com/oasislabs/oasis-core/go/keymanager/client"
+	registry "github.com/oasislabs/oasis-core/go/registry/api"
 	"github.com/oasislabs/oasis-core/go/runtime/localstorage"
 	runtimeRegistry "github.com/oasislabs/oasis-core/go/runtime/registry"
 	storage "github.com/oasislabs/oasis-core/go/storage/api"
@@ -50,7 +51,10 @@ func (h *runtimeHostHandler) Handle(ctx context.Context, body *protocol.Body) (*
 		if rt.KeyManager == nil {
 			return nil, errors.New("runtime has no key manager")
 		}
-		status, err := h.keyManager.GetStatus(ctx, *rt.KeyManager, consensus.HeightLatest)
+		status, err := h.keyManager.GetStatus(ctx, &registry.NamespaceQuery{
+			ID:     *rt.KeyManager,
+			Height: consensus.HeightLatest,
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/tests/fixture-data/net-runner/default.json
+++ b/tests/fixture-data/net-runner/default.json
@@ -137,6 +137,7 @@
         {
             "runtime": 0,
             "entity": 1,
+            "policy": 0,
             "allow_early_termination": false,
             "allow_error_termination": false,
             "consensus": {
@@ -146,6 +147,12 @@
                 "prune_num_kept": 0,
                 "tendermint_recover_corrupted_wal": false
             }
+        }
+    ],
+    "keymanager_policies": [
+        {
+            "runtime": 0,
+            "serial": 1
         }
     ],
     "storage_workers": [


### PR DESCRIPTION
 * [x] Add a basic replication test.
    * [x] Spin up a replica.
    * [x] Explicitly query the replica or something.
 * [x] Fix bugs.
    * [x] Oh my god, the key manager worker host doesn't support enclave rpc.
    * [x] Key manager client should support km->km.
    * [x] Fix the key manager grpc access control.