### PR TITLE
go/runtime/committee: Restore previously picked node in RR selection

### DIFF
--- a/.changelog/2885.bugfix.md
+++ b/.changelog/2885.bugfix.md
@@ -1,0 +1,10 @@
+go/runtime/committee: Restore previously picked node in RR selection
+
+Previously the round-robin node selection policy would randomize the order on
+every update ignoring the currently picked node. This would cause the current
+node to flip on each update causing problems with EnclaveRPC which is
+stateful.
+
+The fix makes the round-robin node selection policy attempt to restore the
+currently picked node on each update. This means that in case the node is
+still in the node list, it will not change.

--- a/go/oasis-test-runner/scenario/e2e/keymanager_replicate.go
+++ b/go/oasis-test-runner/scenario/e2e/keymanager_replicate.go
@@ -21,12 +21,10 @@ type kmReplicateImpl struct {
 }
 
 func newKmReplicateImpl() scenario.Scenario {
-	// BUG/2885: This should use `simple-keyvalue-enc-client`, but the client
-	// panics when the request goes to the replica.
 	return &kmReplicateImpl{
 		runtimeImpl: *newRuntimeImpl(
 			"keymanager-replication",
-			"simple-keyvalue-client",
+			"simple-keyvalue-enc-client",
 			nil,
 		),
 	}


### PR DESCRIPTION
Fixes #2885 

Previously the round-robin node selection policy would randomize the order on
every update ignoring the currently picked node. This would cause the current
node to flip on each update causing problems with EnclaveRPC which is stateful.

The fix makes the round-robin node selection policy attempt to restore the
currently picked node on each update. This means that in case the node is still
in the node list, it will not change.