### PR TITLE
go/common/crypto/mrae/deoxysii: Use SHA512/256 for the KDF

### DIFF
--- a/.changelog/2853.bugfix.md
+++ b/.changelog/2853.bugfix.md
@@ -1,0 +1,4 @@
+go/common/crypto/mrae/deoxysii: Use SHA512/256 for the KDF
+
+Following 73aacaa73d7116a6be0443e70f2d10d0c7a4b76e, this should also use
+the correct hash algorithm for the KDF.

--- a/go/common/crypto/mrae/deoxysii/asymmetric.go
+++ b/go/common/crypto/mrae/deoxysii/asymmetric.go
@@ -2,7 +2,7 @@
 package deoxysii
 
 import (
-	"crypto/sha256"
+	"crypto/sha512"
 
 	"github.com/oasislabs/deoxysii"
 	"github.com/oasislabs/oasis-core/go/common/crypto/mrae/api"
@@ -18,7 +18,7 @@ var (
 type boxImpl struct{}
 
 func (impl *boxImpl) DeriveSymmetricKey(key []byte, publicKey, privateKey *[32]byte) {
-	api.ECDHAndTweak(key, publicKey, privateKey, sha256.New, boxKDFTweak)
+	api.ECDHAndTweak(key, publicKey, privateKey, sha512.New512_256, boxKDFTweak)
 }
 
 func (impl *boxImpl) Seal(dst, nonce, plaintext, additionalData []byte, peersPublicKey, privateKey *[32]byte) []byte {


### PR DESCRIPTION
Following 73aacaa73d7116a6be0443e70f2d10d0c7a4b76e, this should also use
the correct hash algorithm for the KDF.