### PR TITLE
.buildkite: retry exit status '125'

### DIFF
--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -66,6 +66,8 @@ retry: &retry_agent_failure
   automatic:
     - exit_status: -1  # Agent was lost
       limit: 2
+    - exit_status: 125 # ERRO[0092] error waiting for container: unexpected EOF
+      limit: 2
     - exit_status: 255 # Forced agent shutdown
       limit: 2
 

--- a/.changelog/2900.internal.md
+++ b/.changelog/2900.internal.md
@@ -1,0 +1,1 @@
+ci: automatically rety exit status 125 failures


### PR DESCRIPTION
This actually the error we hit when an agent is killed while a docker job is running, so retry it: https://buildkite.com/oasislabs/oasis-core-ci/builds/3755#67e54104-47e9-44cb-8c31-2e1218d6b51c