### PR TITLE
go/runtime/committee: Don't close gRPC connections on connection refresh

### DIFF
--- a/.changelog/2826.internal.md
+++ b/.changelog/2826.internal.md
@@ -1,0 +1,1 @@
+go/runtime/committee: Don't close gRPC connections on connection refresh

--- a/go/go.mod
+++ b/go/go.mod
@@ -69,8 +69,8 @@ require (
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
-	google.golang.org/grpc v1.28.1
-	google.golang.org/grpc/security/advancedtls v0.0.0-20200406221258-98e4c7ad3eef
+	google.golang.org/grpc v1.29.1
+	google.golang.org/grpc/security/advancedtls v0.0.0-20200504170109-c8482678eb49
 	google.golang.org/protobuf v1.21.0
 	gopkg.in/ini.v1 v1.55.0 // indirect
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -861,8 +861,10 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.28.1 h1:C1QC6KzgSiLyBabDi87BbjaGreoRgGUF5nOyvfrAZ1k=
 google.golang.org/grpc v1.28.1/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
-google.golang.org/grpc/security/advancedtls v0.0.0-20200406221258-98e4c7ad3eef h1:Iuxg0dBV6Cb0vj23A+JR7Csp7tOdgVE4geQJhneVq9k=
-google.golang.org/grpc/security/advancedtls v0.0.0-20200406221258-98e4c7ad3eef/go.mod h1:MqvBVrZckRvDn3WrLNRHuHWrNGuZISOF4ohGDsL+tK4=
+google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
+google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
+google.golang.org/grpc/security/advancedtls v0.0.0-20200504170109-c8482678eb49 h1:0JUa0KgbivB+hPBKMrS/PEPhlzyH2gya70HZFd3Bi6E=
+google.golang.org/grpc/security/advancedtls v0.0.0-20200504170109-c8482678eb49/go.mod h1:MqvBVrZckRvDn3WrLNRHuHWrNGuZISOF4ohGDsL+tK4=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
Fixes #2826 