### PR TITLE
go/epochtime: add WatchLatestEpoch method

### DIFF
--- a/.changelog/2876.bugfix.md
+++ b/.changelog/2876.bugfix.md
@@ -1,0 +1,5 @@
+worker/registration: use WatchLatestEpoch when watching for registrations
+
+By using WatchLatestEpoch the worker will always try to register for latest
+known epoch, which should prevent cases where registration worker fell behind
+and was trying to register for past epochs.

--- a/.changelog/2876.internal.1.md
+++ b/.changelog/2876.internal.1.md
@@ -1,0 +1,1 @@
+go/common/pubsub: support subscriptions based on bounded ring channels

--- a/.changelog/2876.internal.2.md
+++ b/.changelog/2876.internal.2.md
@@ -1,0 +1,4 @@
+go/epochtime: add WatchLatestEpoch method
+
+The method is similar to the existing WatchEpochs method, with the change that
+unread epochs get overridden with latest epoch.

--- a/go/common/pubsub/pubsub_test.go
+++ b/go/common/pubsub/pubsub_test.go
@@ -8,16 +8,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const recvTimeout = 5 * time.Second
+const (
+	recvTimeout = 5 * time.Second
+	bufferSize  = 5
+)
 
 func TestPubSub(t *testing.T) {
-	t.Run("Basic", testBasic)
+	t.Run("BasicInfinity", testBasicInfinity)
+	t.Run("BasicOverwriting", testBasicOverwriting)
 	t.Run("PubLastOnSubscribe", testLastOnSubscribe)
 	t.Run("SubscribeEx", testSubscribeEx)
 	t.Run("NewBrokerEx", testNewBrokerEx)
 }
 
-func testBasic(t *testing.T) {
+func testBasicInfinity(t *testing.T) {
 	broker := NewBroker(false)
 
 	sub := broker.Subscribe()
@@ -50,41 +54,104 @@ func testBasic(t *testing.T) {
 	require.Len(t, broker.subscribers, 0, "Subscriber map, post Close()")
 }
 
+func testBasicOverwriting(t *testing.T) {
+	broker := NewBroker(false)
+
+	sub := broker.SubscribeBuffered(bufferSize)
+	typedCh := make(chan int)
+	sub.Unwrap(typedCh)
+
+	// Test a single broadcast/receive.
+	broker.Broadcast(23)
+	select {
+	case v := <-typedCh:
+		require.Equal(t, 23, v, "Single Broadcast())")
+	case <-time.After(recvTimeout):
+		t.Fatalf("Failed to receive value, initial Broadcast()")
+	}
+
+	// Test the buffered nature of the overwriting channel.
+	for i := 0; i < bufferSize+10; i++ {
+		broker.Broadcast(i)
+	}
+	// Ensure we don't start reading before all messages are processed by the
+	// underlying channel.
+	time.Sleep(100 * time.Millisecond)
+
+	// RingChannel prefers to write before buffering the items, so the first
+	// element will be instantly send to the output channel and removed from the
+	// buffer so it will not get overwritten.
+	expected := []int{
+		0,
+	}
+	for i := 10; i < bufferSize+10; i++ {
+		expected = append(expected, i)
+	}
+	for _, i := range expected {
+		select {
+		case v := <-typedCh:
+			require.Equal(t, i, v, "Buffered Broadcast()")
+		case <-time.After(recvTimeout):
+			t.Fatalf("Failed to receive value, buffered Broadcast()")
+		}
+	}
+
+	require.NotPanics(t, func() { sub.Close() }, "Close()")
+	require.Len(t, broker.subscribers, 0, "Subscriber map, post Close()")
+}
+
 func testLastOnSubscribe(t *testing.T) {
 	broker := NewBroker(true)
 	broker.Broadcast(23)
 
-	sub := broker.Subscribe()
-	typedCh := make(chan int)
-	sub.Unwrap(typedCh)
+	for _, b := range []int64{
+		int64(channels.Infinity),
+		bufferSize,
+	} {
+		sub := broker.SubscribeBuffered(b)
+		typedCh := make(chan int)
+		sub.Unwrap(typedCh)
 
-	select {
-	case v := <-typedCh:
-		require.Equal(t, 23, v, "Last Broadcast()")
-	case <-time.After(recvTimeout):
-		t.Fatalf("Failed to receive value, last Broadcast() on Subscribe()")
+		select {
+		case v := <-typedCh:
+			require.Equal(t, 23, v, "Last Broadcast()")
+		case <-time.After(recvTimeout):
+			t.Fatalf("Failed to receive value, last Broadcast() on Subscribe()")
+		}
 	}
 }
 
 func testSubscribeEx(t *testing.T) {
 	broker := NewBroker(false)
-
-	var callbackCh *channels.InfiniteChannel
-	sub := broker.SubscribeEx(func(ch *channels.InfiniteChannel) {
+	var callbackCh channels.Channel
+	callback := func(ch channels.Channel) {
 		callbackCh = ch
-	})
+	}
 
-	require.NotNil(t, sub.ch, "Subscription, inner channel")
-	require.Equal(t, sub.ch, callbackCh, "Callback channel != Subscription, inner channel")
+	for _, b := range []int64{
+		int64(channels.Infinity),
+		bufferSize,
+	} {
+		sub := broker.SubscribeEx(b, callback)
+
+		require.NotNil(t, sub.ch, "Subscription, inner channel")
+		require.Equal(t, sub.ch, callbackCh, "Callback channel != Subscription, inner channel")
+	}
+
 }
 
 func testNewBrokerEx(t *testing.T) {
-	var callbackCh *channels.InfiniteChannel
-	broker := NewBrokerEx(func(ch *channels.InfiniteChannel) {
+	var callbackCh channels.Channel
+	broker := NewBrokerEx(func(ch channels.Channel) {
 		callbackCh = ch
 	})
 
-	sub := broker.Subscribe()
-	require.NotNil(t, sub.ch, "Subscription, inner channel")
-	require.Equal(t, sub.ch, callbackCh, "Callback channel != Subscription, inner channel")
+	for _, b := range []int64{
+		int64(channels.Infinity),
+		bufferSize,
+	} {
+		sub := broker.SubscribeBuffered(b)
+		require.NotNil(t, sub.ch, "Subscription, inner channel")
+		require.Equal(t, sub.ch, callbackCh, "Callback channel != Subscription, inner channel")
+	}
 }

--- a/go/consensus/tendermint/epochtime/epochtime.go
+++ b/go/consensus/tendermint/epochtime/epochtime.go
@@ -63,6 +63,14 @@ func (t *tendermintBackend) WatchEpochs() (<-chan api.EpochTime, *pubsub.Subscri
 	return typedCh, sub
 }
 
+func (t *tendermintBackend) WatchLatestEpoch() (<-chan api.EpochTime, *pubsub.Subscription) {
+	typedCh := make(chan api.EpochTime)
+	sub := t.notifier.SubscribeBuffered(1)
+	sub.Unwrap(typedCh)
+
+	return typedCh, sub
+}
+
 func (t *tendermintBackend) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
 	now, err := t.GetEpoch(ctx, height)
 	if err != nil {
@@ -125,7 +133,7 @@ func New(ctx context.Context, service service.TendermintService, interval int64)
 		base:     base,
 		epoch:    base,
 	}
-	r.notifier = pubsub.NewBrokerEx(func(ch *channels.InfiniteChannel) {
+	r.notifier = pubsub.NewBrokerEx(func(ch channels.Channel) {
 		r.RLock()
 		defer r.RUnlock()
 

--- a/go/consensus/tendermint/epochtime_mock/epochtime_mock.go
+++ b/go/consensus/tendermint/epochtime_mock/epochtime_mock.go
@@ -80,6 +80,14 @@ func (t *tendermintMockBackend) WatchEpochs() (<-chan api.EpochTime, *pubsub.Sub
 	return typedCh, sub
 }
 
+func (t *tendermintMockBackend) WatchLatestEpoch() (<-chan api.EpochTime, *pubsub.Subscription) {
+	typedCh := make(chan api.EpochTime)
+	sub := t.notifier.SubscribeBuffered(1)
+	sub.Unwrap(typedCh)
+
+	return typedCh, sub
+}
+
 func (t *tendermintMockBackend) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
 	now, err := t.GetEpoch(ctx, height)
 	if err != nil {
@@ -232,7 +240,7 @@ func New(ctx context.Context, service service.TendermintService) (api.SetableBac
 		service: service,
 		querier: a.QueryFactory().(*app.QueryFactory),
 	}
-	r.notifier = pubsub.NewBrokerEx(func(ch *channels.InfiniteChannel) {
+	r.notifier = pubsub.NewBrokerEx(func(ch channels.Channel) {
 		r.RLock()
 		defer r.RUnlock()
 

--- a/go/consensus/tendermint/keymanager/keymanager.go
+++ b/go/consensus/tendermint/keymanager/keymanager.go
@@ -145,7 +145,7 @@ func New(ctx context.Context, service service.TendermintService) (api.Backend, e
 		service: service,
 		querier: a.QueryFactory().(*app.QueryFactory),
 	}
-	tb.notifier = pubsub.NewBrokerEx(func(ch *channels.InfiniteChannel) {
+	tb.notifier = pubsub.NewBrokerEx(func(ch channels.Channel) {
 		statuses, err := tb.GetStatuses(ctx, consensus.HeightLatest)
 		if err != nil {
 			tb.logger.Error("status notifier: unable to get a list of statuses",

--- a/go/consensus/tendermint/registry/registry.go
+++ b/go/consensus/tendermint/registry/registry.go
@@ -414,7 +414,7 @@ func New(ctx context.Context, service service.TendermintService) (api.Backend, e
 		nodeNotifier:     pubsub.NewBroker(false),
 		nodeListNotifier: pubsub.NewBroker(true),
 	}
-	tb.runtimeNotifier = pubsub.NewBrokerEx(func(ch *channels.InfiniteChannel) {
+	tb.runtimeNotifier = pubsub.NewBrokerEx(func(ch channels.Channel) {
 		wr := ch.In()
 		runtimes, err := tb.GetRuntimes(ctx, consensus.HeightLatest)
 		if err != nil {

--- a/go/consensus/tendermint/roothash/roothash.go
+++ b/go/consensus/tendermint/roothash/roothash.go
@@ -104,7 +104,7 @@ func (tb *tendermintBackend) getLatestBlockAt(ctx context.Context, id common.Nam
 func (tb *tendermintBackend) WatchBlocks(id common.Namespace) (<-chan *api.AnnotatedBlock, *pubsub.Subscription, error) {
 	notifiers := tb.getRuntimeNotifiers(id)
 
-	sub := notifiers.blockNotifier.SubscribeEx(func(ch *channels.InfiniteChannel) {
+	sub := notifiers.blockNotifier.SubscribeEx(-1, func(ch channels.Channel) {
 		// Replay the latest block if it exists.
 		notifiers.Lock()
 		defer notifiers.Unlock()

--- a/go/consensus/tendermint/scheduler/scheduler.go
+++ b/go/consensus/tendermint/scheduler/scheduler.go
@@ -182,7 +182,7 @@ func New(ctx context.Context, service service.TendermintService) (api.Backend, e
 		service: service,
 		querier: a.QueryFactory().(*app.QueryFactory),
 	}
-	tb.notifier = pubsub.NewBrokerEx(func(ch *channels.InfiniteChannel) {
+	tb.notifier = pubsub.NewBrokerEx(func(ch channels.Channel) {
 		currentCommittees, err := tb.getCurrentCommittees()
 		if err != nil {
 			tb.logger.Error("couldn't get current committees. won't send them. good luck to the subscriber",

--- a/go/epochtime/api/api.go
+++ b/go/epochtime/api/api.go
@@ -36,6 +36,13 @@ type Backend interface {
 	// Upon subscription the current epoch is sent immediately.
 	WatchEpochs() (<-chan EpochTime, *pubsub.Subscription)
 
+	// WatchLatestEpoch returns a channel that produces a stream of messages on
+	// epoch transitions. If an epoch transition hapens before previous epoch
+	// is read from channel, the old epochs is overwritten.
+	//
+	// Upon subscription the current epoch is sent immediately.
+	WatchLatestEpoch() (<-chan EpochTime, *pubsub.Subscription)
+
 	// StateToGenesis returns the genesis state at the specified block height.
 	StateToGenesis(ctx context.Context, height int64) (*Genesis, error)
 }

--- a/go/oasis-node/cmd/debug/consim/timesource.go
+++ b/go/oasis-node/cmd/debug/consim/timesource.go
@@ -37,6 +37,10 @@ func (b *simTimeSource) WatchEpochs() (<-chan api.EpochTime, *pubsub.Subscriptio
 	panic("consim/epochtime: WatchEpochs not supported")
 }
 
+func (b *simTimeSource) WatchLatestEpoch() (<-chan api.EpochTime, *pubsub.Subscription) {
+	panic("consim/epochtime: WatchLatestEpoch not supported")
+}
+
 func (b *simTimeSource) StateToGenesis(ctx context.Context, height int64) (*api.Genesis, error) {
 	// WARNING: This ignores the height because it's only used for the final
 	// dump.

--- a/go/runtime/committee/nodes.go
+++ b/go/runtime/committee/nodes.go
@@ -239,7 +239,7 @@ func NewNodeDescriptorWatcher(ctx context.Context, registry registry.Backend) (N
 		ctx:      ctx,
 		logger:   logging.GetLogger("runtime/committee/nodedescriptorwatcher"),
 	}
-	nw.notifier = pubsub.NewBrokerEx(func(ch *channels.InfiniteChannel) {
+	nw.notifier = pubsub.NewBrokerEx(func(ch channels.Channel) {
 		nw.RLock()
 		defer nw.RUnlock()
 

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -206,7 +206,7 @@ func (w *Worker) registrationLoop() { // nolint: gocyclo
 	// (re-)register the node on each epoch transition. This doesn't
 	// need to be strict block-epoch time, since it just serves to
 	// extend the node's expiration.
-	ch, sub := w.epochtime.WatchEpochs()
+	ch, sub := w.epochtime.WatchLatestEpoch()
 	defer sub.Close()
 
 	regFn := func(epoch epochtime.EpochTime, hook RegisterNodeHook, retry bool) error {


### PR DESCRIPTION
Fixes: #2862

Pubsub framework is extended to support subscriptions based on bounded
ring channels. Bounded subscriptions are used in the new epochtime
WatchLatestEpoch method. The method is similar to the existing WatchEpochs
method, with the change that unread epochs get overridden with latest
epoch.

Registration worker is changed to use the WatchLatestEpoch method to
prevent trying to register for old epochs in case the worker falls
behind.

XXX: any other places where using a ring channel (e.g. skipping past/outdated channel items) would be preferable?