### PR TITLE
Basic consensus light client support

### DIFF
--- a/.changelog/2440.feature.1.md
+++ b/.changelog/2440.feature.1.md
@@ -1,0 +1,1 @@
+go/consensus: Add basic API for supporting light consensus clients

--- a/.changelog/2440.feature.2.md
+++ b/.changelog/2440.feature.2.md
@@ -1,0 +1,9 @@
+go/worker/consensusrpc: Add public consensus RPC services worker
+
+A public consensus services worker enables any full consensus node to expose
+light client services to other nodes that may need them (e.g., they are needed
+to support light clients).
+
+The worker can be enabled using `--worker.consensusrpc.enabled` and is
+disabled by default. Enabling the public consensus services worker exposes
+the light consensus client interface over publicly accessible gRPC.

--- a/.changelog/2881.breaking.md
+++ b/.changelog/2881.breaking.md
@@ -1,0 +1,1 @@
+go/common/node: Add RoleConsensusRPC role bit

--- a/go/common/node/node.go
+++ b/go/common/node/node.go
@@ -69,18 +69,20 @@ type Node struct {
 type RolesMask uint32
 
 const (
-	// RoleComputeWorker is Oasis compute worker role.
+	// RoleComputeWorker is the compute worker role.
 	RoleComputeWorker RolesMask = 1 << 0
-	// RoleStorageWorker is Oasis storage worker role.
+	// RoleStorageWorker is the storage worker role.
 	RoleStorageWorker RolesMask = 1 << 1
-	// RoleKeyManager is the Oasis key manager role.
+	// RoleKeyManager is the the key manager role.
 	RoleKeyManager RolesMask = 1 << 2
-	// RoleValidator is the Oasis validator role.
+	// RoleValidator is the validator role.
 	RoleValidator RolesMask = 1 << 3
+	// RoleConsensusRPC is the public consensus RPC services worker role.
+	RoleConsensusRPC RolesMask = 1 << 4
 
 	// RoleReserved are all the bits of the Oasis node roles bitmask
 	// that are reserved and must not be used.
-	RoleReserved RolesMask = ((1 << 32) - 1) & ^((RoleValidator << 1) - 1)
+	RoleReserved RolesMask = ((1 << 32) - 1) & ^((RoleConsensusRPC << 1) - 1)
 )
 
 // IsSingleRole returns true if RolesMask encodes a single valid role.
@@ -102,10 +104,13 @@ func (m RolesMask) String() string {
 		ret = append(ret, "storage")
 	}
 	if m&RoleKeyManager != 0 {
-		ret = append(ret, "key_manager")
+		ret = append(ret, "key-manager")
 	}
 	if m&RoleValidator != 0 {
 		ret = append(ret, "validator")
+	}
+	if m&RoleConsensusRPC != 0 {
+		ret = append(ret, "consensus-rpc")
 	}
 
 	return strings.Join(ret, ",")

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"context"
+	"time"
 
 	beacon "github.com/oasislabs/oasis-core/go/beacon/api"
 	"github.com/oasislabs/oasis-core/go/common/cbor"
@@ -42,9 +43,10 @@ var (
 	ErrVersionNotFound = errors.New(moduleName, 3, "consensus: version not found")
 )
 
-// ClientBackend is a limited consensus interface used by clients that
-// connect to the local node.
+// ClientBackend is a limited consensus interface used by clients that connect to the local full
+// node. This is separate from light clients which use the LightClientBackend interface.
 type ClientBackend interface {
+	LightClientBackend
 	TransactionAuthHandler
 
 	// SubmitTx submits a signed consensus transaction.
@@ -87,6 +89,10 @@ type ClientBackend interface {
 type Block struct {
 	// Height contains the block height.
 	Height int64 `json:"height"`
+	// Hash contains the block header hash.
+	Hash []byte `json:"hash"`
+	// Time is the second-granular consensus time.
+	Time time.Time `json:"time"`
 	// Meta contains the consensus backend specific block metadata.
 	Meta cbor.RawMessage `json:"meta"`
 }

--- a/go/consensus/api/light.go
+++ b/go/consensus/api/light.go
@@ -36,9 +36,8 @@ type ValidatorSet struct {
 type Parameters struct {
 	// Height contains the block height these consensus parameters are for.
 	Height int64 `json:"height"`
-
-	// TODO: Consider also including consensus/genesis.Parameters which are backend-agnostic.
-
 	// Meta contains the consensus backend specific consensus parameters.
 	Meta []byte `json:"meta"`
+
+	// TODO: Consider also including consensus/genesis.Parameters which are backend-agnostic.
 }

--- a/go/consensus/api/light.go
+++ b/go/consensus/api/light.go
@@ -1,0 +1,44 @@
+package api
+
+import "context"
+
+// LightClientBackend is the limited consensus interface used by light clients.
+type LightClientBackend interface {
+	// GetSignedHeader returns the signed header for a specific height.
+	GetSignedHeader(ctx context.Context, height int64) (*SignedHeader, error)
+
+	// GetValidatorSet returns the validator set for a specific height.
+	GetValidatorSet(ctx context.Context, height int64) (*ValidatorSet, error)
+
+	// GetParameters returns the consensus parameters for a specific height.
+	GetParameters(ctx context.Context, height int64) (*Parameters, error)
+
+	// TODO: Move SubmitEvidence etc. from Backend.
+}
+
+// SignedHeader is a signed consensus block header.
+type SignedHeader struct {
+	// Height contains the block height this header is for.
+	Height int64 `json:"height"`
+	// Meta contains the consensus backend specific signed header.
+	Meta []byte `json:"meta"`
+}
+
+// ValidatorSet contains the validator set information.
+type ValidatorSet struct {
+	// Height contains the block height this validator set is for.
+	Height int64 `json:"height"`
+	// Meta contains the consensus backend specific validator set.
+	Meta []byte `json:"meta"`
+}
+
+// Parameters are the consensus backend parameters.
+type Parameters struct {
+	// Height contains the block height these consensus parameters are for.
+	Height int64 `json:"height"`
+
+	// TODO: Consider also including consensus/genesis.Parameters which are backend-agnostic.
+
+	// Meta contains the consensus backend specific consensus parameters.
+	Meta []byte `json:"meta"`
+}

--- a/go/consensus/tendermint/api/api.go
+++ b/go/consensus/tendermint/api/api.go
@@ -149,6 +149,8 @@ func NewBlock(blk *tmtypes.Block) *consensus.Block {
 
 	return &consensus.Block{
 		Height: blk.Header.Height,
+		Hash:   blk.Header.Hash(),
+		Time:   blk.Header.Time,
 		Meta:   rawMeta,
 	}
 }

--- a/go/consensus/tendermint/full.go
+++ b/go/consensus/tendermint/full.go
@@ -1,0 +1,75 @@
+package tendermint
+
+import (
+	"context"
+	"fmt"
+
+	tmamino "github.com/tendermint/go-amino"
+	tmrpctypes "github.com/tendermint/tendermint/rpc/core/types"
+	tmstate "github.com/tendermint/tendermint/state"
+
+	consensusAPI "github.com/oasislabs/oasis-core/go/consensus/api"
+)
+
+// We must use Tendermint's amino codec as some Tendermint's types are not easily unmarshallable.
+var aminoCodec = tmamino.NewCodec()
+
+func init() {
+	tmrpctypes.RegisterAmino(aminoCodec)
+}
+
+// Implements LightClientBackend.
+func (t *tendermintService) GetSignedHeader(ctx context.Context, height int64) (*consensusAPI.SignedHeader, error) {
+	if err := t.ensureStarted(ctx); err != nil {
+		return nil, err
+	}
+
+	commit, err := t.client.Commit(&height)
+	if err != nil {
+		return nil, fmt.Errorf("%w: tendermint: header query failed: %s", consensusAPI.ErrVersionNotFound, err.Error())
+	}
+
+	if commit.Header == nil {
+		return nil, fmt.Errorf("tendermint: header is nil")
+	}
+
+	return &consensusAPI.SignedHeader{
+		Height: commit.Header.Height,
+		Meta:   aminoCodec.MustMarshalBinaryBare(commit.SignedHeader),
+	}, nil
+}
+
+// Implements LightClientBackend.
+func (t *tendermintService) GetValidatorSet(ctx context.Context, height int64) (*consensusAPI.ValidatorSet, error) {
+	if err := t.ensureStarted(ctx); err != nil {
+		return nil, err
+	}
+
+	// Don't use the client as that imposes stupid pagination. Access the state database directly.
+	vals, err := tmstate.LoadValidators(t.stateDb, height)
+	if err != nil {
+		return nil, consensusAPI.ErrVersionNotFound
+	}
+
+	return &consensusAPI.ValidatorSet{
+		Height: height,
+		Meta:   aminoCodec.MustMarshalBinaryBare(vals),
+	}, nil
+}
+
+// Implements LightClientBackend.
+func (t *tendermintService) GetParameters(ctx context.Context, height int64) (*consensusAPI.Parameters, error) {
+	if err := t.ensureStarted(ctx); err != nil {
+		return nil, err
+	}
+
+	params, err := t.client.ConsensusParams(&height)
+	if err != nil {
+		return nil, fmt.Errorf("%w: tendermint: consensus params query failed: %s", consensusAPI.ErrVersionNotFound, err.Error())
+	}
+
+	return &consensusAPI.Parameters{
+		Height: params.BlockHeight,
+		Meta:   aminoCodec.MustMarshalBinaryBare(params.ConsensusParams),
+	}, nil
+}

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -68,4 +68,20 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.ClientBackend)
 	})
 	require.NoError(err, "GetSignerNonce")
 	require.Equal(uint64(0), nonce, "Nonce should be zero")
+
+	// Light client API.
+	shdr, err := backend.GetSignedHeader(ctx, blk.Height)
+	require.NoError(err, "GetSignedHeader")
+	require.Equal(shdr.Height, blk.Height, "returned header height should be correct")
+	require.NotNil(shdr.Meta, "returned header should contain metadata")
+
+	vals, err := backend.GetValidatorSet(ctx, blk.Height)
+	require.NoError(err, "GetValidatorSet")
+	require.Equal(vals.Height, blk.Height, "returned validator set height should be correct")
+	require.NotNil(vals.Meta, "returned validator set should contain metadata")
+
+	params, err := backend.GetParameters(ctx, blk.Height)
+	require.NoError(err, "GetParameters")
+	require.Equal(params.Height, blk.Height, "returned parameters height should be correct")
+	require.NotNil(params.Meta, "returned parameters should contain metadata")
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/spf13/viper v1.6.3
 	github.com/steveyen/gtreap v0.0.0-20150807155958-0abe01ef9be2 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/tendermint/go-amino v0.15.0 // indirect
+	github.com/tendermint/go-amino v0.15.0
 	github.com/tendermint/tendermint v0.32.8
 	github.com/tendermint/tm-db v0.5.1
 	github.com/thepudds/fzgo v0.2.2

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -30,6 +30,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/worker/common/p2p"
 	"github.com/oasislabs/oasis-core/go/worker/compute"
 	"github.com/oasislabs/oasis-core/go/worker/compute/txnscheduler"
+	workerConsensusRPC "github.com/oasislabs/oasis-core/go/worker/consensusrpc"
 	"github.com/oasislabs/oasis-core/go/worker/keymanager"
 	"github.com/oasislabs/oasis-core/go/worker/registration"
 	workerSentry "github.com/oasislabs/oasis-core/go/worker/sentry"
@@ -374,6 +375,11 @@ func (args *argBuilder) workerStorageCheckpointCheckInterval(interval time.Durat
 
 func (args *argBuilder) workerTxnschedulerCheckTxEnabled() *argBuilder {
 	args.vec = append(args.vec, "--"+txnscheduler.CfgCheckTxEnabled)
+	return args
+}
+
+func (args *argBuilder) workerConsensusRPCEnabled() *argBuilder {
+	args.vec = append(args.vec, "--"+workerConsensusRPC.CfgWorkerEnabled)
 	return args
 }
 

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -133,6 +133,9 @@ type ConsensusFixture struct { // nolint: maligned
 
 	// TendermintRecoverCorruptedWAL enables automatic recovery of corrupted Tendermint's WAL.
 	TendermintRecoverCorruptedWAL bool `json:"tendermint_recover_corrupted_wal"`
+
+	// EnableConsensusRPCWorker enables the public consensus RPC services worker.
+	EnableConsensusRPCWorker bool `json:"enable_consensusrpc_worker,omitempty"`
 }
 
 // TEEFixture is a TEE configuration fixture.

--- a/go/oasis-test-runner/scenario/e2e/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime.go
@@ -193,9 +193,9 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 			},
 		},
 		Validators: []oasis.ValidatorFixture{
-			oasis.ValidatorFixture{Entity: 1},
-			oasis.ValidatorFixture{Entity: 1},
-			oasis.ValidatorFixture{Entity: 1},
+			oasis.ValidatorFixture{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}},
+			oasis.ValidatorFixture{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}},
+			oasis.ValidatorFixture{Entity: 1, Consensus: oasis.ConsensusFixture{EnableConsensusRPCWorker: true}},
 		},
 		KeymanagerPolicies: []oasis.KeymanagerPolicyFixture{
 			oasis.KeymanagerPolicyFixture{Runtime: 0, Serial: 1},

--- a/go/storage/mkvs/checkpoint/checkpoint.go
+++ b/go/storage/mkvs/checkpoint/checkpoint.go
@@ -50,6 +50,10 @@ type ChunkProvider interface {
 type GetCheckpointsRequest struct {
 	Version   uint16           `json:"version"`
 	Namespace common.Namespace `json:"namespace"`
+
+	// RootVersion specifies an optional root version to limit the request to. If specified, only
+	// checkpoints for roots with the specific version will be considered.
+	RootVersion *uint64 `json:"root_version,omitempty"`
 }
 
 // Creator is a checkpoint creator.

--- a/go/storage/mkvs/checkpoint/checkpoint.go
+++ b/go/storage/mkvs/checkpoint/checkpoint.go
@@ -87,6 +87,10 @@ type Restorer interface {
 	// StartRestore starts a checkpoint restoration process.
 	StartRestore(ctx context.Context, checkpoint *Metadata) error
 
+	// GetCurrentCheckpoint returns the checkpoint that is being restored. If no restoration is in
+	// progress, this method may return nil.
+	GetCurrentCheckpoint() *Metadata
+
 	// RestoreChunk restores the given chunk into the underlying node database.
 	//
 	// This method requires that a restoration is in progress.

--- a/go/storage/mkvs/checkpoint/checkpoint.go
+++ b/go/storage/mkvs/checkpoint/checkpoint.go
@@ -133,16 +133,25 @@ type Metadata struct {
 	Chunks  []hash.Hash `json:"chunks"`
 }
 
+// EncodedHash returns the encoded cryptographic hash of the checkpoint metadata.
+func (m *Metadata) EncodedHash() hash.Hash {
+	var hh hash.Hash
+
+	hh.From(m)
+
+	return hh
+}
+
 // GetChunkMetadata returns the chunk metadata for the corresponding chunk.
-func (c Metadata) GetChunkMetadata(idx uint64) (*ChunkMetadata, error) {
-	if idx >= uint64(len(c.Chunks)) {
+func (m Metadata) GetChunkMetadata(idx uint64) (*ChunkMetadata, error) {
+	if idx >= uint64(len(m.Chunks)) {
 		return nil, ErrChunkNotFound
 	}
 
 	return &ChunkMetadata{
-		Version: c.Version,
-		Root:    c.Root,
+		Version: m.Version,
+		Root:    m.Root,
 		Index:   idx,
-		Digest:  c.Chunks[int(idx)],
+		Digest:  m.Chunks[int(idx)],
 	}, nil
 }

--- a/go/storage/mkvs/checkpoint/checkpoint_test.go
+++ b/go/storage/mkvs/checkpoint/checkpoint_test.go
@@ -182,6 +182,9 @@ func TestFileCheckpointCreator(t *testing.T) {
 	err = rs.StartRestore(ctx, cp)
 	require.Error(err, "StartRestore should fail when a restore is already in progress")
 	require.True(errors.Is(err, ErrRestoreAlreadyInProgress))
+	rcp := rs.GetCurrentCheckpoint()
+	require.EqualValues(rcp, cp, "GetCurrentCheckpoint should return the checkpoint being restored")
+	require.NotSame(rcp, cp, "GetCurrentCheckpoint should return a copy")
 	for i := 0; i < len(cp.Chunks); i++ {
 		var cm *ChunkMetadata
 		cm, err = cp.GetChunkMetadata(uint64(i))

--- a/go/storage/mkvs/checkpoint/file.go
+++ b/go/storage/mkvs/checkpoint/file.go
@@ -110,7 +110,13 @@ func (fc *fileCreator) GetCheckpoints(ctx context.Context, request *GetCheckpoin
 		return []*Metadata{}, nil
 	}
 
-	matches, err := filepath.Glob(filepath.Join(fc.dataDir, "*", "*", checkpointMetadataFile))
+	// Apply optional root version filter.
+	versionGlob := "*"
+	if request.RootVersion != nil {
+		versionGlob = strconv.FormatUint(*request.RootVersion, 10)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(fc.dataDir, versionGlob, "*", checkpointMetadataFile))
 	if err != nil {
 		return nil, fmt.Errorf("checkpoint: failed to enumerate checkpoints: %w", err)
 	}

--- a/go/storage/mkvs/checkpoint/restorer.go
+++ b/go/storage/mkvs/checkpoint/restorer.go
@@ -40,6 +40,18 @@ func (rs *restorer) StartRestore(ctx context.Context, checkpoint *Metadata) erro
 	return nil
 }
 
+func (rs *restorer) GetCurrentCheckpoint() *Metadata {
+	rs.Lock()
+	defer rs.Unlock()
+
+	if rs.currentCheckpoint == nil {
+		return nil
+	}
+
+	cp := *rs.currentCheckpoint
+	return &cp
+}
+
 // Implements Restorer.
 func (rs *restorer) RestoreChunk(ctx context.Context, idx uint64, r io.Reader) (bool, error) {
 	chunk, err := func() (*ChunkMetadata, error) {

--- a/go/worker/consensusrpc/worker.go
+++ b/go/worker/consensusrpc/worker.go
@@ -1,0 +1,105 @@
+// Package consensus implements publicly accessible consensus services.
+package consensus
+
+import (
+	"fmt"
+
+	flag "github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/oasislabs/oasis-core/go/common/logging"
+	"github.com/oasislabs/oasis-core/go/common/node"
+	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
+	workerCommon "github.com/oasislabs/oasis-core/go/worker/common"
+	"github.com/oasislabs/oasis-core/go/worker/registration"
+)
+
+const (
+	// CfgWorkerEnabled enables the consensus RPC services worker.
+	CfgWorkerEnabled = "worker.consensusrpc.enabled"
+)
+
+// Flags has the configuration flags.
+var Flags = flag.NewFlagSet("", flag.ContinueOnError)
+
+// Worker is a worker providing publicly accessible consensus services.
+//
+// Currently this only exposes the consensus light client service.
+type Worker struct {
+	enabled bool
+
+	commonWorker *workerCommon.Worker
+
+	quitCh chan struct{}
+
+	logger *logging.Logger
+}
+
+// Name returns the service name.
+func (w *Worker) Name() string {
+	return "public consensus RPC services worker"
+}
+
+// Enabled returns if worker is enabled.
+func (w *Worker) Enabled() bool {
+	return w.enabled
+}
+
+// Start starts the worker.
+func (w *Worker) Start() error {
+	if w.enabled {
+		w.logger.Info("starting public consensus RPC services worker")
+	}
+	return nil
+}
+
+// Stop halts the service.
+func (w *Worker) Stop() {
+	close(w.quitCh)
+}
+
+// Quit returns a channel that will be closed when the service terminates.
+func (w *Worker) Quit() <-chan struct{} {
+	return w.quitCh
+}
+
+// Cleanup performs the service specific post-termination cleanup.
+func (w *Worker) Cleanup() {
+}
+
+// New creates a new public consensus services worker.
+func New(commonWorker *workerCommon.Worker, registration *registration.Worker) (*Worker, error) {
+	w := &Worker{
+		enabled:      Enabled(),
+		commonWorker: commonWorker,
+		quitCh:       make(chan struct{}),
+		logger:       logging.GetLogger("worker/consensusrpc"),
+	}
+
+	if w.enabled {
+		// Register the consensus light client service.
+		consensus.RegisterLightService(commonWorker.Grpc.Server(), commonWorker.Consensus)
+
+		// Publish our role to ease discovery for clients.
+		rp, err := registration.NewRoleProvider(node.RoleConsensusRPC)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create role provider: %w", err)
+		}
+
+		// The consensus RPC service is available immediately.
+		rp.SetAvailable(func(*node.Node) error { return nil })
+	}
+
+	return w, nil
+}
+
+// Enabled reads our enabled flag from viper.
+func Enabled() bool {
+	return viper.GetBool(CfgWorkerEnabled)
+}
+
+func init() {
+	Flags.Bool(CfgWorkerEnabled, false, "Enable public consensus RPC services worker")
+
+	_ = viper.BindPFlags(Flags)
+}


### PR DESCRIPTION
Initial implementation of #2440, required for #2880.

TODO
* [x] Cleanup (extracted from branch which also bumps Tendermint to an unreleased version, see #2882).
* [x] More tests where missing.