### PR TITLE
go/extra/stats: fix heights at which missing nodes should be queried

### DIFF
--- a/.changelog/2858.bugfix.md
+++ b/.changelog/2858.bugfix.md
@@ -1,0 +1,4 @@
+go/extra/stats: fix heights at which missing nodes should be queried
+
+If a missing signature is encountered, the registry should be queried at
+previous height, since that is the height at which the vote was made.

--- a/go/extra/stats/cmd/stats.go
+++ b/go/extra/stats/cmd/stats.go
@@ -273,10 +273,11 @@ func getStats(ctx context.Context, consensus consensusAPI.ClientBackend, registr
 			}
 			nodeTmAddr := sig.ValidatorAddress.String()
 
-			if err := ensureNodeTracking(ctx, stats, nodeTmAddr, height, registry); err != nil {
+			// Signatures are for previous height.
+			if err := ensureNodeTracking(ctx, stats, nodeTmAddr, height-1, registry); err != nil {
 				logger.Error("failed to query registry",
 					"err", err,
-					"height", height,
+					"height", height-1,
 				)
 				os.Exit(1)
 			}
@@ -294,10 +295,11 @@ func getStats(ctx context.Context, consensus consensusAPI.ClientBackend, registr
 		if previousProposerAddr != "" {
 			// Only count round 0 proposals.
 			if tmBlockMeta.LastCommit.Round == 0 {
-				if err := ensureNodeTracking(ctx, stats, previousProposerAddr, height, registry); err != nil {
+				// Proposers are for previous height.
+				if err := ensureNodeTracking(ctx, stats, previousProposerAddr, height-1, registry); err != nil {
 					logger.Error("failed to query registry",
 						"err", err,
-						"height", height,
+						"height", height-1,
 					)
 					os.Exit(1)
 				}


### PR DESCRIPTION
If we encounter a signature for a node that is not yet being tracked, we should query for it's info on the previous height, as that's the block at which the vote was made.

Tested on blocks 0-69488 questnet.