### PR TITLE
{consensus,control}: Add GetStatus method to API

### DIFF
--- a/.changelog/2902.feature.1.md
+++ b/.changelog/2902.feature.1.md
@@ -1,0 +1,5 @@
+consensus: Add GetStatus method to API
+
+A new `GetStatus` method has been added to the consensus API.
+It returns useful information about the latest block, the genesis
+block, and the node itself.

--- a/.changelog/2902.feature.2.md
+++ b/.changelog/2902.feature.2.md
@@ -1,0 +1,4 @@
+control: Add GetStatus method to API
+
+A new `GetStatus` method has been added to the control API.
+It returns the software version and the status of the consensus layer.

--- a/go/consensus/api/api.go
+++ b/go/consensus/api/api.go
@@ -83,6 +83,9 @@ type ClientBackend interface {
 
 	// GetGenesisDocument returns the original genesis document.
 	GetGenesisDocument(ctx context.Context) (*genesis.Document, error)
+
+	// GetStatus returns the current status overview.
+	GetStatus(ctx context.Context) (*Status, error)
 }
 
 // Block is a consensus block.
@@ -98,6 +101,29 @@ type Block struct {
 	Time time.Time `json:"time"`
 	// Meta contains the consensus backend specific block metadata.
 	Meta cbor.RawMessage `json:"meta"`
+}
+
+// Status is the current status overview.
+type Status struct {
+	// ConsensusVersion is the version of the consensus protocol that the node is using.
+	ConsensusVersion string `json:"consensus_version"`
+	// Backend is the consensus backend identifier.
+	Backend string `json:"backend"`
+
+	// NodePeers is a list of node's peers.
+	NodePeers []string `json:"node_peers"`
+
+	// LatestHeight is the height of the latest block.
+	LatestHeight int64 `json:"latest_height"`
+	// LatestHash is the hash of the latest block.
+	LatestHash []byte `json:"latest_hash"`
+	// LatestTime is the timestamp of the latest block.
+	LatestTime time.Time `json:"latest_time"`
+
+	// GenesisHeight is the height of the genesis block.
+	GenesisHeight int64 `json:"genesis_height"`
+	// GenesisHash is the hash of the genesis block.
+	GenesisHash []byte `json:"genesis_hash"`
 }
 
 // Backend is an interface that a consensus backend must provide.

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -37,6 +37,13 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.ClientBackend)
 	require.NotNil(blk, "returned block should not be nil")
 	require.True(blk.Height > 0, "block height should be greater than zero")
 
+	status, err := backend.GetStatus(ctx)
+	require.NoError(err, "GetStatus")
+	require.NotNil(status, "returned status should not be nil")
+	require.EqualValues(genDoc.Height, status.GenesisHeight)
+	require.EqualValues(blk.Height, status.LatestHeight, "latest block heights should match")
+	require.EqualValues(blk.Hash, status.LatestHash, "latest block hashes should match")
+
 	_, err = backend.GetTransactions(ctx, consensus.HeightLatest)
 	require.NoError(err, "GetTransactions")
 

--- a/go/control/api/api.go
+++ b/go/control/api/api.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/oasislabs/oasis-core/go/common/errors"
+	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	upgrade "github.com/oasislabs/oasis-core/go/upgrade/api"
 )
@@ -32,6 +33,18 @@ type NodeController interface {
 
 	// CancelUpgrade cancels a pending upgrade, unless it is already in progress.
 	CancelUpgrade(ctx context.Context) error
+
+	// GetStatus returns the current status overview of the node.
+	GetStatus(ctx context.Context) (*Status, error)
+}
+
+// Status is the current status overview.
+type Status struct {
+	// SoftwareVersion is the oasis-node software version.
+	SoftwareVersion string `json:"software_version"`
+
+	// Consensus is the status overview of the consensus layer.
+	Consensus consensus.Status `json:"consensus"`
 }
 
 // Shutdownable is an interface the node presents for shutting itself down.

--- a/go/control/api/grpc.go
+++ b/go/control/api/grpc.go
@@ -23,6 +23,8 @@ var (
 	methodUpgradeBinary = serviceName.NewMethod("UpgradeBinary", upgradeApi.Descriptor{})
 	// methodCancelUpgrade is the CancelUpgrade method.
 	methodCancelUpgrade = serviceName.NewMethod("CancelUpgrade", nil)
+	// methodGetStatus is the GetStatus method.
+	methodGetStatus = serviceName.NewMethod("GetStatus", nil)
 
 	// serviceDesc is the gRPC service descriptor.
 	serviceDesc = grpc.ServiceDesc{
@@ -48,6 +50,10 @@ var (
 			{
 				MethodName: methodCancelUpgrade.ShortName(),
 				Handler:    handlerCancelUpgrade,
+			},
+			{
+				MethodName: methodGetStatus.ShortName(),
+				Handler:    handlerGetStatus,
 			},
 		},
 		Streams: []grpc.StreamDesc{},
@@ -157,6 +163,25 @@ func handlerCancelUpgrade( // nolint: golint
 	return interceptor(ctx, nil, info, handler)
 }
 
+func handlerGetStatus( // nolint: golint
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	if interceptor == nil {
+		return srv.(NodeController).GetStatus(ctx)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: methodGetStatus.FullName(),
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NodeController).GetStatus(ctx)
+	}
+	return interceptor(ctx, nil, info, handler)
+}
+
 // RegisterService registers a new node controller service with the given gRPC server.
 func RegisterService(server *grpc.Server, service NodeController) {
 	server.RegisterService(&serviceDesc, service)
@@ -188,6 +213,14 @@ func (c *nodeControllerClient) UpgradeBinary(ctx context.Context, descriptor *up
 
 func (c *nodeControllerClient) CancelUpgrade(ctx context.Context) error {
 	return c.conn.Invoke(ctx, methodCancelUpgrade.FullName(), nil, nil)
+}
+
+func (c *nodeControllerClient) GetStatus(ctx context.Context) (*Status, error) {
+	var rsp Status
+	if err := c.conn.Invoke(ctx, methodGetStatus.FullName(), nil, &rsp); err != nil {
+		return nil, err
+	}
+	return &rsp, nil
 }
 
 // NewNodeControllerClient creates a new gRPC node controller client service.

--- a/go/control/control.go
+++ b/go/control/control.go
@@ -4,6 +4,7 @@ package control
 import (
 	"context"
 
+	"github.com/oasislabs/oasis-core/go/common/version"
 	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
 	control "github.com/oasislabs/oasis-core/go/control/api"
 	upgrade "github.com/oasislabs/oasis-core/go/upgrade/api"
@@ -57,6 +58,18 @@ func (c *nodeController) UpgradeBinary(ctx context.Context, descriptor *upgrade.
 
 func (c *nodeController) CancelUpgrade(ctx context.Context) error {
 	return c.upgrader.CancelUpgrade(ctx)
+}
+
+func (c *nodeController) GetStatus(ctx context.Context) (*control.Status, error) {
+	cs, err := c.consensus.GetStatus(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &control.Status{
+		SoftwareVersion: version.SoftwareVersion,
+		Consensus:       *cs,
+	}, nil
 }
 
 // New creates a new oasis-node controller.


### PR DESCRIPTION
Closes #2902.

* consensus: Add GetStatus method to API

    A new `GetStatus` method has been added to the consensus API.
    It returns useful information about the latest block, the genesis
    block, and the node itself.

* control: Add GetStatus method to API

    A new `GetStatus` method has been added to the control API.
    It returns the software version and the status of the consensus layer.
