### PR TITLE
metrics: Ignore labels with empty values

### DIFF
--- a/.changelog/2898.trivial.md
+++ b/.changelog/2898.trivial.md
@@ -1,0 +1,4 @@
+Don't send metric labels with empty values to prometheus
+
+Workaround for
+[pushgateway#344](https://github.com/prometheus/pushgateway/issues/344).

--- a/go/oasis-node/cmd/common/metrics/metrics.go
+++ b/go/oasis-node/cmd/common/metrics/metrics.go
@@ -272,6 +272,18 @@ func GetDefaultPushLabels(ti *env.TestInstanceInfo) map[string]string {
 		for k, v := range flags.GetStringMapString(CfgMetricsLabels) {
 			labels[k] = v
 		}
+
+		// Remove empty label values - workaround for
+		// https://github.com/prometheus/pushgateway/issues/344
+		var emptyKeys []string
+		for k, v := range labels {
+			if v == "" {
+				emptyKeys = append(emptyKeys, k)
+			}
+		}
+		for _, k := range emptyKeys {
+			delete(labels, k)
+		}
 	}
 
 	return labels


### PR DESCRIPTION
Workaround for https://github.com/prometheus/pushgateway/issues/344

Prometheus push gateway rejects labels with empty values (e.g. when SGX is not used `tee_hardware` label is empty). This PR removes labels with empty values before sending them to push gateway.