### PR TITLE
go stats: give ties the same rank

### DIFF
--- a/.changelog/2908.feature.md
+++ b/.changelog/2908.feature.md
@@ -1,0 +1,4 @@
+go/extra/stats: Give ties the same rank
+
+Previously records tied by availability score would get different
+ranks, which was wrong.

--- a/go/extra/stats/cmd/stats.go
+++ b/go/extra/stats/cmd/stats.go
@@ -113,8 +113,14 @@ func (s stats) printEntityAvailability(topN int) {
 	// Print results.
 	written, _ := fmt.Printf("|%-5s|%-64s|%-6s|%13s|%10s|%14s|%9s|%18s|\n", "Rank", "Entity ID", "Nodes", "Had validator", "Signatures", "Times selected", "Proposals", "Availability score")
 	fmt.Println(strings.Repeat("-", written-1))
+	rank := 0
+	tieScore := int64(0)
 	for idx, r := range res {
-		fmt.Printf("|%-5d|%-64s|%6d|%13d|%10d|%14d|%9d|%18d|\n", idx+1, r.entityID, r.nodes, r.elections, r.signatures, r.selections, r.proposals, r.availabilityScore)
+		if idx == 0 || r.availabilityScore != tieScore {
+			rank = idx + 1
+			tieScore = r.availabilityScore
+		}
+		fmt.Printf("|%-5d|%-64s|%6d|%13d|%10d|%14d|%9d|%18d|\n", rank, r.entityID, r.nodes, r.elections, r.signatures, r.selections, r.proposals, r.availabilityScore)
 	}
 }
 


### PR DESCRIPTION
we don't use the "Rank" column from the stats program because it's wrong on ties. we probably still can't use it directly because we often need to combine it across upgrades. but here's some logic to give ties the same rank.