### PR TITLE
go/consensus/tendermint: sync-worker additionally check block timestamps

### DIFF
--- a/.changelog/2873.feature.md
+++ b/.changelog/2873.feature.md
@@ -1,0 +1,6 @@
+go/consensus/tendermint: sync-worker additionally check block timestamps
+
+Sync-worker relied on Tendermint fast-sync to determine if the node is still
+catching up. This PR adds aditional condition that the latest block is not
+older than 1 minute. This prevents cases where node would report as caught up
+after stopping fast-sync, but before it has actually caught up.

--- a/go/oasis-test-runner/scenario/e2e/late_start.go
+++ b/go/oasis-test-runner/scenario/e2e/late_start.go
@@ -1,0 +1,73 @@
+package e2e
+
+import (
+	"time"
+
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/scenario"
+)
+
+var (
+	// LateStart is the LateStart node basic scenario.
+	LateStart scenario.Scenario = newLateStartImpl("late-start", "simple-keyvalue-client", nil)
+)
+
+const lateStartInitialWait = 2 * time.Minute
+
+type lateStartImpl struct {
+	basicImpl
+}
+
+func newLateStartImpl(name, clientBinary string, clientArgs []string) scenario.Scenario {
+	return &lateStartImpl{
+		basicImpl: *newBasicImpl(name, clientBinary, clientArgs),
+	}
+}
+
+func (sc *lateStartImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := sc.basicImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	// Start without a client.
+	f.Clients = []oasis.ClientFixture{}
+
+	return f, nil
+}
+
+func (sc *lateStartImpl) Run(childEnv *env.Env) error {
+	// Start the network.
+	var err error
+	if err = sc.net.Start(); err != nil {
+		return err
+	}
+
+	sc.logger.Info("Waiting before starting the client node",
+		"wait_for", lateStartInitialWait,
+	)
+	time.Sleep(lateStartInitialWait)
+
+	sc.logger.Info("Starting the client node")
+	clientFixture := &oasis.ClientFixture{}
+	client, err := clientFixture.Create(sc.net)
+	if err != nil {
+		return err
+	}
+	if err = client.Start(); err != nil {
+		return err
+	}
+
+	sc.logger.Info("Starting the basic client")
+	cmd, err := startClient(childEnv, sc.net, resolveClientBinary(sc.clientBinary), sc.clientArgs)
+	if err != nil {
+		return err
+	}
+	clientErrCh := make(chan error)
+	go func() {
+		clientErrCh <- cmd.Wait()
+	}()
+
+	return sc.wait(childEnv, cmd, clientErrCh)
+}

--- a/go/oasis-test-runner/test-runner.go
+++ b/go/oasis-test-runner/test-runner.go
@@ -67,6 +67,8 @@ func main() {
 	_ = cmd.Register(e2e.NodeUpgradeCancel)
 	// Debonding entries from genesis test.
 	_ = cmd.Register(e2e.Debond)
+	// Late start test.
+	_ = cmd.Register(e2e.LateStart)
 
 	// Register the remote signer test cases.
 	rootCmd.Flags().AddFlagSet(remotesigner.Flags)


### PR DESCRIPTION
Fixes: https://github.com/oasislabs/oasis-core/issues/2861

Sync-worker relies on Tendermint fast-sync to determine if the node is still
catching up. This PR adds aditional condition that the latest block is not
older than 1 minute. This prevents cases where node stops fast-syincing
before it has actually caught up.

TODO:
- [x] although not directly testing the change itself done in this PR it would probably be good to have an E2E test that starts a client node at a later time (e.g. after 2 minutes or so), and ensures the node catches up and starts 
 