### PR TITLE
go/oasis-test-runner: Test dynamic KM runtime registration

### DIFF
--- a/go/consensus/tendermint/apps/keymanager/keymanager.go
+++ b/go/consensus/tendermint/apps/keymanager/keymanager.go
@@ -19,6 +19,7 @@ import (
 	stakingState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/staking/state"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	"github.com/oasislabs/oasis-core/go/keymanager/api"
+	keymanager "github.com/oasislabs/oasis-core/go/keymanager/api"
 	registry "github.com/oasislabs/oasis-core/go/registry/api"
 )
 
@@ -37,7 +38,7 @@ func (app *keymanagerApplication) ID() uint8 {
 }
 
 func (app *keymanagerApplication) Methods() []transaction.MethodName {
-	return nil
+	return keymanager.Methods
 }
 
 func (app *keymanagerApplication) Blessed() bool {

--- a/go/keymanager/api/policy_sgx.go
+++ b/go/keymanager/api/policy_sgx.go
@@ -32,7 +32,7 @@ type EnclavePolicySGX struct {
 	//
 	// TODO: This could be made more sophisticated and seggregate based on
 	// contract ID as well, but for now punt on the added complexity.
-	MayQuery map[signature.PublicKey][]sgx.EnclaveIdentity `json:"may_query"`
+	MayQuery map[common.Namespace][]sgx.EnclaveIdentity `json:"may_query"`
 
 	// MayReplicate is the vector of enclave IDs that may retrieve the master
 	// secret (Note: Each enclave ID may always implicitly replicate from other

--- a/go/oasis-node/cmd/keymanager/keymanager.go
+++ b/go/oasis-node/cmd/keymanager/keymanager.go
@@ -28,22 +28,22 @@ import (
 )
 
 const (
-	cfgPolicySerial       = "keymanager.policy.serial"
-	cfgPolicyID           = "keymanager.policy.id"
-	cfgPolicyFile         = "keymanager.policy.file"
-	cfgPolicyEnclaveID    = "keymanager.policy.enclave.id"
-	cfgPolicyMayQuery     = "keymanager.policy.may.query"
-	cfgPolicyMayReplicate = "keymanager.policy.may.replicate"
-	cfgPolicyKeyFile      = "keymanager.policy.key.file"
-	cfgPolicyTestKey      = "keymanager.policy.testkey"
-	cfgPolicySigFile      = "keymanager.policy.signature.file"
-	cfgPolicyIgnoreSig    = "keymanager.policy.ignore.signature"
+	CfgPolicySerial       = "keymanager.policy.serial"
+	CfgPolicyID           = "keymanager.policy.id"
+	CfgPolicyFile         = "keymanager.policy.file"
+	CfgPolicyEnclaveID    = "keymanager.policy.enclave.id"
+	CfgPolicyMayQuery     = "keymanager.policy.may.query"
+	CfgPolicyMayReplicate = "keymanager.policy.may.replicate"
+	CfgPolicyKeyFile      = "keymanager.policy.key.file"
+	CfgPolicyTestKey      = "keymanager.policy.testkey"
+	CfgPolicySigFile      = "keymanager.policy.signature.file"
+	CfgPolicyIgnoreSig    = "keymanager.policy.ignore.signature"
 
-	cfgStatusFile        = "keymanager.status.file"
-	cfgStatusID          = "keymanager.status.id"
-	cfgStatusInitialized = "keymanager.status.initialized"
-	cfgStatusSecure      = "keymanager.status.secure"
-	cfgStatusChecksum    = "keymanager.status.checksum"
+	CfgStatusFile        = "keymanager.status.file"
+	CfgStatusID          = "keymanager.status.id"
+	CfgStatusInitialized = "keymanager.status.initialized"
+	CfgStatusSecure      = "keymanager.status.secure"
+	CfgStatusChecksum    = "keymanager.status.checksum"
 
 	policyFilename = "km_policy.cbor"
 	statusFilename = "km_status.json"
@@ -102,10 +102,10 @@ func doInitPolicy(cmd *cobra.Command, args []string) {
 	}
 
 	c := cbor.Marshal(p)
-	if err = ioutil.WriteFile(viper.GetString(cfgPolicyFile), c, 0666); err != nil {
+	if err = ioutil.WriteFile(viper.GetString(CfgPolicyFile), c, 0666); err != nil {
 		logger.Error("failed to write key manager policy cbor file",
 			"err", err,
-			"cfgPolicyFile", viper.GetString(cfgPolicyFile),
+			"CfgPolicyFile", viper.GetString(CfgPolicyFile),
 		)
 		os.Exit(1)
 	}
@@ -117,15 +117,15 @@ func doInitPolicy(cmd *cobra.Command, args []string) {
 
 func policyFromFlags() (*kmApi.PolicySGX, error) {
 	var id common.Namespace
-	if err := id.UnmarshalHex(viper.GetString(cfgPolicyID)); err != nil {
+	if err := id.UnmarshalHex(viper.GetString(CfgPolicyID)); err != nil {
 		logger.Error("failed to parse key manager runtime ID",
 			"err", err,
-			"cfgPolicyID", viper.GetString(cfgPolicyID),
+			"CfgPolicyID", viper.GetString(CfgPolicyID),
 		)
 		return nil, err
 	}
 
-	serial := viper.GetUint32(cfgPolicySerial)
+	serial := viper.GetUint32(CfgPolicySerial)
 
 	enclaves := make(map[sgx.EnclaveIdentity]*kmApi.EnclavePolicySGX)
 
@@ -133,7 +133,7 @@ func policyFromFlags() (*kmApi.PolicySGX, error) {
 	// Since viper doesn't store order of arguments, go through os.Args by hand,
 	// find --keymanager.policy.enclave.id and construct its permissions.
 	for curArgIdx, curArg := range os.Args {
-		if curArg == "--"+cfgPolicyEnclaveID {
+		if curArg == "--"+CfgPolicyEnclaveID {
 			kmEnclaveIDStr := os.Args[curArgIdx+1]
 			kmEnclaveID := sgx.EnclaveIdentity{}
 			if err := kmEnclaveID.UnmarshalHex(kmEnclaveIDStr); err != nil {
@@ -145,17 +145,17 @@ func policyFromFlags() (*kmApi.PolicySGX, error) {
 
 			enclaves[kmEnclaveID] = &kmApi.EnclavePolicySGX{
 				MayReplicate: []sgx.EnclaveIdentity{},
-				MayQuery:     make(map[signature.PublicKey][]sgx.EnclaveIdentity),
+				MayQuery:     make(map[common.Namespace][]sgx.EnclaveIdentity),
 			}
 
 			for curArgIdx = curArgIdx + 2; curArgIdx < len(os.Args); curArgIdx++ {
 				// Break, if the next enclave-id is caught.
-				if os.Args[curArgIdx] == "--"+cfgPolicyEnclaveID {
+				if os.Args[curArgIdx] == "--"+CfgPolicyEnclaveID {
 					break
 				}
 
 				// Catch --keymanager.policy.may.replicate option
-				if os.Args[curArgIdx] == "--"+cfgPolicyMayReplicate {
+				if os.Args[curArgIdx] == "--"+CfgPolicyMayReplicate {
 					replicateStr := os.Args[curArgIdx+1]
 					for _, r := range strings.Split(replicateStr, ",") {
 						replEnclaveID := sgx.EnclaveIdentity{}
@@ -171,11 +171,11 @@ func policyFromFlags() (*kmApi.PolicySGX, error) {
 				}
 
 				// Catch --keymanager.policy.may.query option
-				if os.Args[curArgIdx] == "--"+cfgPolicyMayQuery {
+				if os.Args[curArgIdx] == "--"+CfgPolicyMayQuery {
 					queryStr := os.Args[curArgIdx+1]
 
 					qRuntimeIDStr := strings.Split(queryStr, "=")[0]
-					var qRuntimeID signature.PublicKey
+					var qRuntimeID common.Namespace
 					if err := qRuntimeID.UnmarshalHex(qRuntimeIDStr); err != nil {
 						logger.Error("failed to parse may-query runtime ID",
 							"err", err,
@@ -231,10 +231,10 @@ func doSignPolicy(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	if err = ioutil.WriteFile(viper.GetStringSlice(cfgPolicySigFile)[0], sigBytes, 0600); err != nil {
+	if err = ioutil.WriteFile(viper.GetStringSlice(CfgPolicySigFile)[0], sigBytes, 0600); err != nil {
 		logger.Error("failed to write policy file signature",
 			"err", err,
-			"cfgPolicySigFile", viper.GetStringSlice(cfgPolicySigFile),
+			"CfgPolicySigFile", viper.GetStringSlice(CfgPolicySigFile),
 		)
 		os.Exit(1)
 	}
@@ -243,29 +243,29 @@ func doSignPolicy(cmd *cobra.Command, args []string) {
 func signPolicyFromFlags() (*signature.Signature, error) {
 	var signer signature.Signer
 	var err error
-	if viper.GetString(cfgPolicyKeyFile) != "" {
+	if viper.GetString(CfgPolicyKeyFile) != "" {
 		var signerFactory signature.SignerFactory
 		signerFactory, err = fileSigner.NewFactory("", signature.SignerUnknown)
 		if err != nil {
 			return nil, err
 		}
-		signer, err = signerFactory.(*fileSigner.Factory).ForceLoad(viper.GetString(cfgPolicyKeyFile))
+		signer, err = signerFactory.(*fileSigner.Factory).ForceLoad(viper.GetString(CfgPolicyKeyFile))
 		if err != nil {
 			return nil, err
 		}
-	} else if viper.GetUint(cfgPolicyTestKey) != 0 {
+	} else if viper.GetUint(CfgPolicyTestKey) != 0 {
 		if !cmdFlags.DebugDontBlameOasis() {
 			return nil, errors.New("refusing to use test keys for signing")
 		}
-		if viper.GetUint(cfgPolicyTestKey) > uint(len(kmApi.TestSigners)) {
+		if viper.GetUint(CfgPolicyTestKey) > uint(len(kmApi.TestSigners)) {
 			return nil, errors.New("test key index invalid")
 		}
-		signer = kmApi.TestSigners[viper.GetUint(cfgPolicyTestKey)-1]
+		signer = kmApi.TestSigners[viper.GetUint(CfgPolicyTestKey)-1]
 	} else {
 		return nil, errors.New("no private key file or test key provided")
 	}
 
-	policyBytes, err := ioutil.ReadFile(viper.GetString(cfgPolicyFile))
+	policyBytes, err := ioutil.ReadFile(viper.GetString(CfgPolicyFile))
 	if err != nil {
 		return nil, err
 	}
@@ -303,7 +303,7 @@ func doVerifyPolicy(cmd *cobra.Command, args []string) {
 }
 
 func verifyPolicyFromFlags() error {
-	policyBytes, err := ioutil.ReadFile(viper.GetString(cfgPolicyFile))
+	policyBytes, err := ioutil.ReadFile(viper.GetString(CfgPolicyFile))
 	if err != nil {
 		return err
 	}
@@ -322,8 +322,8 @@ func verifyPolicyFromFlags() error {
 
 	// Check the signatures of the policy. Public key is taken from the PEM
 	// signature file.
-	if !viper.GetBool(cfgPolicyIgnoreSig) {
-		for _, sigFile := range viper.GetStringSlice(cfgPolicySigFile) {
+	if !viper.GetBool(CfgPolicyIgnoreSig) {
+		for _, sigFile := range viper.GetStringSlice(CfgPolicySigFile) {
 			policySigBytes, err := ioutil.ReadFile(sigFile)
 			if err != nil {
 				return err
@@ -373,10 +373,10 @@ func doInitStatus(cmd *cobra.Command, args []string) {
 	}
 
 	c, _ := json.Marshal(s)
-	if err = ioutil.WriteFile(viper.GetString(cfgStatusFile), c, 0666); err != nil {
+	if err = ioutil.WriteFile(viper.GetString(CfgStatusFile), c, 0666); err != nil {
 		logger.Error("failed to write key manager status json file",
 			"err", err,
-			"cfgStatusFile", viper.GetString(cfgStatusFile),
+			"CfgStatusFile", viper.GetString(CfgStatusFile),
 		)
 		os.Exit(1)
 	}
@@ -398,21 +398,21 @@ func doGenUpdate(cmd *cobra.Command, args []string) {
 	// signatures.
 	var signedPolicy kmApi.SignedPolicySGX
 
-	policyBytes, err := ioutil.ReadFile(viper.GetString(cfgPolicyFile))
+	policyBytes, err := ioutil.ReadFile(viper.GetString(CfgPolicyFile))
 	if err != nil {
 		logger.Error("failed to read policy file",
 			"err", err,
 		)
 		os.Exit(1)
 	}
-	if err = json.Unmarshal(policyBytes, &signedPolicy.Policy); err != nil {
+	if err = cbor.Unmarshal(policyBytes, &signedPolicy.Policy); err != nil {
 		logger.Error("failed to unmarshal policy file",
 			"err", err,
 		)
 		os.Exit(1)
 	}
 
-	for _, sigFile := range viper.GetStringSlice(cfgPolicySigFile) {
+	for _, sigFile := range viper.GetStringSlice(CfgPolicySigFile) {
 		var policySigBytes []byte
 		if policySigBytes, err = ioutil.ReadFile(sigFile); err != nil {
 			logger.Error("failed to read signature file",
@@ -449,18 +449,18 @@ func doGenUpdate(cmd *cobra.Command, args []string) {
 
 func statusFromFlags() (*kmApi.Status, error) {
 	var id common.Namespace
-	if err := id.UnmarshalHex(viper.GetString(cfgStatusID)); err != nil {
+	if err := id.UnmarshalHex(viper.GetString(CfgStatusID)); err != nil {
 		logger.Error("failed to parse key manager status ID",
 			"err", err,
-			"cfgStatusID", viper.GetString(cfgStatusID),
+			"CfgStatusID", viper.GetString(CfgStatusID),
 		)
 		return nil, err
 	}
 
 	// Unmarshal KM policy and its signatures.
 	var signedPolicy *kmApi.SignedPolicySGX
-	if viper.GetString(cfgPolicyFile) != "" {
-		pb, err := ioutil.ReadFile(viper.GetString(cfgPolicyFile))
+	if viper.GetString(CfgPolicyFile) != "" {
+		pb, err := ioutil.ReadFile(viper.GetString(CfgPolicyFile))
 		if err != nil {
 			return nil, err
 		}
@@ -473,7 +473,7 @@ func statusFromFlags() (*kmApi.Status, error) {
 			Policy: *p,
 		}
 
-		for _, sigFile := range viper.GetStringSlice(cfgPolicySigFile) {
+		for _, sigFile := range viper.GetStringSlice(CfgPolicySigFile) {
 			sigBytes, err := ioutil.ReadFile(sigFile)
 			if err != nil {
 				return nil, err
@@ -489,9 +489,9 @@ func statusFromFlags() (*kmApi.Status, error) {
 	}
 
 	checksum := []byte{}
-	if viper.GetString(cfgStatusChecksum) != "" {
+	if viper.GetString(CfgStatusChecksum) != "" {
 		var err error
-		checksum, err = hex.DecodeString(viper.GetString(cfgStatusChecksum))
+		checksum, err = hex.DecodeString(viper.GetString(CfgStatusChecksum))
 		if err != nil {
 			return nil, err
 		}
@@ -500,18 +500,18 @@ func statusFromFlags() (*kmApi.Status, error) {
 		}
 	}
 
-	if viper.GetString(cfgStatusChecksum) != "" && !viper.GetBool(cfgStatusInitialized) {
-		return nil, fmt.Errorf("%s provided, but %s is false", cfgStatusChecksum, cfgStatusInitialized)
+	if viper.GetString(CfgStatusChecksum) != "" && !viper.GetBool(CfgStatusInitialized) {
+		return nil, fmt.Errorf("%s provided, but %s is false", CfgStatusChecksum, CfgStatusInitialized)
 	}
 
-	if viper.GetString(cfgStatusChecksum) == "" && viper.GetBool(cfgStatusInitialized) {
-		return nil, fmt.Errorf("%s is true, but %s is not provided", cfgStatusInitialized, cfgStatusChecksum)
+	if viper.GetString(CfgStatusChecksum) == "" && viper.GetBool(CfgStatusInitialized) {
+		return nil, fmt.Errorf("%s is true, but %s is not provided", CfgStatusInitialized, CfgStatusChecksum)
 	}
 
 	return &kmApi.Status{
 		ID:            id,
-		IsInitialized: viper.GetBool(cfgStatusInitialized),
-		IsSecure:      viper.GetBool(cfgStatusSecure),
+		IsInitialized: viper.GetBool(CfgStatusInitialized),
+		IsSecure:      viper.GetBool(CfgStatusSecure),
 		Checksum:      checksum,
 		Policy:        signedPolicy,
 	}, nil
@@ -519,28 +519,28 @@ func statusFromFlags() (*kmApi.Status, error) {
 
 func registerKMInitPolicyFlags(cmd *cobra.Command) {
 	if !cmd.Flags().Parsed() {
-		cmd.Flags().Uint32(cfgPolicySerial, 0, "monotonically increasing number of the policy")
-		cmd.Flags().String(cfgPolicyID, "", "256-bit Runtime ID this policy is valid for in hex")
-		cmd.Flags().String(cfgPolicyEnclaveID, "", "512-bit Key Manager Enclave ID in hex (concatenated MRENCLAVE and MRSIGNER). Multiple Enclave IDs with corresponding permissions can be provided respectively.")
-		cmd.Flags().StringSlice(cfgPolicyMayReplicate, []string{}, "enclave_id1,enclave_id2... list of new enclaves which are allowed to access the master secret. Requires "+cfgPolicyEnclaveID)
-		cmd.Flags().StringToString(cfgPolicyMayQuery, map[string]string{}, "runtime_id=enclave_id1,enclave_id2... sets enclave query permission for runtime_id. Requires "+cfgPolicyEnclaveID)
+		cmd.Flags().Uint32(CfgPolicySerial, 0, "monotonically increasing number of the policy")
+		cmd.Flags().String(CfgPolicyID, "", "256-bit Runtime ID this policy is valid for in hex")
+		cmd.Flags().String(CfgPolicyEnclaveID, "", "512-bit Key Manager Enclave ID in hex (concatenated MRENCLAVE and MRSIGNER). Multiple Enclave IDs with corresponding permissions can be provided respectively.")
+		cmd.Flags().StringSlice(CfgPolicyMayReplicate, []string{}, "enclave_id1,enclave_id2... list of new enclaves which are allowed to access the master secret. Requires "+CfgPolicyEnclaveID)
+		cmd.Flags().StringToString(CfgPolicyMayQuery, map[string]string{}, "runtime_id=enclave_id1,enclave_id2... sets enclave query permission for runtime_id. Requires "+CfgPolicyEnclaveID)
 	}
 
 	cmd.Flags().AddFlagSet(policyFileFlag)
 
 	for _, v := range []string{
-		cfgPolicySerial,
-		cfgPolicyID,
+		CfgPolicySerial,
+		CfgPolicyID,
 	} {
 		_ = cmd.MarkFlagRequired(v)
 	}
 
 	for _, v := range []string{
-		cfgPolicySerial,
-		cfgPolicyID,
-		cfgPolicyEnclaveID,
-		cfgPolicyMayReplicate,
-		cfgPolicyMayQuery,
+		CfgPolicySerial,
+		CfgPolicyID,
+		CfgPolicyEnclaveID,
+		CfgPolicyMayReplicate,
+		CfgPolicyMayQuery,
 	} {
 		_ = viper.BindPFlag(v, cmd.Flags().Lookup(v))
 	}
@@ -548,9 +548,9 @@ func registerKMInitPolicyFlags(cmd *cobra.Command) {
 
 func registerKMSignPolicyFlags(cmd *cobra.Command) {
 	if !cmd.Flags().Parsed() {
-		cmd.Flags().String(cfgPolicyKeyFile, "", "input file name containing client key")
-		cmd.Flags().Uint(cfgPolicyTestKey, 0, "index of test key to use (for debugging only) counting from 1")
-		_ = cmd.Flags().MarkHidden(cfgPolicyTestKey)
+		cmd.Flags().String(CfgPolicyKeyFile, "", "input file name containing client key")
+		cmd.Flags().Uint(CfgPolicyTestKey, 0, "index of test key to use (for debugging only) counting from 1")
+		_ = cmd.Flags().MarkHidden(CfgPolicyTestKey)
 	}
 
 	cmd.Flags().AddFlagSet(policyFileFlag)
@@ -558,8 +558,8 @@ func registerKMSignPolicyFlags(cmd *cobra.Command) {
 	cmd.Flags().AddFlagSet(cmdFlags.DebugDontBlameOasisFlag)
 
 	for _, v := range []string{
-		cfgPolicyKeyFile,
-		cfgPolicyTestKey,
+		CfgPolicyKeyFile,
+		CfgPolicyTestKey,
 	} {
 		_ = viper.BindPFlag(v, cmd.Flags().Lookup(v))
 	}
@@ -567,7 +567,7 @@ func registerKMSignPolicyFlags(cmd *cobra.Command) {
 
 func registerKMVerifyPolicyFlags(cmd *cobra.Command) {
 	if !cmd.Flags().Parsed() {
-		cmd.Flags().Bool(cfgPolicyIgnoreSig, false, "just check, if policy file is well formed and ignore signature file")
+		cmd.Flags().Bool(CfgPolicyIgnoreSig, false, "just check, if policy file is well formed and ignore signature file")
 	}
 
 	cmd.Flags().AddFlagSet(cmdFlags.VerboseFlags)
@@ -575,7 +575,7 @@ func registerKMVerifyPolicyFlags(cmd *cobra.Command) {
 	cmd.Flags().AddFlagSet(policySigFileFlag)
 
 	for _, v := range []string{
-		cfgPolicyIgnoreSig,
+		CfgPolicyIgnoreSig,
 	} {
 		_ = viper.BindPFlag(v, cmd.Flags().Lookup(v))
 	}
@@ -583,28 +583,28 @@ func registerKMVerifyPolicyFlags(cmd *cobra.Command) {
 
 func registerKMInitStatusFlags(cmd *cobra.Command) {
 	if !cmd.Flags().Parsed() {
-		cmd.Flags().String(cfgStatusID, "", "256-bit Runtime ID this status is valid for in hex")
-		cmd.Flags().String(cfgStatusFile, statusFilename, "JSON output file name of status to be written")
-		cmd.Flags().Bool(cfgStatusInitialized, false, "is key manager done initializing. Requires "+cfgStatusChecksum)
-		cmd.Flags().Bool(cfgStatusSecure, false, "is key manager secure")
-		cmd.Flags().String(cfgStatusChecksum, "", "key manager's master secret verification checksum in hex. Requires "+cfgStatusInitialized)
+		cmd.Flags().String(CfgStatusID, "", "256-bit Runtime ID this status is valid for in hex")
+		cmd.Flags().String(CfgStatusFile, statusFilename, "JSON output file name of status to be written")
+		cmd.Flags().Bool(CfgStatusInitialized, false, "is key manager done initializing. Requires "+CfgStatusChecksum)
+		cmd.Flags().Bool(CfgStatusSecure, false, "is key manager secure")
+		cmd.Flags().String(CfgStatusChecksum, "", "key manager's master secret verification checksum in hex. Requires "+CfgStatusInitialized)
 	}
 
 	cmd.Flags().AddFlagSet(policyFileFlag)
 	cmd.Flags().AddFlagSet(policySigFileFlag)
 
 	for _, v := range []string{
-		cfgStatusID,
+		CfgStatusID,
 	} {
 		_ = cmd.MarkFlagRequired(v)
 	}
 
 	for _, v := range []string{
-		cfgStatusID,
-		cfgStatusFile,
-		cfgStatusInitialized,
-		cfgStatusSecure,
-		cfgStatusChecksum,
+		CfgStatusID,
+		CfgStatusFile,
+		CfgStatusInitialized,
+		CfgStatusSecure,
+		CfgStatusChecksum,
 	} {
 		_ = viper.BindPFlag(v, cmd.Flags().Lookup(v))
 	}
@@ -612,8 +612,8 @@ func registerKMInitStatusFlags(cmd *cobra.Command) {
 
 // Register registers the keymanager sub-command and all of it's children.
 func Register(parentCmd *cobra.Command) {
-	policyFileFlag.String(cfgPolicyFile, policyFilename, "file name of policy in CBOR format")
-	policySigFileFlag.StringSlice(cfgPolicySigFile, []string{policyFilename + ".sign"}, "file name(s) containing policy signature")
+	policyFileFlag.String(CfgPolicyFile, policyFilename, "file name of policy in CBOR format")
+	policySigFileFlag.StringSlice(CfgPolicySigFile, []string{policyFilename + ".sign"}, "file name(s) containing policy signature")
 
 	_ = viper.BindPFlags(policyFileFlag)
 	_ = viper.BindPFlags(policySigFileFlag)
@@ -632,6 +632,10 @@ func Register(parentCmd *cobra.Command) {
 	registerKMSignPolicyFlags(signPolicyCmd)
 	registerKMVerifyPolicyFlags(verifyPolicyCmd)
 	registerKMInitStatusFlags(initStatusCmd)
+
+	genUpdateCmd.Flags().AddFlagSet(policyFileFlag)
+	genUpdateCmd.Flags().AddFlagSet(policySigFileFlag)
+	genUpdateCmd.Flags().AddFlagSet(cmdConsensus.TxFlags)
 
 	parentCmd.AddCommand(keyManagerCmd)
 }

--- a/go/oasis-test-runner/oasis/cli/cli.go
+++ b/go/oasis-test-runner/oasis/cli/cli.go
@@ -29,8 +29,9 @@ func (b *helpersBase) runSubCommandWithOutput(name string, args []string) (bytes
 
 // Helpers are the oasis-node cli helpers.
 type Helpers struct {
-	Consensus *ConsensusHelpers
-	Registry  *RegistryHelpers
+	Consensus  *ConsensusHelpers
+	Registry   *RegistryHelpers
+	Keymanager *KeymanagerHelpers
 }
 
 // New creates new oasis-node cli helpers.
@@ -42,8 +43,9 @@ func New(env *env.Env, net *oasis.Network, logger *logging.Logger) *Helpers {
 	}
 
 	return &Helpers{
-		Consensus: &ConsensusHelpers{base},
-		Registry:  &RegistryHelpers{base},
+		Consensus:  &ConsensusHelpers{base},
+		Registry:   &RegistryHelpers{base},
+		Keymanager: &KeymanagerHelpers{base},
 	}
 }
 

--- a/go/oasis-test-runner/oasis/cli/keymanager.go
+++ b/go/oasis-test-runner/oasis/cli/keymanager.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/oasislabs/oasis-core/go/common"
+	"github.com/oasislabs/oasis-core/go/common/sgx"
+	keymanager "github.com/oasislabs/oasis-core/go/keymanager/api"
+	cmdCommon "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	cmdConsensus "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/consensus"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
+	cmdKM "github.com/oasislabs/oasis-core/go/oasis-node/cmd/keymanager"
+)
+
+// KeymanagerHelpers contains the oasis-node keymanager CLI helpers.
+type KeymanagerHelpers struct {
+	*helpersBase
+}
+
+// InitPolicy generates the KM policy file.
+func (k *KeymanagerHelpers) InitPolicy(runtimeID common.Namespace, serial uint32, policies map[sgx.EnclaveIdentity]*keymanager.EnclavePolicySGX, polPath string) error {
+	k.logger.Info("initing KM policy",
+		"policy_path", polPath,
+		"serial", serial,
+		"num_policies", len(policies),
+	)
+
+	args := []string{
+		"keymanager", "init_policy",
+		"--" + cmdKM.CfgPolicyFile, polPath,
+		"--" + cmdKM.CfgPolicyID, runtimeID.String(),
+		"--" + cmdKM.CfgPolicySerial, strconv.FormatUint(uint64(serial), 10),
+	}
+	for enclave, policy := range policies {
+		args = append(args, "--"+cmdKM.CfgPolicyEnclaveID)
+		args = append(args, enclave.String())
+		if len(policy.MayQuery) > 0 {
+			for rtID, encIDs := range policy.MayQuery {
+				args = append(args, "--"+cmdKM.CfgPolicyMayQuery)
+				var encIDstrs []string
+				for _, eid := range encIDs {
+					encIDstrs = append(encIDstrs, eid.String())
+				}
+				args = append(args, rtID.String()+"="+strings.Join(encIDstrs, ","))
+			}
+		}
+		if len(policy.MayReplicate) > 0 {
+			args = append(args, "--"+cmdKM.CfgPolicyMayReplicate)
+			var encIDstrs []string
+			for _, eid := range policy.MayReplicate {
+				encIDstrs = append(encIDstrs, eid.String())
+			}
+			args = append(args, strings.Join(encIDstrs, ","))
+		}
+	}
+	if err := k.runSubCommand("keymanager-init_policy", args); err != nil {
+		return fmt.Errorf("failed to init KM policy: %w", err)
+	}
+	return nil
+}
+
+// SignPolicy signs the KM policy file using the given test key ("1", "2", or "3").
+func (k *KeymanagerHelpers) SignPolicy(testKey string, polPath string, polSigPath string) error {
+	k.logger.Info("signing KM policy",
+		"policy_path", polPath,
+		"policy_signature_path", polSigPath,
+		"test_key", testKey,
+	)
+
+	args := []string{
+		"keymanager", "sign_policy",
+		"--" + flags.CfgDebugDontBlameOasis,
+		"--" + cmdCommon.CfgDebugAllowTestKeys,
+		"--" + cmdKM.CfgPolicyFile, polPath,
+		"--" + cmdKM.CfgPolicySigFile, polSigPath,
+		"--" + cmdKM.CfgPolicyTestKey, testKey,
+	}
+	if err := k.runSubCommand("keymanager-sign_policy", args); err != nil {
+		return fmt.Errorf("failed to sign KM policy: %w", err)
+	}
+	return nil
+}
+
+// GenUpdate generates the update KM policy transaction.
+func (k *KeymanagerHelpers) GenUpdate(nonce uint64, polPath string, polSigPaths []string, txPath string) error {
+	k.logger.Info("generating KM policy update",
+		"policy_path", polPath,
+		"policy_signature_paths", polSigPaths,
+		"transaction_path", txPath,
+	)
+
+	args := []string{
+		"keymanager", "gen_update",
+		"--" + cmdConsensus.CfgTxNonce, strconv.FormatUint(nonce, 10),
+		"--" + cmdConsensus.CfgTxFile, txPath,
+		"--" + cmdConsensus.CfgTxFeeAmount, strconv.Itoa(0), // TODO: Make fee configurable.
+		"--" + cmdConsensus.CfgTxFeeGas, strconv.Itoa(10000), // TODO: Make fee configurable.
+		"--" + cmdKM.CfgPolicyFile, polPath,
+		"--" + flags.CfgDebugDontBlameOasis,
+		"--" + cmdCommon.CfgDebugAllowTestKeys,
+		"--" + flags.CfgDebugTestEntity,
+		"--" + flags.CfgGenesisFile, k.net.GenesisPath(),
+	}
+	for _, sigPath := range polSigPaths {
+		args = append(args, "--"+cmdKM.CfgPolicySigFile, sigPath)
+	}
+	if err := k.runSubCommand("keymanager-gen_update", args); err != nil {
+		return fmt.Errorf("failed to generate KM update transaction: %w", err)
+	}
+	return nil
+}

--- a/go/oasis-test-runner/oasis/keymanager.go
+++ b/go/oasis-test-runner/oasis/keymanager.go
@@ -78,6 +78,10 @@ func (km *Keymanager) Start() error {
 }
 
 func (km *Keymanager) provisionGenesis() error {
+	if km.runtime.excludeFromGenesis {
+		return nil
+	}
+
 	// Provision status and policy. We can only provision this here as we need
 	// a list of runtimes allowed to query the key manager.
 	statusArgs := []string{
@@ -174,6 +178,10 @@ func (km *Keymanager) provisionGenesis() error {
 }
 
 func (km *Keymanager) toGenesisArgs() []string {
+	if km.runtime.excludeFromGenesis {
+		return nil
+	}
+
 	return []string{
 		"--keymanager", filepath.Join(km.dir.String(), kmStatusFile),
 	}

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -76,6 +76,22 @@ func (rt *Runtime) ID() common.Namespace {
 	return rt.id
 }
 
+// Kind returns the runtime kind.
+func (rt *Runtime) Kind() registry.RuntimeKind {
+	return rt.kind
+}
+
+// GetEnclaveIdentity returns the runtime's enclave ID.
+func (rt *Runtime) GetEnclaveIdentity() *sgx.EnclaveIdentity {
+	if rt.mrEnclave != nil && rt.mrSigner != nil {
+		return &sgx.EnclaveIdentity{
+			MrEnclave: *rt.mrEnclave,
+			MrSigner:  *rt.mrSigner,
+		}
+	}
+	return nil
+}
+
 func (rt *Runtime) toGenesisArgs() []string {
 	if rt.excludeFromGenesis {
 		return []string{}


### PR DESCRIPTION
Fixes #2840.

TODO:
- [X] Add helper for keymanager CLI stuff to oasis-test-runner.
- [X] Fix keymanager tendermint app to actually register the UpdatePolicy method.
- [X] Handle non-existing previous KM status as new in UpdatePolicy transaction.
- [X] Convert `signature.PublicKey` to `common.Namespace` in EnclavePolicySGX and related.
- [X] Fix `keymanager gen_update` command to accept the consensus txn flags and the policy & policy signatures flags.
- [X] Fix `keymanager gen_update` command to properly deserialize policy file (should use CBOR, but previous code had JSON).
- [X] Add `GetEnclaveIdentity` and `Kind` helpers to oasis-test-runner's Runtime struct.
- [X] Dynamically register KM runtime in `runtime-dynamic` e2e test.
- [X] Figure out why it doesn't work (forgot to bump the nonces in the rest of the `runtime-dynamic` test, oops).
- [X] Figure out why it hangs in SGX tests waiting on nodes (tendermint keymanager app didn't handle tags that weren't at the beginning of blocks).
- [X] Make the keymanager tendermint app's `updatePolicy` actually update the policy :smile:
- [x] Figure out why it still hangs in SGX (not enough signatures).