### PR TITLE
Key manager EnclaveRPC fixes

### DIFF
--- a/.changelog/2844.breaking.md
+++ b/.changelog/2844.breaking.md
@@ -1,0 +1,10 @@
+go/runtime/enclaverpc: Refactor gRPC endpoint routing
+
+Previously each endpoint required its own gRPC service. But since all
+EnclaveRPC requests already include an "endpoint" field, it is better to use
+that for routing requests.
+
+This commit adds a new enclaverpc.Endpoint interface that is used as an
+endpoint descriptor. All endpoints must be registered in advance (e.g.,
+during init). It also changes the key manager EnclaveRPC support to use the
+new API.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,7 +1379,9 @@ version = "0.3.0-alpha"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io-context 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "oasis-core-client 0.3.0-alpha",
+ "oasis-core-keymanager-client 0.3.0-alpha",
  "oasis-core-runtime 0.3.0-alpha",
  "simple-keyvalue-api 0.3.0-alpha",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/go/common/grpc/policy/policy.go
+++ b/go/common/grpc/policy/policy.go
@@ -48,11 +48,15 @@ func GRPCAuthenticationFunction(policy RuntimePolicyChecker) auth.Authentication
 			return status.Errorf(codes.PermissionDenied, "invalid request method")
 		}
 
-		if !md.IsAccessControlled(req) {
+		ac, err := md.IsAccessControlled(ctx, req)
+		if err != nil {
+			return status.Errorf(codes.PermissionDenied, "internal error: %s", err.Error())
+		}
+		if !ac {
 			return nil
 		}
 
-		namespace, err := md.ExtractNamespace(req)
+		namespace, err := md.ExtractNamespace(ctx, req)
 		if err != nil {
 			return status.Errorf(codes.PermissionDenied, "invalid request namespace")
 		}

--- a/go/common/grpc/service.go
+++ b/go/common/grpc/service.go
@@ -76,7 +76,7 @@ func (m *MethodDesc) WithNamespaceExtractor(f NamespaceExtractor) *MethodDesc {
 	return m
 }
 
-// WithAccessControl tells weather the endpoint does have access controll.
+// WithAccessControl tells weather the endpoint does have access control.
 func (m *MethodDesc) WithAccessControl(f func(req interface{}) bool) *MethodDesc {
 	m.accessControl = f
 	return m

--- a/go/common/grpc/testing/ping.go
+++ b/go/common/grpc/testing/ping.go
@@ -33,26 +33,26 @@ var (
 	serviceName = cmnGrpc.NewServiceName("PingService")
 	// MethodPing is the Ping method.
 	MethodPing = serviceName.NewMethod("Ping", PingQuery{}).
-			WithNamespaceExtractor(func(req interface{}) (common.Namespace, error) {
+			WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
 			r, ok := req.(*PingQuery)
 			if !ok {
 				return common.Namespace{}, errInvalidRequestType
 			}
 			return r.Namespace, nil
-		}).WithAccessControl(func(req interface{}) bool {
-		return true
+		}).WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
+		return true, nil
 	})
 
 	// MethodWatchPings is the WatchPings method.
 	MethodWatchPings = serviceName.NewMethod("WatchPings", PingQuery{}).
-				WithNamespaceExtractor(func(req interface{}) (common.Namespace, error) {
+				WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
 			r, ok := req.(*PingQuery)
 			if !ok {
 				return common.Namespace{}, errInvalidRequestType
 			}
 			return r.Namespace, nil
-		}).WithAccessControl(func(req interface{}) bool {
-		return true
+		}).WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
+		return true, nil
 	})
 )
 

--- a/go/keymanager/api/grpc.go
+++ b/go/keymanager/api/grpc.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/oasislabs/oasis-core/go/common/cbor"
@@ -11,46 +12,35 @@ var (
 	// Make sure this always matches the appropriate method in
 	// `keymanager-runtime/src/methods.rs`.
 	getPublicKeyRequestMethod = "get_public_key"
-
-	// requestSkipPolicyCheck defines if policy check is needed for the request.
-	requestSkipPolicyCheck = func(req interface{}) bool {
-		r, ok := req.(*enclaverpc.CallEnclaveRequest)
-		if !ok {
-			return false
-		}
-
-		// Check if policy access is needed.
-		skipPolicyCheck, err := payloadSkipPolicyCheck(r.Payload)
-		if err != nil {
-			return false
-		}
-
-		return skipPolicyCheck
-	}
-
-	// Service is the Keymanager enclave gRPC service.
-	Service = enclaverpc.NewService(ModuleName, requestSkipPolicyCheck)
 )
 
-func payloadSkipPolicyCheck(data cbor.RawMessage) (bool, error) {
+type enclaveRPCEndpoint struct {
+}
+
+// Implements enclaverpc.Endpoint.
+func (e *enclaveRPCEndpoint) AccessControlRequired(ctx context.Context, request *enclaverpc.CallEnclaveRequest) (bool, error) {
 	// Unpack the payload, get method from Frame.
 	var f enclaverpc.Frame
-	if err := cbor.Unmarshal(data, &f); err != nil {
-		return false, fmt.Errorf("unable to unpack Frame: %w", err)
+	if err := cbor.Unmarshal(request.Payload, &f); err != nil {
+		return false, fmt.Errorf("keymanager: unable to unpack EnclaveRPC frame: %w", err)
 	}
 
-	if f.UntrustedPlaintext == "" {
+	switch f.UntrustedPlaintext {
+	case "":
 		// Anyone can connect.
-		return true, nil
-	}
-
-	if f.UntrustedPlaintext == getPublicKeyRequestMethod {
+		return false, nil
+	case getPublicKeyRequestMethod:
 		// Anyone can get public keys.
+		//
 		// Note that this is also checked in the enclave, so if the node lied
 		// about what method it's using, we will know.
+		return false, nil
+	default:
+		// Defer to access control to check the policy.
 		return true, nil
 	}
+}
 
-	// Defer to access control to check the policy.
-	return false, nil
+func init() {
+	enclaverpc.NewEndpoint(EnclaveRPCEndpoint, &enclaveRPCEndpoint{})
 }

--- a/go/keymanager/client/client.go
+++ b/go/keymanager/client/client.go
@@ -69,8 +69,8 @@ func (c *Client) CallRemote(ctx context.Context, data []byte) ([]byte, error) {
 	call := func() error {
 		conn := c.committeeClient.GetConnection()
 		if conn == nil {
-			c.logger.Error("no key manager connection for runtime")
-			return backoff.Permanent(ErrKeyManagerNotAvailable)
+			c.logger.Warn("no key manager connection for runtime")
+			return ErrKeyManagerNotAvailable
 		}
 		client := enclaverpc.NewTransportClient(conn)
 

--- a/go/keymanager/client/client.go
+++ b/go/keymanager/client/client.go
@@ -72,7 +72,7 @@ func (c *Client) CallRemote(ctx context.Context, data []byte) ([]byte, error) {
 			c.logger.Error("no key manager connection for runtime")
 			return backoff.Permanent(ErrKeyManagerNotAvailable)
 		}
-		client := enclaverpc.NewTransportClient(api.Service, conn)
+		client := enclaverpc.NewTransportClient(conn)
 
 		var err error
 		resp, err = client.CallEnclave(ctx, &enclaverpc.CallEnclaveRequest{

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -32,7 +32,6 @@ import (
 	genesisTestHelpers "github.com/oasislabs/oasis-core/go/genesis/tests"
 	"github.com/oasislabs/oasis-core/go/ias"
 	iasAPI "github.com/oasislabs/oasis-core/go/ias/api"
-	keymanagerAPI "github.com/oasislabs/oasis-core/go/keymanager/api"
 	cmdCommon "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/background"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
@@ -45,6 +44,7 @@ import (
 	registryAPI "github.com/oasislabs/oasis-core/go/registry/api"
 	runtimeClient "github.com/oasislabs/oasis-core/go/runtime/client"
 	runtimeClientAPI "github.com/oasislabs/oasis-core/go/runtime/client/api"
+	enclaverpc "github.com/oasislabs/oasis-core/go/runtime/enclaverpc/api"
 	runtimeRegistry "github.com/oasislabs/oasis-core/go/runtime/registry"
 	scheduler "github.com/oasislabs/oasis-core/go/scheduler/api"
 	"github.com/oasislabs/oasis-core/go/sentry"
@@ -698,7 +698,7 @@ func newNode(testNode bool) (*Node, error) { // nolint: gocyclo
 	}
 	node.svcMgr.RegisterCleanupOnly(node.RuntimeClient, "client service")
 	runtimeClientAPI.RegisterService(node.grpcInternal.Server(), node.RuntimeClient)
-	keymanagerAPI.Service.RegisterService(node.grpcInternal.Server(), node.RuntimeClient)
+	enclaverpc.RegisterService(node.grpcInternal.Server(), node.RuntimeClient)
 
 	// Start metric server.
 	if err = metrics.Start(); err != nil {

--- a/go/runtime/client/api/grpc.go
+++ b/go/runtime/client/api/grpc.go
@@ -11,7 +11,6 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/errors"
 	cmnGrpc "github.com/oasislabs/oasis-core/go/common/grpc"
 	"github.com/oasislabs/oasis-core/go/common/pubsub"
-	keymanager "github.com/oasislabs/oasis-core/go/keymanager/api"
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
 	enclaverpc "github.com/oasislabs/oasis-core/go/runtime/enclaverpc/api"
@@ -527,9 +526,7 @@ func (c *runtimeClient) Cleanup() {
 // NewRuntimeClient creates a new gRPC runtime client service.
 func NewRuntimeClient(c *grpc.ClientConn) RuntimeClient {
 	return &runtimeClient{
-		/// XXX: keymanager is the only one that currently implements the gRPC client.
-		// In future, the client here should depend on the type of the node connecting to.
-		Transport: enclaverpc.NewTransportClient(keymanager.Service, c),
+		Transport: enclaverpc.NewTransportClient(c),
 		conn:      c,
 	}
 }

--- a/go/runtime/enclaverpc/api/api.go
+++ b/go/runtime/enclaverpc/api/api.go
@@ -5,7 +5,6 @@ import (
 	"context"
 
 	"github.com/oasislabs/oasis-core/go/common"
-	"github.com/oasislabs/oasis-core/go/common/cbor"
 )
 
 // Transport is the EnclaveRPC transport interface.
@@ -14,18 +13,27 @@ type Transport interface {
 	CallEnclave(ctx context.Context, request *CallEnclaveRequest) ([]byte, error)
 }
 
+// Endpoint is an EnclaveRPC endpoint descriptor.
+//
+// Endpoints may be registered using the `NewEndpoint` function.
+type Endpoint interface {
+	// AccessControlRequired returns true if access control policy lookup is required for a specific
+	// request. In case an error is returned the request is aborted.
+	AccessControlRequired(ctx context.Context, request *CallEnclaveRequest) (bool, error)
+}
+
 // CallEnclaveRequest is a CallEnclave request.
 type CallEnclaveRequest struct {
 	RuntimeID common.Namespace `json:"runtime_id"`
 	Endpoint  string           `json:"endpoint"`
 
 	// Payload is a CBOR-serialized Frame.
-	Payload cbor.RawMessage `json:"payload"`
+	Payload []byte `json:"payload"`
 }
 
 // Frame is an EnclaveRPC frame.
 //
-// It is the Go analog of the Rust RPC frame defined in client/src/rpc/client.rs.
+// It is the Go analog of the Rust RPC frame defined in client/src/rpc/types.rs.
 type Frame struct {
 	Session            []byte `json:"session,omitempty"`
 	UntrustedPlaintext string `json:"untrusted_plaintext,omitempty"`

--- a/go/runtime/enclaverpc/api/grpc.go
+++ b/go/runtime/enclaverpc/api/grpc.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"google.golang.org/grpc"
 
@@ -10,25 +11,56 @@ import (
 	cmnGrpc "github.com/oasislabs/oasis-core/go/common/grpc"
 )
 
-var errInvalidRequestType = fmt.Errorf("invalid request type")
+var (
+	errInvalidRequestType = fmt.Errorf("invalid request type")
 
-const (
-	serviceNameBase = "EnclaveRPC"
+	// ServiceName is the gRPC service name.
+	ServiceName = cmnGrpc.NewServiceName("EnclaveRPC")
 
-	methodCallEnclaveName = "CallEnclave"
+	// MethodCallEnclave is the CallEnclave method.
+	MethodCallEnclave = ServiceName.NewMethod("CallEnclave", CallEnclaveRequest{}).
+				WithNamespaceExtractor(func(req interface{}) (common.Namespace, error) {
+			r, ok := req.(*CallEnclaveRequest)
+			if !ok {
+				return common.Namespace{}, errInvalidRequestType
+			}
+			return r.RuntimeID, nil
+		}).
+		WithAccessControl(func(req interface{}) bool {
+			r, ok := req.(*CallEnclaveRequest)
+			if !ok {
+				return false //, errInvalidRequestType
+			}
+
+			endpoint, ok := registeredEndpoints.Load(r.Endpoint)
+			if !ok {
+				return false //, fmt.Errorf("enclaverpc: unsupported endpoint: %s", r.Endpoint)
+			}
+
+			// TODO: Make WithAccessControl accept a context and return an error.
+			ok, _ = endpoint.(Endpoint).AccessControlRequired(context.TODO(), r)
+			return ok
+		})
+
+	// serviceDesc is the gRPC service descriptor.
+	serviceDesc = grpc.ServiceDesc{
+		ServiceName: string(ServiceName),
+		HandlerType: (*Transport)(nil),
+		Methods: []grpc.MethodDesc{
+			{
+				MethodName: MethodCallEnclave.ShortName(),
+				Handler:    handlerCallEnclave,
+			},
+		},
+		Streams: []grpc.StreamDesc{},
+	}
+
+	// registeredEndpoints is a map of registered EnclaveRPC endpoints. It maps endpoint names
+	// to instances of the Endpoint interface.
+	registeredEndpoints sync.Map
 )
 
-// Service is the enclave RPC gRPC service.
-type Service struct {
-	// ServiceName is the EnclaveRPC service name.
-	ServiceName cmnGrpc.ServiceName
-	// MethodCallEnclave is the EnclaveRPC CallEnclave method descriptor.
-	MethodCallEnclave *cmnGrpc.MethodDesc
-	// ServiceDesc is the EnclaveRPC gRPC service descriptor.
-	ServiceDesc grpc.ServiceDesc
-}
-
-func (e *Service) handlerCallEnclave( // nolint: golint
+func handlerCallEnclave( // nolint: golint
 	srv interface{},
 	ctx context.Context,
 	dec func(interface{}) error,
@@ -43,7 +75,7 @@ func (e *Service) handlerCallEnclave( // nolint: golint
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: e.MethodCallEnclave.FullName(),
+		FullMethod: MethodCallEnclave.FullName(),
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(Transport).CallEnclave(ctx, req.(*CallEnclaveRequest))
@@ -52,59 +84,31 @@ func (e *Service) handlerCallEnclave( // nolint: golint
 }
 
 // RegisterService registers a new EnclaveRPC transport service with the given gRPC server.
-func (e *Service) RegisterService(server *grpc.Server, service Transport) {
-	server.RegisterService(&e.ServiceDesc, service)
+func RegisterService(server *grpc.Server, service Transport) {
+	server.RegisterService(&serviceDesc, service)
 }
 
-// NewService creates a new EnclaveRPC gRPC service.
-func NewService(serviceNamePrefix string, accessControl func(req interface{}) bool) *Service {
-	serviceName := cmnGrpc.NewServiceName(serviceNamePrefix + "." + serviceNameBase)
-
-	methodCallEnclave := serviceName.NewMethod(methodCallEnclaveName, CallEnclaveRequest{}).
-		WithNamespaceExtractor(func(req interface{}) (common.Namespace, error) {
-			r, ok := req.(*CallEnclaveRequest)
-			if !ok {
-				return common.Namespace{}, errInvalidRequestType
-			}
-			return r.RuntimeID, nil
-		}).
-		WithAccessControl(accessControl)
-
-	erpc := &Service{
-		ServiceName:       serviceName,
-		MethodCallEnclave: methodCallEnclave,
-		ServiceDesc: grpc.ServiceDesc{
-			ServiceName: string(serviceName),
-			HandlerType: (*Transport)(nil),
-			Methods:     []grpc.MethodDesc{},
-			Streams:     []grpc.StreamDesc{},
-		},
+// NewEndpoint registers a new EnclaveRPC endpoint.
+func NewEndpoint(name string, endpoint Endpoint) {
+	if _, isRegistered := registeredEndpoints.Load(name); isRegistered {
+		panic(fmt.Errorf("enclaverpc: endpoint already registered: %s", name))
 	}
-
-	erpc.ServiceDesc.Methods = []grpc.MethodDesc{
-		{
-			MethodName: methodCallEnclave.ShortName(),
-			Handler:    erpc.handlerCallEnclave,
-		},
-	}
-
-	return erpc
+	registeredEndpoints.Store(name, endpoint)
 }
 
 type transportClient struct {
-	conn    *grpc.ClientConn
-	service *Service
+	conn *grpc.ClientConn
 }
 
 func (c *transportClient) CallEnclave(ctx context.Context, request *CallEnclaveRequest) ([]byte, error) {
 	var rsp []byte
-	if err := c.conn.Invoke(ctx, c.service.MethodCallEnclave.FullName(), request, &rsp); err != nil {
+	if err := c.conn.Invoke(ctx, MethodCallEnclave.FullName(), request, &rsp); err != nil {
 		return nil, err
 	}
 	return rsp, nil
 }
 
 // NewTransportClient creates a new EnclaveRPC gRPC transport client service.
-func NewTransportClient(service *Service, c *grpc.ClientConn) Transport {
-	return &transportClient{c, service}
+func NewTransportClient(c *grpc.ClientConn) Transport {
+	return &transportClient{c}
 }

--- a/go/storage/api/grpc.go
+++ b/go/storage/api/grpc.go
@@ -28,93 +28,93 @@ var (
 	MethodSyncIterate = ServiceName.NewMethod("SyncIterate", IterateRequest{})
 	// MethodApply is the Apply method.
 	MethodApply = ServiceName.NewMethod("Apply", ApplyRequest{}).
-			WithNamespaceExtractor(func(req interface{}) (common.Namespace, error) {
+			WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
 			r, ok := req.(*ApplyRequest)
 			if !ok {
 				return common.Namespace{}, errInvalidRequestType
 			}
 			return r.Namespace, nil
 		}).
-		WithAccessControl(func(req interface{}) bool {
-			return true
+		WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
+			return true, nil
 		})
 
 	// MethodApplyBatch is the ApplyBatch method.
 	MethodApplyBatch = ServiceName.NewMethod("ApplyBatch", ApplyBatchRequest{}).
-				WithNamespaceExtractor(func(req interface{}) (common.Namespace, error) {
+				WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
 			r, ok := req.(*ApplyBatchRequest)
 			if !ok {
 				return common.Namespace{}, errInvalidRequestType
 			}
 			return r.Namespace, nil
 		}).
-		WithAccessControl(func(req interface{}) bool {
-			return true
+		WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
+			return true, nil
 		})
 
 	// MethodMerge is the Merge method.
 	MethodMerge = ServiceName.NewMethod("Merge", MergeRequest{}).
-			WithNamespaceExtractor(func(req interface{}) (common.Namespace, error) {
+			WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
 			r, ok := req.(*MergeRequest)
 			if !ok {
 				return common.Namespace{}, errInvalidRequestType
 			}
 			return r.Namespace, nil
 		}).
-		WithAccessControl(func(req interface{}) bool {
-			return true
+		WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
+			return true, nil
 		})
 
 	// MethodMergeBatch is the MergeBatch method.
 	MethodMergeBatch = ServiceName.NewMethod("MergeBatch", MergeBatchRequest{}).
-				WithNamespaceExtractor(func(req interface{}) (common.Namespace, error) {
+				WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
 			r, ok := req.(*MergeBatchRequest)
 			if !ok {
 				return common.Namespace{}, errInvalidRequestType
 			}
 			return r.Namespace, nil
 		}).
-		WithAccessControl(func(req interface{}) bool {
-			return true
+		WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
+			return true, nil
 		})
 
 	// MethodGetDiff is the GetDiff method.
 	MethodGetDiff = ServiceName.NewMethod("GetDiff", GetDiffRequest{}).
-			WithNamespaceExtractor(func(req interface{}) (common.Namespace, error) {
+			WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
 			r, ok := req.(*GetDiffRequest)
 			if !ok {
 				return common.Namespace{}, errInvalidRequestType
 			}
 			return r.StartRoot.Namespace, nil
 		}).
-		WithAccessControl(func(req interface{}) bool {
-			return true
+		WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
+			return true, nil
 		})
 
 	// MethodGetCheckpoints is the GetCheckpoints method.
 	MethodGetCheckpoints = ServiceName.NewMethod("GetCheckpoints", checkpoint.GetCheckpointsRequest{}).
-				WithNamespaceExtractor(func(req interface{}) (common.Namespace, error) {
+				WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
 			r, ok := req.(*checkpoint.GetCheckpointsRequest)
 			if !ok {
 				return common.Namespace{}, errInvalidRequestType
 			}
 			return r.Namespace, nil
 		}).
-		WithAccessControl(func(req interface{}) bool {
-			return true
+		WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
+			return true, nil
 		})
 
 	// MethodGetCheckpointChunk is the GetCheckpointChunk method.
 	MethodGetCheckpointChunk = ServiceName.NewMethod("GetCheckpointChunk", checkpoint.ChunkMetadata{}).
-					WithNamespaceExtractor(func(req interface{}) (common.Namespace, error) {
+					WithNamespaceExtractor(func(ctx context.Context, req interface{}) (common.Namespace, error) {
 			cm, ok := req.(*checkpoint.ChunkMetadata)
 			if !ok {
 				return common.Namespace{}, errInvalidRequestType
 			}
 			return cm.Root.Namespace, nil
 		}).
-		WithAccessControl(func(req interface{}) bool {
-			return true
+		WithAccessControl(func(ctx context.Context, req interface{}) (bool, error) {
+			return true, nil
 		})
 
 	// serviceDesc is the gRPC service descriptor.

--- a/go/worker/keymanager/init.go
+++ b/go/worker/keymanager/init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/common/node"
 	ias "github.com/oasislabs/oasis-core/go/ias/api"
 	"github.com/oasislabs/oasis-core/go/keymanager/api"
+	enclaverpc "github.com/oasislabs/oasis-core/go/runtime/enclaverpc/api"
 	"github.com/oasislabs/oasis-core/go/runtime/localstorage"
 	runtimeRegistry "github.com/oasislabs/oasis-core/go/runtime/registry"
 	workerCommon "github.com/oasislabs/oasis-core/go/worker/common"
@@ -73,7 +74,7 @@ func New(
 		initCh:       make(chan struct{}),
 		commonWorker: commonWorker,
 		backend:      backend,
-		grpcPolicy:   policy.NewDynamicRuntimePolicyChecker(api.Service.ServiceName, commonWorker.GrpcPolicyWatcher),
+		grpcPolicy:   policy.NewDynamicRuntimePolicyChecker(enclaverpc.ServiceName, commonWorker.GrpcPolicyWatcher),
 		enabled:      Enabled(),
 		mayGenerate:  viper.GetBool(CfgMayGenerate),
 	}
@@ -120,7 +121,7 @@ func New(
 		}
 
 		// Register the Keymanager EnclaveRPC transport gRPC service.
-		api.Service.RegisterService(w.commonWorker.Grpc.Server(), w)
+		enclaverpc.RegisterService(w.commonWorker.Grpc.Server(), w)
 	}
 
 	return w, nil

--- a/go/worker/keymanager/policy.go
+++ b/go/worker/keymanager/policy.go
@@ -2,28 +2,29 @@ package keymanager
 
 import (
 	"github.com/oasislabs/oasis-core/go/common/accessctl"
-	"github.com/oasislabs/oasis-core/go/keymanager/api"
+	enclaverpc "github.com/oasislabs/oasis-core/go/runtime/enclaverpc/api"
 	"github.com/oasislabs/oasis-core/go/worker/common/committee"
 )
 
 // Only members of the current executor committee and other key manager nodes
 // can make gRPC calls to the key manager.
+//
 // Note that everyone can make `get_public_key` calls, this check is done by
-// the `keymanager/api/.mustAllowAccess` function.
+// the key manager EnclaveRPC endpoint registered in `go/keymanager/api/grpc.go`.
 var (
 	executorCommitteePolicy = &committee.AccessPolicy{
 		Actions: []accessctl.Action{
-			accessctl.Action(api.Service.MethodCallEnclave.FullName()),
+			accessctl.Action(enclaverpc.MethodCallEnclave.FullName()),
 		},
 	}
 	kmNodesPolicy = &committee.AccessPolicy{
 		Actions: []accessctl.Action{
-			accessctl.Action(api.Service.MethodCallEnclave.FullName()),
+			accessctl.Action(enclaverpc.MethodCallEnclave.FullName()),
 		},
 	}
 	sentryNodesPolicy = &committee.AccessPolicy{
 		Actions: []accessctl.Action{
-			accessctl.Action(api.Service.MethodCallEnclave.FullName()),
+			accessctl.Action(enclaverpc.MethodCallEnclave.FullName()),
 		},
 	}
 )

--- a/keymanager-api-common/src/api.rs
+++ b/keymanager-api-common/src/api.rs
@@ -173,7 +173,7 @@ impl InputKeyPair {
 pub const PUBLIC_KEY_CONTEXT: [u8; 8] = *b"EkKmPubK";
 
 /// Signed public key.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SignedPublicKey {
     /// Public key.
     pub key: PublicKey,

--- a/keymanager-client/src/client.rs
+++ b/keymanager-client/src/client.rs
@@ -97,6 +97,9 @@ impl RemoteClient {
         #[cfg(target_env = "sgx")]
         set_trusted_policy_signers(signers);
 
+        #[cfg(not(target_env = "sgx"))]
+        let _ = signers;
+
         #[cfg(target_env = "sgx")]
         let enclaves: Option<HashSet<EnclaveIdentity>> = match protocol
             .make_request(Context::background(), Body::HostKeyManagerPolicyRequest {})

--- a/tests/clients/simple-keyvalue-enc/Cargo.toml
+++ b/tests/clients/simple-keyvalue-enc/Cargo.toml
@@ -3,11 +3,14 @@ name = "simple-keyvalue-enc-client"
 version = "0.3.0-alpha"
 authors = ["Oasis Labs Inc. <info@oasislabs.com>"]
 description = "Encrypted key value test client"
+edition = "2018"
 
 [dependencies]
 oasis-core-client = { path = "../../../client" }
 oasis-core-runtime = { path = "../../../runtime" }
+oasis-core-keymanager-client = { path = "../../../keymanager-client" }
 simple-keyvalue-api = { path = "../../runtimes/simple-keyvalue/api" }
 clap = "2.29.1"
 tokio = "0.1.17"
 grpcio = "0.4.6"
+io-context = "0.2.0"

--- a/tests/clients/simple-keyvalue-ops/Cargo.toml
+++ b/tests/clients/simple-keyvalue-ops/Cargo.toml
@@ -3,6 +3,7 @@ name = "simple-keyvalue-ops-client"
 version = "0.3.0-alpha"
 authors = ["Oasis Labs Inc. <info@oasislabs.com>"]
 description = "Simple key value operation test client"
+edition = "2018"
 
 [dependencies]
 oasis-core-client = { path = "../../../client" }

--- a/tests/clients/simple-keyvalue-ops/src/main.rs
+++ b/tests/clients/simple-keyvalue-ops/src/main.rs
@@ -1,14 +1,6 @@
-#[macro_use]
-extern crate clap;
-extern crate grpcio;
-extern crate oasis_core_client;
-extern crate oasis_core_runtime;
-extern crate simple_keyvalue_api;
-extern crate tokio;
-
 use std::sync::Arc;
 
-use clap::{App, Arg, SubCommand};
+use clap::{value_t_or_exit, App, Arg, SubCommand};
 use grpcio::EnvBuilder;
 use tokio::runtime::Runtime;
 

--- a/tests/clients/simple-keyvalue/Cargo.toml
+++ b/tests/clients/simple-keyvalue/Cargo.toml
@@ -3,6 +3,7 @@ name = "simple-keyvalue-client"
 version = "0.3.0-alpha"
 authors = ["Oasis Labs Inc. <info@oasislabs.com>"]
 description = "Key value test client"
+edition = "2018"
 
 [dependencies]
 oasis-core-client = { path = "../../../client" }

--- a/tests/clients/test-long-term/Cargo.toml
+++ b/tests/clients/test-long-term/Cargo.toml
@@ -3,6 +3,7 @@ name = "test-long-term-client"
 version = "0.3.0-alpha"
 authors = ["Oasis Labs Inc. <info@oasislabs.com>"]
 description = "Key value test client"
+edition = "2018"
 
 [dependencies]
 oasis-core-client = { path = "../../../client" }

--- a/tests/clients/test-long-term/src/main.rs
+++ b/tests/clients/test-long-term/src/main.rs
@@ -1,14 +1,6 @@
-#[macro_use]
-extern crate clap;
-extern crate grpcio;
-extern crate oasis_core_client;
-extern crate oasis_core_runtime;
-extern crate simple_keyvalue_api;
-extern crate tokio;
-
 use std::{sync::Arc, thread, time};
 
-use clap::{App, Arg};
+use clap::{value_t_or_exit, App, Arg};
 use grpcio::EnvBuilder;
 use tokio::runtime::Runtime;
 

--- a/tests/runtimes/simple-keyvalue/src/main.rs
+++ b/tests/runtimes/simple-keyvalue/src/main.rs
@@ -1,10 +1,3 @@
-extern crate failure;
-extern crate io_context;
-extern crate oasis_core_keymanager_api_common;
-extern crate oasis_core_keymanager_client;
-extern crate oasis_core_runtime;
-extern crate simple_keyvalue_api;
-
 use std::sync::Arc;
 
 use failure::{format_err, Fallible};


### PR DESCRIPTION
* go/runtime/enclaverpc: Refactor gRPC endpoint routing
  
  Previously each endpoint required its own gRPC service. But since all EnclaveRPC
  requests already include an "endpoint" field, it is better to use that for
  routing requests.
  
  This commit adds a new enclaverpc.Endpoint interface that is used as an endpoint
  descriptor. All endpoints must be registered in advance (e.g., during init). It
  also changes the key manager EnclaveRPC support to use the new API.
  
  Since it changes the gRPC service name this BREAKS the committee gRPC protocol.

* tests/clients/simple-keyvalue-enc: Test the key manager client via gRPC
  
  Previously we only tested the runtime transport for the key manager so this adds
  a test that also tests the gRPC transport.