### PR TITLE
[BACKPORT] go/extra/stats: fix & simplify node-entity mapping

### DIFF
--- a/.changelog/2856.bugfix.md
+++ b/.changelog/2856.bugfix.md
@@ -1,0 +1,7 @@
+go/extra/stats: fix & simplify node-entity mapping
+
+Instead of separately querying for entities and nodes, we can get Entity IDs
+from nodes directly.
+
+This change also fixes a case that previous variant missed: node that was
+removed from entity list of nodes, but has not yet expired.


### PR DESCRIPTION
Backports: https://github.com/oasislabs/oasis-core/pull/2856

Instead of separately querying for entities and nodes, we can get Entity IDs
from nodes directly.

This change also fixes a case that previous variant missed: node that was
removed from entity list of nodes, but has not yet expired.