### PR TITLE
go/oasis-test-runner: add support for running tests with non-mock IAS

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -12,6 +12,8 @@ docker_plugin_default_config: &docker_plugin_default_config
   volumes:
     - /var/lib/buildkite-agent/.coveralls:/root/.coveralls
     - /var/lib/buildkite-agent/.codecov:/root/.codecov
+    # IAS Development API keys.
+    - /var/lib/buildkite-agent/.oasis-ias:/root/.oasis-ias
     # Shared Rust incremental compile caches.
     - /var/tmp/cargo_ic/debug:/var/tmp/artifacts/default/debug/incremental
     - /var/tmp/cargo_ic/debug_sgx:/var/tmp/artifacts/sgx/x86_64-unknown-linux-sgx/debug/incremental
@@ -252,7 +254,31 @@ steps:
       - .buildkite/scripts/download_e2e_test_artifacts.sh
       - .buildkite/scripts/test_e2e.sh
     artifact_paths:
-      - coverage-merged-e2e-sgx-*.txt
+      - coverage-merged-e2e-*.txt
+      - /tmp/e2e/**/*.log
+    env:
+      OASIS_E2E_COVERAGE: enable
+      TEST_BASE_DIR: /tmp
+    agents:
+      queue: intel-sgx
+    retry:
+      <<: *retry_agent_failure
+    plugins:
+      <<: *docker_plugin_sgx
+
+  ###############################
+  # E2E test - intel-sgx with IAS
+  ###############################
+  - label: E2E tests - intel-sgx - IAS
+    timeout_in_minutes: 10
+    command:
+      - .buildkite/scripts/sgx_ias_tests.sh
+    # A unique string to identify the step. The value is available in the
+    # BUILDKITE_STEP_KEY and is used to ensure the generated coverage file
+    # names are unique across this pipeline.
+    key: sgx-ias
+    artifact_paths:
+      - coverage-merged-e2e-*.txt
       - /tmp/e2e/**/*.log
     env:
       OASIS_E2E_COVERAGE: enable

--- a/.buildkite/scripts/sgx_ias_tests.sh
+++ b/.buildkite/scripts/sgx_ias_tests.sh
@@ -1,0 +1,24 @@
+#! /bin/bash
+
+set -euxo pipefail
+
+# Script invoked from .buildkite/iastests.pipeline.yml
+
+set +x
+OASIS_IAS_APIKEY=$(cat ~/.oasis-ias/api_key)
+export OASIS_IAS_APIKEY
+OASIS_IAS_SPID=$(cat ~/.oasis-ias/spid)
+export OASIS_IAS_SPID
+set -x
+
+export GO_BUILD_E2E_COVERAGE=1
+# Ensure AVR verify is not skipped.
+unset OASIS_UNSAFE_SKIP_AVR_VERIFY
+export OASIS_TEE_HARDWARE=intel-sgx
+# Allow use of usnafe km policy keys.
+export OASIS_UNSAFE_KM_POLICY_KEYS=1
+# Allow debug encalves (tests are running against developemnt endpoint).
+export OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1
+
+make all
+.buildkite/scripts/test_e2e.sh -t e2e/runtime/runtime-encryption

--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -42,9 +42,12 @@ if [[ ${OASIS_E2E_COVERAGE:-""} != "" ]]; then
 fi
 
 ias_mock="true"
+set +x
 if [[ ${OASIS_IAS_APIKEY:-""} != "" ]]; then
+    set -x
     ias_mock="false"
 fi
+set -x
 
 # Run Oasis test runner.
 ${test_runner_binary} \
@@ -56,8 +59,6 @@ ${test_runner_binary} \
     --e2e/runtime.runtime.loader ${WORKDIR}/target/default/debug/oasis-core-runtime-loader \
     --e2e/runtime.tee_hardware ${OASIS_TEE_HARDWARE:-""} \
     --e2e/runtime.ias.mock=${ias_mock} \
-    ${OASIS_IAS_SPID:+--e2e/runtime.ias.spid ${OASIS_IAS_SPID}} \
-    ${OASIS_IAS_APIKEY:+--e2e/runtime.ias.api_key ${OASIS_IAS_APIKEY}} \
     --remote-signer.binary ${WORKDIR}/go/oasis-remote-signer/oasis-remote-signer \
     --log.level info \
     ${BUILDKITE_PARALLEL_JOB_COUNT:+--parallel.job_count ${BUILDKITE_PARALLEL_JOB_COUNT}} \
@@ -67,10 +68,10 @@ ${test_runner_binary} \
 # Gather the coverage output.
 if [[ "${BUILDKITE:-""}" != "" ]]; then
     if [[ ${OASIS_E2E_COVERAGE:-""} != "" ]]; then
-        merged_file="coverage-merged-e2e-$BUILDKITE_PARALLEL_JOB.txt"
-        if [[ "${OASIS_TEE_HARDWARE:-""}" == "intel-sgx" ]]; then
-            merged_file="coverage-merged-e2e-sgx-$BUILDKITE_PARALLEL_JOB.txt"
-        fi
+        hw_tag="${OASIS_TEE_HARDWARE:+-${OASIS_TEE_HARDWARE}}"
+        step_tag="${BUILDKITE_STEP_KEY:+-${BUILDKITE_STEP_KEY}}"
+        parallel_tag="-${BUILDKITE_PARALLEL_JOB:-0}"
+        merged_file="coverage-merged-e2e${hw_tag}${step_tag}${parallel_tag}.txt"
         gocovmerge coverage-e2e-*.txt >"$merged_file"
     fi
 fi

--- a/.buildkite/scripts/test_e2e.sh
+++ b/.buildkite/scripts/test_e2e.sh
@@ -41,6 +41,11 @@ if [[ ${OASIS_E2E_COVERAGE:-""} != "" ]]; then
     node_binary="${WORKDIR}/scripts/e2e-coverage-wrapper-env.sh"
 fi
 
+ias_mock="true"
+if [[ ${OASIS_IAS_APIKEY:-""} != "" ]]; then
+    ias_mock="false"
+fi
+
 # Run Oasis test runner.
 ${test_runner_binary} \
     ${BUILDKITE:+--basedir ${TEST_BASE_DIR:-$PWD}/e2e} \
@@ -50,6 +55,9 @@ ${test_runner_binary} \
     --e2e/runtime.runtime.binary_dir ${WORKDIR}/target/${runtime_target}/debug \
     --e2e/runtime.runtime.loader ${WORKDIR}/target/default/debug/oasis-core-runtime-loader \
     --e2e/runtime.tee_hardware ${OASIS_TEE_HARDWARE:-""} \
+    --e2e/runtime.ias.mock=${ias_mock} \
+    ${OASIS_IAS_SPID:+--e2e/runtime.ias.spid ${OASIS_IAS_SPID}} \
+    ${OASIS_IAS_APIKEY:+--e2e/runtime.ias.api_key ${OASIS_IAS_APIKEY}} \
     --remote-signer.binary ${WORKDIR}/go/oasis-remote-signer/oasis-remote-signer \
     --log.level info \
     ${BUILDKITE_PARALLEL_JOB_COUNT:+--parallel.job_count ${BUILDKITE_PARALLEL_JOB_COUNT}} \

--- a/.changelog/2883.bugfix.md
+++ b/.changelog/2883.bugfix.md
@@ -1,0 +1,4 @@
+ias: support for IAS API v4
+
+IAS-proxy now proxies to IAS v4 endpoint. Attestation code now works with v4
+IAS API spec.

--- a/.changelog/2883.feature.md
+++ b/.changelog/2883.feature.md
@@ -1,0 +1,1 @@
+oasis-net-runner: add support for running networks with non-mock IAS

--- a/.changelog/2883.internal.md
+++ b/.changelog/2883.internal.md
@@ -1,0 +1,1 @@
+ci: Add CI test for running E2E tests with IAS development API

--- a/go/ias/http/http.go
+++ b/go/ias/http/http.go
@@ -4,20 +4,19 @@ package http
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/net/context/ctxhttp"
 
 	"github.com/oasislabs/oasis-core/go/common/logging"
@@ -32,12 +31,50 @@ var (
 	_ api.Endpoint = (*mockEndpoint)(nil)
 )
 
+const (
+	// iasAPISubscriptionKeyHeader is the header IAS V4 endpoint uses for client
+	// authentication.
+	iasAPISubscriptionKeyHeader = "Ocp-Apim-Subscription-Key"
+	iasAPITimeout               = 10 * time.Second
+	iasAPIProductionBaseURL     = "https://api.trustedservices.intel.com/sgx"
+	iasAPITestingBaseURL        = "https://api.trustedservices.intel.com/sgx/dev"
+	iasAPIAttestationReportPath = "/attestation/v4/report"
+	iasAPISigRLPath             = "/attestation/v4/sigrl/"
+)
+
 type httpEndpoint struct {
-	baseURL    *url.URL
-	httpClient *http.Client
-	trustRoots *x509.CertPool
+	baseURL         *url.URL
+	httpClient      *http.Client
+	trustRoots      *x509.CertPool
+	subscriptionKey string
 
 	spidInfo api.SPIDInfo
+}
+
+func (e *httpEndpoint) doIASRequest(ctx context.Context, method string, uPath string, bodyType string, body io.Reader) (*http.Response, error) {
+	u := *e.baseURL
+	u.Path = path.Join(u.Path, uPath)
+
+	req, err := http.NewRequest(method, u.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", bodyType)
+	}
+	req.Header.Set(iasAPISubscriptionKeyHeader, e.subscriptionKey)
+
+	resp, err := ctxhttp.Do(ctx, e.httpClient, req)
+	if err != nil {
+		logger.Error("ias request error", "err", err, "method", method, "url", u)
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		logger.Error("ias response status error", "status", http.StatusText(resp.StatusCode), "method", method, "url", u)
+		return nil, fmt.Errorf("ias: response status error: %s", http.StatusText(resp.StatusCode))
+	}
+
+	return resp, nil
 }
 
 func (e *httpEndpoint) VerifyEvidence(ctx context.Context, evidence *api.Evidence) (*ias.AVRBundle, error) {
@@ -46,7 +83,7 @@ func (e *httpEndpoint) VerifyEvidence(ctx context.Context, evidence *api.Evidenc
 	// XXX: Should this happen here, or should the caller handle this?
 	var quote ias.Quote
 	if err := quote.UnmarshalBinary(evidence.Quote); err != nil {
-		return nil, errors.Wrap(err, "ias: invalid quoteBinary")
+		return nil, fmt.Errorf("ias: invalid quoteBinary: %w", err)
 	}
 	if len(evidence.Nonce) > ias.NonceMaxLen {
 		return nil, fmt.Errorf("ias: invalid nonce length")
@@ -63,42 +100,30 @@ func (e *httpEndpoint) VerifyEvidence(ctx context.Context, evidence *api.Evidenc
 		Nonce:           evidence.Nonce,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "ias: failed to marshal")
+		return nil, fmt.Errorf("ias: failed to marshal: %w", err)
 	}
 
 	// Dispatch the request via HTTP.
-	u := *e.baseURL
-	u.Path = path.Join(u.Path, "/attestation/sgx/v3/report")
-	resp, err := ctxhttp.Post(ctx, e.httpClient, u.String(), "application/json", bytes.NewReader(reqPayload))
+	resp, err := e.doIASRequest(ctx, http.MethodPost, iasAPIAttestationReportPath, "application/json", bytes.NewReader(reqPayload))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
-		return nil, errors.Wrap(err, "ias: http POST failed")
+		return nil, fmt.Errorf("ias: http POST failed: %w", err)
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Wrapf(err, "ias: http POST returned error: %s", http.StatusText(resp.StatusCode))
-	}
 
 	// Extract the pertinent parts of the response.
 	sig := []byte(resp.Header.Get("X-IASReport-Signature"))
 	certChain := []byte(resp.Header.Get("X-IASReport-Signing-Certificate"))
 	avr, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.Wrap(err, "ias: failed to read response body")
+		return nil, fmt.Errorf("ias: failed to read response body: %w", err)
 	}
 
 	// Ensure that the AVR is valid.
 	if _, err = ias.DecodeAVR(avr, sig, certChain, e.trustRoots, time.Now()); err != nil {
-		return nil, errors.Wrap(err, "ias: failed to parse/validate AVR")
-	}
-
-	// Check for advisories.
-	// TODO: Maybe forward these to the caller.
-	if advisoryIDs := resp.Header.Get("Advisory-IDs"); advisoryIDs != "" {
-		logger.Warn("Received advisory IDs", "advisoryIDs", advisoryIDs)
-	}
-	if advisoryURL := resp.Header.Get("Advisory-URL"); advisoryURL != "" {
-		logger.Warn("Received advisory URL", "advisoryURL", advisoryURL)
+		return nil, fmt.Errorf("ias: failed to parse/validate AVR: %w", err)
 	}
 
 	return &ias.AVRBundle{
@@ -117,27 +142,24 @@ func (e *httpEndpoint) GetSigRL(ctx context.Context, epidGID uint32) ([]byte, er
 	binary.BigEndian.PutUint32(gid[:], epidGID)
 
 	// Dispatch the request via HTTP.
-	u := *e.baseURL
-	u.Path = path.Join(u.Path, "/attestation/sgx/v3/sigrl/"+hex.EncodeToString(gid[:]))
-	resp, err := ctxhttp.Get(ctx, e.httpClient, u.String())
-	if err != nil {
-		return nil, errors.Wrap(err, "ias: http GET failed")
+	p := path.Join(iasAPISigRLPath, hex.EncodeToString(gid[:]))
+	resp, err := e.doIASRequest(ctx, http.MethodGet, p, "", nil)
+	if resp != nil {
+		defer resp.Body.Close()
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Wrapf(err, "ias: http GET returned error: %s", http.StatusText(resp.StatusCode))
+	if err != nil {
+		return nil, fmt.Errorf("ias: http GET failed: %w", err)
 	}
 
 	// Extract and parse the SigRL.
 	sigRL, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.Wrap(err, "ias: failed to read response body")
+		return nil, fmt.Errorf("ias: failed to read response body: %w", err)
 	}
 	var b []byte
 	if len(sigRL) > 0 { // No SigRL is signified by a 0 byte response.
 		if b, err = base64.StdEncoding.DecodeString(string(sigRL)); err != nil {
-			return nil, errors.Wrap(err, "ias: failed to decode SigRL")
+			return nil, fmt.Errorf("ias: failed to decode SigRL: %w", err)
 		}
 	}
 
@@ -164,7 +186,7 @@ func (e *mockEndpoint) VerifyEvidence(ctx context.Context, evidence *api.Evidenc
 
 	avr, err := ias.NewMockAVR(evidence.Quote, evidence.Nonce)
 	if err != nil {
-		return nil, errors.Wrap(err, "ias: failed to generate mock AVR")
+		return nil, fmt.Errorf("ias: failed to generate mock AVR: %w", err)
 	}
 
 	return &ias.AVRBundle{
@@ -185,11 +207,8 @@ func (e *mockEndpoint) Cleanup() {
 
 // Config is the IAS HTTP endpoint configuration.
 type Config struct {
-	// AuthCert is the IAS authentication certificate (and private key).
-	AuthCert *tls.Certificate
-
-	// AuthCertCA is the CA cert for the IAS authentication certificate.
-	AuthCertCA *x509.Certificate
+	// SubscriptionKey is the IAS API key used for client authentication.
+	SubscriptionKey string
 
 	// SPID is the service provider ID.
 	SPID string
@@ -217,11 +236,13 @@ func New(cfg *Config) (api.Endpoint, error) {
 		return nil, err
 	}
 
+	if !cfg.IsProduction {
+		logger.Warn("IsProduction not set, enclaves in debug mode will be allowed")
+		ias.SetAllowDebugEnclaves()
+	}
 	if cfg.DebugIsMock {
 		logger.Warn("DebugSkipVerify set, VerifyEvidence calls will be mocked")
-
-		ias.SetSkipVerify()         // Intel isn't signing anything.
-		ias.SetAllowDebugEnclaves() // Debug enclaves are used for testing.
+		ias.SetSkipVerify() // Intel isn't signing anything.
 		return &mockEndpoint{
 			spidInfo: api.SPIDInfo{
 				SPID:               spidBin,
@@ -230,59 +251,21 @@ func New(cfg *Config) (api.Endpoint, error) {
 		}, nil
 	}
 
-	tlsRoots, err := x509.SystemCertPool()
-	if err != nil {
-		return nil, errors.Wrap(err, "ias: failed to load system cert pool")
-	}
-
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{*cfg.AuthCert},
-		RootCAs:      tlsRoots,
-	}
-
-	// Go's TLS library requires that client certificates be signed with
-	// a cert in the pool that's passed to the TLS client, that also is
-	// used to verify the server cert.
-	mustRevalidate := true
-	if cfg.AuthCertCA != nil {
-		// The caller provided a CA for the authentication cert.
-		tlsRoots.AddCert(cfg.AuthCertCA)
-	} else if _, err = cfg.AuthCert.Leaf.Verify(x509.VerifyOptions{Roots: tlsRoots}); err != nil {
-		if _, ok := err.(x509.UnknownAuthorityError); !ok {
-			// Should never happen.
-			return nil, errors.Wrap(err, "ias: failed to validate client certificate")
-		}
-
-		// The cert is presumably self-signed.
-		tlsRoots.AddCert(cfg.AuthCert.Leaf)
-	} else {
-		// Cert is signed by a CA.
-		mustRevalidate = false
-	}
-	if mustRevalidate {
-		// Ensure that the the client authentication certificate is now
-		// actually signed by a cert in the TLS client cert pool.
-		if _, err = cfg.AuthCert.Leaf.Verify(x509.VerifyOptions{Roots: tlsRoots}); err != nil {
-			return nil, errors.Wrap(err, "ias: failed to verify client certificate CA")
-		}
-	}
-
 	e := &httpEndpoint{
 		httpClient: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: tlsConfig,
-			},
+			Timeout: iasAPITimeout,
 		},
-		trustRoots: ias.IntelTrustRoots,
+		subscriptionKey: cfg.SubscriptionKey,
+		trustRoots:      ias.IntelTrustRoots,
 		spidInfo: api.SPIDInfo{
 			SPID:               spidBin,
 			QuoteSignatureType: cfg.QuoteSignatureType,
 		},
 	}
 	if cfg.IsProduction {
-		e.baseURL, _ = url.Parse("https://as.sgx.trustedservices.intel.com/")
+		e.baseURL, _ = url.Parse(iasAPIProductionBaseURL)
 	} else {
-		e.baseURL, _ = url.Parse("https://test-as.sgx.trustedservices.intel.com/")
+		e.baseURL, _ = url.Parse(iasAPITestingBaseURL)
 	}
 
 	return e, nil

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -53,6 +53,9 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 			ConsensusTimeoutCommit: 1 * time.Second,
 			EpochtimeMock:          viper.GetBool(cfgEpochtimeMock),
 			HaltEpoch:              viper.GetUint64(cfgHaltEpoch),
+			IAS: oasis.IASCfg{
+				Mock: true,
+			},
 		},
 		Entities: []oasis.EntityCfg{
 			oasis.EntityCfg{IsDebugTestEntity: true},

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -510,9 +510,11 @@ func (args *argBuilder) appendIASProxy(iasProxy *iasProxy) *argBuilder {
 		args.vec = append(args.vec, []string{
 			"--" + ias.CfgProxyAddress, "127.0.0.1:" + strconv.Itoa(int(iasProxy.grpcPort)),
 			"--" + ias.CfgTLSCertFile, iasProxy.tlsCertPath(),
-			"--" + ias.CfgDebugSkipVerify,
 			"--" + ias.CfgAllowDebugEnclaves,
 		}...)
+		if iasProxy.mock {
+			args.vec = append(args.vec, "--"+ias.CfgDebugSkipVerify)
+		}
 	}
 	return args
 }

--- a/go/oasis-test-runner/oasis/oasis.go
+++ b/go/oasis-test-runner/oasis/oasis.go
@@ -213,6 +213,16 @@ type Network struct {
 	errCh chan error
 }
 
+// IASCfg is the Oasis test network IAS configuration.
+type IASCfg struct {
+	// UseRegistry specifies whether the IAS proxy should use the registry
+	// instead of the genesis document for authenticating runtime IDs.
+	UseRegistry bool `json:"use_registry,omitempty"`
+
+	// Mock specifies if Mock IAS Proxy should be used.
+	Mock bool `json:"mock,omitempty"`
+}
+
 // NetworkCfg is the Oasis test network configuration.
 type NetworkCfg struct { // nolint: maligned
 	// GenesisFile is an optional genesis file to use.
@@ -245,9 +255,8 @@ type NetworkCfg struct { // nolint: maligned
 	// DeterministicIdentities is the deterministic identities flag.
 	DeterministicIdentities bool `json:"deterministic_identities"`
 
-	// IASUseRegistry specifies whether the IAS proxy should use the registry instead of the
-	// genesis document for authenticating runtime IDs.
-	IASUseRegistry bool `json:"ias_use_registry,omitempty"`
+	// IAS is the Network IAS configuration.
+	IAS IASCfg `json:"ias"`
 
 	// StakingGenesis is the name of a file with a staking genesis document to use if GenesisFile isn't set.
 	StakingGenesis string `json:"staking_genesis"`

--- a/go/oasis-test-runner/scenario/e2e/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime.go
@@ -33,6 +33,8 @@ const (
 	cfgRuntimeBinaryDir = "runtime.binary_dir"
 	cfgRuntimeLoader    = "runtime.loader"
 	cfgTEEHardware      = "tee_hardware"
+
+	cfgIasMock = "ias.mock"
 )
 
 var (
@@ -70,6 +72,8 @@ type runtimeImpl struct {
 	runtimeBinaryDir string
 	runtimeLoader    string
 	TEEHardware      string
+
+	iasMock bool
 }
 
 func newRuntimeImpl(name, clientBinary string, clientArgs []string) *runtimeImpl {
@@ -93,6 +97,7 @@ func (sc *runtimeImpl) Clone() scenario.Scenario {
 		runtimeBinaryDir: sc.runtimeBinaryDir,
 		runtimeLoader:    sc.runtimeLoader,
 		TEEHardware:      sc.TEEHardware,
+		iasMock:          sc.iasMock,
 	}
 }
 
@@ -102,6 +107,9 @@ func (sc *runtimeImpl) Parameters() *flag.FlagSet {
 	f.StringVar(&sc.runtimeBinaryDir, cfgRuntimeBinaryDir, sc.runtimeBinaryDir, "path to the runtime binaries directory")
 	f.StringVar(&sc.runtimeLoader, cfgRuntimeLoader, sc.runtimeLoader, "path to the runtime loader")
 	f.StringVar(&sc.TEEHardware, cfgTEEHardware, sc.TEEHardware, "TEE hardware to use")
+	// XXX: change the default to `true` after:
+	// https://github.com/oasislabs/oasis-core/issues/2897
+	f.BoolVar(&sc.iasMock, cfgIasMock, sc.iasMock, "if mock IAS service should be used")
 
 	return f
 }
@@ -139,6 +147,9 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 			RuntimeLoaderBinary:               sc.runtimeLoader,
 			DefaultLogWatcherHandlerFactories: DefaultRuntimeLogWatcherHandlerFactories,
 			ConsensusGasCostsTxByte:           1,
+			IAS: oasis.IASCfg{
+				Mock: sc.iasMock,
+			},
 		},
 		Entities: []oasis.EntityCfg{
 			oasis.EntityCfg{IsDebugTestEntity: true},

--- a/go/oasis-test-runner/scenario/e2e/runtime_dynamic.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime_dynamic.go
@@ -56,7 +56,7 @@ func (sc *runtimeDynamicImpl) Fixture() (*oasis.NetworkFixture, error) {
 	// Allocate stake and set runtime thresholds.
 	f.Network.StakingGenesis = "tests/fixture-data/runtime-dynamic/staking-genesis.json"
 	// We need IAS proxy to use the registry as we are registering runtimes dynamically.
-	f.Network.IASUseRegistry = true
+	f.Network.IAS.UseRegistry = true
 	// Avoid unexpected blocks.
 	f.Network.EpochtimeMock = true
 	// Exclude all runtimes from genesis as we will register those dynamically.

--- a/runtime/src/common/sgx/avr.rs
+++ b/runtime/src/common/sgx/avr.rs
@@ -271,7 +271,10 @@ pub fn verify(avr: &AVR) -> Fallible<AuthenticatedAVR> {
     let quote_status = avr_body.isv_enclave_quote_status()?;
     match quote_status.as_str() {
         "OK" => {}
-        "GROUP_OUT_OF_DATE" | "CONFIGURATION_NEEDED" => {
+        "GROUP_OUT_OF_DATE"
+        | "CONFIGURATION_NEEDED"
+        | "SW_HARDENING_NEEDED"
+        | "CONFIGURATION_AND_SW_HARDENING_NEEDED" => {
             if strict_avr_verification {
                 return Err(AVRError::QuoteStatusInvalid {
                     status: quote_status.to_owned(),

--- a/tests/fixture-data/net-runner/default.json
+++ b/tests/fixture-data/net-runner/default.json
@@ -13,6 +13,9 @@
         "epochtime_mock": false,
         "epochtime_tendermint_interval": 0,
         "deterministic_identities": false,
+        "ias": {
+            "mock": true
+        },
         "staking_genesis": ""
     },
     "entities": [


### PR DESCRIPTION
Fixes: #1733

TODO:
- [x] test on actual sgx instance 
- [x] update to work with latest (v4) IAS API (ref: https://api.trustedservices.intel.com/documents/sgx-attestation-api-spec.pdf)
  - no more client certs, but client authentication is done with an API key
  - new statuses: `SW_HARDENING_NEEDED` & `CONFIGURATION_AND_SW_HARDENING_NEEDED`
  - advisories moved from response headers into actual report
- [x] setup a job that runs a test with actual IAS (probably daily on master)