### PR TITLE
staking: Emit events when disbursing fees and rewards

### DIFF
--- a/.changelog/2909.bugfix.md
+++ b/.changelog/2909.bugfix.md
@@ -1,0 +1,9 @@
+staking: Emit events when disbursing fees and rewards
+
+Staking events are now generated when disbursing fees and rewards.
+There are two new special account IDs -- `CommonPoolAccountID` and
+`FeeAccumulatorAccountID` (both defined in `go/staking/api/api.go`),
+which are used only in events to signify the common pool and the fee
+accumulator respectively.
+These account IDs are invalid by design to prevent misusing them
+anywhere else.

--- a/go/common/crypto/signature/signature.go
+++ b/go/common/crypto/signature/signature.go
@@ -666,3 +666,22 @@ func BuildPublicKeyBlacklist(allowTestKeys bool) {
 		blacklistedPublicKeys.Store(pk, true)
 	}
 }
+
+// NewBlacklistedKey returns the PublicKey from the given hex or panics.
+// The given key is also added to the blacklist.
+func NewBlacklistedKey(hex string) PublicKey {
+	var pk PublicKey
+	if err := pk.UnmarshalHex(hex); err != nil {
+		panic(err)
+	}
+
+	// Make sure that the key doesn't already exist in the blacklist.
+	if pk.isBlacklisted() {
+		panic("key already exists in blacklist, use another")
+	}
+
+	// Blacklist key.
+	blacklistedPublicKeys.Store(pk, true)
+
+	return pk
+}

--- a/go/consensus/tendermint/apps/staking/api.go
+++ b/go/consensus/tendermint/apps/staking/api.go
@@ -39,5 +39,5 @@ var (
 
 	// KeyAddEscrow is an ABCI event attribute key for AddEscrow calls
 	// (value is an api.AddEscrowEvent).
-	KeyAddEscrow = []byte("add_escrow")
+	KeyAddEscrow = stakingState.KeyAddEscrow
 )

--- a/go/staking/api/api.go
+++ b/go/staking/api/api.go
@@ -24,6 +24,17 @@ const (
 )
 
 var (
+	// CommonPoolAccountID signifies the common pool in staking events.
+	// The ID is invalid to prevent it being accidentally used in the
+	// actual ledger.
+	CommonPoolAccountID = signature.NewBlacklistedKey("1abe11edc001ffffffffffffffffffffffffffffffffffffffffffffffffffff")
+
+	// FeeAccumulatorAccountID signifies the staking fee accumulator in
+	// staking events.
+	// The ID is invalid to prevent it being accidentally used in the
+	// actual ledger.
+	FeeAccumulatorAccountID = signature.NewBlacklistedKey("1abe11edfeeaccffffffffffffffffffffffffffffffffffffffffffffffffff")
+
 	// ErrInvalidArgument is the error returned on malformed arguments.
 	ErrInvalidArgument = errors.New(ModuleName, 1, "staking: invalid argument")
 
@@ -164,23 +175,23 @@ type Event struct {
 	EscrowEvent   *EscrowEvent   `json:"escrow,omitempty"`
 }
 
-// AddEscrowEvent is the event emitted when a balance is transfered into a escrow
-// balance.
+// AddEscrowEvent is the event emitted when a balance is transfered into
+// an escrow balance.
 type AddEscrowEvent struct {
 	Owner  signature.PublicKey `json:"owner"`
 	Escrow signature.PublicKey `json:"escrow"`
 	Tokens quantity.Quantity   `json:"tokens"`
 }
 
-// TakeEscrowEvent is the event emitted when balanace is deducted from a escrow
-// balance (stake is slashed).
+// TakeEscrowEvent is the event emitted when balance is deducted from an
+// escrow balance (stake is slashed).
 type TakeEscrowEvent struct {
 	Owner  signature.PublicKey `json:"owner"`
 	Tokens quantity.Quantity   `json:"tokens"`
 }
 
-// ReclaimEscrowEvent is the event emitted when tokens are relaimed from a
-// escrow balance back into the entitie's general balance.
+// ReclaimEscrowEvent is the event emitted when tokens are reclaimed from an
+// escrow balance back into the entity's general balance.
 type ReclaimEscrowEvent struct {
 	Owner  signature.PublicKey `json:"owner"`
 	Escrow signature.PublicKey `json:"escrow"`


### PR DESCRIPTION
Fixes #2909.

Staking events are now generated when disbursing fees and rewards.
There are two new special account IDs -- `CommonPoolAccountID` and
`FeeAccumulatorAccountID` (both defined in `go/staking/api/api.go`),
which are used only in events to signify the common pool and the fee
accumulator respectively.
These account IDs are invalid by design to prevent misusing them
anywhere else.
