### PR TITLE
Version signed entity, node and runtime descriptors

### DIFF
--- a/.changelog/2581.feature.md
+++ b/.changelog/2581.feature.md
@@ -1,0 +1,9 @@
+Version signed entity, node and runtime descriptors
+
+This introduces a DescriptorVersion field to all entity, node and runtime
+descriptors to support future updates and handling of legacy descriptors at
+genesis.
+
+All new registrations only accept the latest version while initializing from
+genesis is also allowed with an older version to support a dump/restore
+upgrade.

--- a/go/consensus/tendermint/apps/keymanager/genesis.go
+++ b/go/consensus/tendermint/apps/keymanager/genesis.go
@@ -31,7 +31,7 @@ func (app *keymanagerApplication) InitChain(ctx *tmapi.Context, request types.Re
 	regSt := doc.Registry
 	rtMap := make(map[common.Namespace]*registry.Runtime)
 	for _, v := range regSt.Runtimes {
-		rt, err := registry.VerifyRegisterRuntimeArgs(&regSt.Parameters, ctx.Logger(), v, true)
+		rt, err := registry.VerifyRegisterRuntimeArgs(&regSt.Parameters, ctx.Logger(), v, true, false)
 		if err != nil {
 			ctx.Logger().Error("InitChain: Invalid runtime",
 				"err", err,

--- a/go/consensus/tendermint/apps/registry/genesis.go
+++ b/go/consensus/tendermint/apps/registry/genesis.go
@@ -49,7 +49,7 @@ func (app *registryApplication) InitChain(ctx *abciAPI.Context, request types.Re
 			if v == nil {
 				return fmt.Errorf("registry: genesis runtime index %d is nil", i)
 			}
-			rt, err := registry.VerifyRegisterRuntimeArgs(&st.Parameters, ctx.Logger(), v, ctx.IsInitChain())
+			rt, err := registry.VerifyRegisterRuntimeArgs(&st.Parameters, ctx.Logger(), v, ctx.IsInitChain(), false)
 			if err != nil {
 				return err
 			}

--- a/go/consensus/tendermint/apps/registry/state/state_test.go
+++ b/go/consensus/tendermint/apps/registry/state/state_test.go
@@ -40,7 +40,8 @@ func TestNodeUpdate(t *testing.T) {
 
 	// Create a new node.
 	n := node.Node{
-		ID: nodeSigner.Public(),
+		DescriptorVersion: node.LatestNodeDescriptorVersion,
+		ID:                nodeSigner.Public(),
 		P2P: node.P2PInfo{
 			ID: p2pSigner1.Public(),
 		},

--- a/go/consensus/tendermint/apps/registry/transactions.go
+++ b/go/consensus/tendermint/apps/registry/transactions.go
@@ -18,7 +18,7 @@ func (app *registryApplication) registerEntity(
 	state *registryState.MutableState,
 	sigEnt *entity.SignedEntity,
 ) error {
-	ent, err := registry.VerifyRegisterEntityArgs(ctx.Logger(), sigEnt, ctx.IsInitChain())
+	ent, err := registry.VerifyRegisterEntityArgs(ctx.Logger(), sigEnt, ctx.IsInitChain(), false)
 	if err != nil {
 		return err
 	}
@@ -198,6 +198,7 @@ func (app *registryApplication) registerNode( // nolint: gocyclo
 		untrustedEntity,
 		ctx.Now(),
 		ctx.IsInitChain(),
+		false,
 		epoch,
 		state,
 		state,
@@ -503,7 +504,7 @@ func (app *registryApplication) registerRuntime( // nolint: gocyclo
 		return registry.ErrForbidden
 	}
 
-	rt, err := registry.VerifyRegisterRuntimeArgs(params, ctx.Logger(), sigRt, ctx.IsInitChain())
+	rt, err := registry.VerifyRegisterRuntimeArgs(params, ctx.Logger(), sigRt, ctx.IsInitChain(), false)
 	if err != nil {
 		return err
 	}

--- a/go/consensus/tendermint/apps/staking/slashing_test.go
+++ b/go/consensus/tendermint/apps/staking/slashing_test.go
@@ -50,8 +50,9 @@ func TestOnEvidenceDoubleSign(t *testing.T) {
 	// Add node.
 	nodeSigner := memorySigner.NewTestSigner("node test signer")
 	nod := &node.Node{
-		ID:       nodeSigner.Public(),
-		EntityID: ent.ID,
+		DescriptorVersion: node.LatestNodeDescriptorVersion,
+		ID:                nodeSigner.Public(),
+		EntityID:          ent.ID,
 		Consensus: node.ConsensusInfo{
 			ID: consensusID,
 		},

--- a/go/genesis/genesis_test.go
+++ b/go/genesis/genesis_test.go
@@ -160,6 +160,7 @@ func TestGenesisSanityCheck(t *testing.T) {
 	// Note that this test entity has no nodes by design, those will be added
 	// later by various tests.
 	testEntity := &entity.Entity{
+		DescriptorVersion:      entity.LatestEntityDescriptorVersion,
 		ID:                     validPK,
 		AllowEntitySignedNodes: true,
 	}
@@ -167,9 +168,10 @@ func TestGenesisSanityCheck(t *testing.T) {
 
 	kmRuntimeID := hex2ns("4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff", false)
 	testKMRuntime := &registry.Runtime{
-		ID:       kmRuntimeID,
-		EntityID: testEntity.ID,
-		Kind:     registry.KindKeyManager,
+		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+		ID:                kmRuntimeID,
+		EntityID:          testEntity.ID,
+		Kind:              registry.KindKeyManager,
 		AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 			EntityWhitelist: &registry.EntityWhitelistRuntimeAdmissionPolicy{
 				Entities: map[signature.PublicKey]bool{
@@ -182,10 +184,11 @@ func TestGenesisSanityCheck(t *testing.T) {
 
 	testRuntimeID := hex2ns("0000000000000000000000000000000000000000000000000000000000000001", false)
 	testRuntime := &registry.Runtime{
-		ID:         testRuntimeID,
-		EntityID:   testEntity.ID,
-		Kind:       registry.KindCompute,
-		KeyManager: &testKMRuntime.ID,
+		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+		ID:                testRuntimeID,
+		EntityID:          testEntity.ID,
+		Kind:              registry.KindCompute,
+		KeyManager:        &testKMRuntime.ID,
 		Executor: registry.ExecutorParameters{
 			GroupSize:    1,
 			RoundTimeout: 1 * time.Second,
@@ -223,10 +226,11 @@ func TestGenesisSanityCheck(t *testing.T) {
 	var testAddress node.Address
 	_ = testAddress.UnmarshalText([]byte("127.0.0.1:1234"))
 	testNode := &node.Node{
-		ID:         nodeSigner.Public(),
-		EntityID:   testEntity.ID,
-		Expiration: 10,
-		Roles:      node.RoleValidator,
+		DescriptorVersion: node.LatestNodeDescriptorVersion,
+		ID:                nodeSigner.Public(),
+		EntityID:          testEntity.ID,
+		Expiration:        10,
+		Roles:             node.RoleValidator,
 		Committee: node.CommitteeInfo{
 			Certificate: dummyCert.Certificate[0],
 			Addresses: []node.CommitteeAddress{

--- a/go/oasis-node/cmd/debug/byzantine/registry.go
+++ b/go/oasis-node/cmd/debug/byzantine/registry.go
@@ -42,9 +42,10 @@ func registryRegisterNode(svc service.TendermintService, id *identity.Identity, 
 	}
 
 	nodeDesc := &node.Node{
-		ID:         id.NodeSigner.Public(),
-		EntityID:   entityID,
-		Expiration: 1000,
+		DescriptorVersion: node.LatestNodeDescriptorVersion,
+		ID:                id.NodeSigner.Public(),
+		EntityID:          entityID,
+		Expiration:        1000,
 		Committee: node.CommitteeInfo{
 			Certificate: id.GetTLSCertificate().Certificate[0],
 			Addresses:   committeeAddresses,

--- a/go/oasis-node/cmd/debug/txsource/workload/registration.go
+++ b/go/oasis-node/cmd/debug/txsource/workload/registration.go
@@ -42,9 +42,10 @@ type registration struct {
 
 func getRuntime(entityID signature.PublicKey, id common.Namespace) *registry.Runtime {
 	rt := &registry.Runtime{
-		ID:       id,
-		EntityID: entityID,
-		Kind:     registry.KindCompute,
+		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+		ID:                id,
+		EntityID:          entityID,
+		Kind:              registry.KindCompute,
 		Executor: registry.ExecutorParameters{
 			GroupSize:    1,
 			RoundTimeout: 1 * time.Second,
@@ -94,10 +95,11 @@ func getNodeDesc(rng *rand.Rand, nodeIdentity *identity.Identity, entityID signa
 	}
 
 	nodeDesc := node.Node{
-		ID:         nodeIdentity.NodeSigner.Public(),
-		EntityID:   entityID,
-		Expiration: 0,
-		Roles:      availableRoles[rng.Intn(len(availableRoles))],
+		DescriptorVersion: node.LatestNodeDescriptorVersion,
+		ID:                nodeIdentity.NodeSigner.Public(),
+		EntityID:          entityID,
+		Expiration:        0,
+		Roles:             availableRoles[rng.Intn(len(availableRoles))],
 		Committee: node.CommitteeInfo{
 			Certificate: nodeIdentity.GetTLSCertificate().Certificate[0],
 			Addresses: []node.CommitteeAddress{
@@ -204,7 +206,8 @@ func (r *registration) Run( // nolint: gocyclo
 		}
 
 		ent := &entity.Entity{
-			ID: entityAccs[i].signer.Public(),
+			DescriptorVersion: entity.LatestEntityDescriptorVersion,
+			ID:                entityAccs[i].signer.Public(),
 		}
 
 		// Generate entity node identities.

--- a/go/oasis-node/cmd/registry/entity/entity.go
+++ b/go/oasis-node/cmd/registry/entity/entity.go
@@ -374,6 +374,7 @@ func loadOrGenerateEntity(dataDir string, generate bool) (*entity.Entity, signat
 
 	if generate {
 		template := &entity.Entity{
+			DescriptorVersion:      entity.LatestEntityDescriptorVersion,
 			AllowEntitySignedNodes: viper.GetBool(cfgAllowEntitySignedNodes),
 		}
 

--- a/go/oasis-node/cmd/registry/node/node.go
+++ b/go/oasis-node/cmd/registry/node/node.go
@@ -176,9 +176,10 @@ func doInit(cmd *cobra.Command, args []string) { // nolint: gocyclo
 	}
 
 	n := &node.Node{
-		ID:         nodeIdentity.NodeSigner.Public(),
-		EntityID:   entityID,
-		Expiration: viper.GetUint64(CfgExpiration),
+		DescriptorVersion: node.LatestNodeDescriptorVersion,
+		ID:                nodeIdentity.NodeSigner.Public(),
+		EntityID:          entityID,
+		Expiration:        viper.GetUint64(CfgExpiration),
 		Committee: node.CommitteeInfo{
 			Certificate:     nodeIdentity.GetTLSCertificate().Certificate[0],
 			NextCertificate: nextCert,

--- a/go/oasis-node/cmd/registry/runtime/runtime.go
+++ b/go/oasis-node/cmd/registry/runtime/runtime.go
@@ -353,11 +353,12 @@ func runtimeFromFlags() (*registry.Runtime, signature.Signer, error) {
 	}
 
 	rt := &registry.Runtime{
-		ID:          id,
-		EntityID:    signer.Public(),
-		Genesis:     gen,
-		Kind:        kind,
-		TEEHardware: teeHardware,
+		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+		ID:                id,
+		EntityID:          signer.Public(),
+		Genesis:           gen,
+		Kind:              kind,
+		TEEHardware:       teeHardware,
 		Version: registry.VersionInfo{
 			Version: version.FromU64(viper.GetUint64(CfgVersion)),
 		},

--- a/go/oasis-node/node_test.go
+++ b/go/oasis-node/node_test.go
@@ -79,6 +79,7 @@ var (
 	}
 
 	testRuntime = &registry.Runtime{
+		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
 		// ID: default value,
 		// EntityID: test entity,
 		Kind: registry.KindCompute,

--- a/go/oasis-test-runner/oasis/runtime.go
+++ b/go/oasis-test-runner/oasis/runtime.go
@@ -115,15 +115,16 @@ func (rt *Runtime) GetGenesisStatePath() string {
 // NewRuntime provisions a new runtime and adds it to the network.
 func (net *Network) NewRuntime(cfg *RuntimeCfg) (*Runtime, error) {
 	descriptor := registry.Runtime{
-		ID:              cfg.ID,
-		EntityID:        cfg.Entity.entity.ID,
-		Kind:            cfg.Kind,
-		TEEHardware:     cfg.TEEHardware,
-		Executor:        cfg.Executor,
-		Merge:           cfg.Merge,
-		TxnScheduler:    cfg.TxnScheduler,
-		Storage:         cfg.Storage,
-		AdmissionPolicy: cfg.AdmissionPolicy,
+		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+		ID:                cfg.ID,
+		EntityID:          cfg.Entity.entity.ID,
+		Kind:              cfg.Kind,
+		TEEHardware:       cfg.TEEHardware,
+		Executor:          cfg.Executor,
+		Merge:             cfg.Merge,
+		TxnScheduler:      cfg.TxnScheduler,
+		Storage:           cfg.Storage,
+		AdmissionPolicy:   cfg.AdmissionPolicy,
 	}
 
 	rtDir, err := net.baseDir.NewSubDir("runtime-" + cfg.ID.String())

--- a/go/oasis-test-runner/scenario/e2e/registry_cli.go
+++ b/go/oasis-test-runner/scenario/e2e/registry_cli.go
@@ -402,9 +402,10 @@ func (r *registryCLIImpl) newTestNode(entityID signature.PublicKey) (*node.Node,
 	}
 
 	testNode := node.Node{
-		ID:         signature.PublicKey{}, // ID is generated afterwards.
-		EntityID:   entityID,
-		Expiration: 42,
+		DescriptorVersion: node.LatestNodeDescriptorVersion,
+		ID:                signature.PublicKey{}, // ID is generated afterwards.
+		EntityID:          entityID,
+		Expiration:        42,
 		Committee: node.CommitteeInfo{
 			Certificate: []byte{}, // Certificate is generated afterwards.
 			Addresses:   testCommitteeAddresses,
@@ -605,8 +606,9 @@ func (r *registryCLIImpl) testRuntime(childEnv *env.Env, cli *cli.Helpers) error
 		return fmt.Errorf("TestEntity: %w", err)
 	}
 	testRuntime := registry.Runtime{
-		EntityID: testEntity.ID,
-		Kind:     registry.KindCompute,
+		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+		EntityID:          testEntity.ID,
+		Kind:              registry.KindCompute,
 		Executor: registry.ExecutorParameters{
 			GroupSize:         1,
 			GroupBackupSize:   2,

--- a/go/registry/api/sanity_check.go
+++ b/go/registry/api/sanity_check.go
@@ -77,7 +77,7 @@ func (g *Genesis) SanityCheck(
 func SanityCheckEntities(logger *logging.Logger, entities []*entity.SignedEntity) (map[signature.PublicKey]*entity.Entity, error) {
 	seenEntities := make(map[signature.PublicKey]*entity.Entity)
 	for _, signedEnt := range entities {
-		entity, err := VerifyRegisterEntityArgs(logger, signedEnt, true)
+		entity, err := VerifyRegisterEntityArgs(logger, signedEnt, true, true)
 		if err != nil {
 			return nil, fmt.Errorf("entity sanity check failed: %w", err)
 		}
@@ -98,7 +98,7 @@ func SanityCheckRuntimes(
 	// First go through all runtimes and perform general sanity checks.
 	seenRuntimes := []*Runtime{}
 	for _, signedRt := range runtimes {
-		rt, err := VerifyRegisterRuntimeArgs(params, logger, signedRt, isGenesis)
+		rt, err := VerifyRegisterRuntimeArgs(params, logger, signedRt, isGenesis, true)
 		if err != nil {
 			return nil, fmt.Errorf("runtime sanity check failed: %w", err)
 		}
@@ -107,7 +107,7 @@ func SanityCheckRuntimes(
 
 	seenSuspendedRuntimes := []*Runtime{}
 	for _, signedRt := range suspendedRuntimes {
-		rt, err := VerifyRegisterRuntimeArgs(params, logger, signedRt, isGenesis)
+		rt, err := VerifyRegisterRuntimeArgs(params, logger, signedRt, isGenesis, true)
 		if err != nil {
 			return nil, fmt.Errorf("runtime sanity check failed: %w", err)
 		}
@@ -174,6 +174,7 @@ func SanityCheckNodes(
 			entity,
 			time.Now(),
 			isGenesis,
+			true,
 			epoch,
 			runtimesLookup,
 			nodeLookup,

--- a/go/roothash/api/commitment/pool_test.go
+++ b/go/roothash/api/commitment/pool_test.go
@@ -61,8 +61,9 @@ type staticNodeLookup struct {
 
 func (n *staticNodeLookup) Node(ctx context.Context, id signature.PublicKey) (*node.Node, error) {
 	return &node.Node{
-		ID:       id,
-		Runtimes: []*node.Runtime{n.runtime},
+		DescriptorVersion: node.LatestNodeDescriptorVersion,
+		ID:                id,
+		Runtimes:          []*node.Runtime{n.runtime},
 	}, nil
 }
 
@@ -109,9 +110,10 @@ func TestPoolSingleCommitment(t *testing.T) {
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt := &registry.Runtime{
-		ID:          rtID,
-		Kind:        registry.KindCompute,
-		TEEHardware: node.TEEHardwareInvalid,
+		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+		ID:                rtID,
+		Kind:              registry.KindCompute,
+		TEEHardware:       node.TEEHardwareInvalid,
 	}
 
 	// Generate a commitment signing key.
@@ -211,9 +213,10 @@ func TestPoolSingleCommitmentTEE(t *testing.T) {
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt := &registry.Runtime{
-		ID:          rtID,
-		Kind:        registry.KindCompute,
-		TEEHardware: node.TEEHardwareIntelSGX,
+		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+		ID:                rtID,
+		Kind:              registry.KindCompute,
+		TEEHardware:       node.TEEHardwareIntelSGX,
 	}
 
 	// Generate a commitment signing key.
@@ -442,9 +445,10 @@ func TestPoolSerialization(t *testing.T) {
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt := &registry.Runtime{
-		ID:          rtID,
-		Kind:        registry.KindCompute,
-		TEEHardware: node.TEEHardwareInvalid,
+		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+		ID:                rtID,
+		Kind:              registry.KindCompute,
+		TEEHardware:       node.TEEHardwareInvalid,
 	}
 
 	// Generate a commitment signing key.
@@ -1088,9 +1092,10 @@ func generateMockCommittee(t *testing.T) (
 	_ = rtID.UnmarshalHex("0000000000000000000000000000000000000000000000000000000000000000")
 
 	rt = &registry.Runtime{
-		ID:          rtID,
-		Kind:        registry.KindCompute,
-		TEEHardware: node.TEEHardwareInvalid,
+		DescriptorVersion: registry.LatestRuntimeDescriptorVersion,
+		ID:                rtID,
+		Kind:              registry.KindCompute,
+		TEEHardware:       node.TEEHardwareInvalid,
 	}
 
 	// Generate commitment signing keys.

--- a/go/worker/registration/worker.go
+++ b/go/worker/registration/worker.go
@@ -569,9 +569,10 @@ func (w *Worker) registerNode(epoch epochtime.EpochTime, hook RegisterNodeHook) 
 	}
 
 	nodeDesc := node.Node{
-		ID:         identityPublic,
-		EntityID:   w.entityID,
-		Expiration: uint64(epoch) + 2,
+		DescriptorVersion: node.LatestNodeDescriptorVersion,
+		ID:                identityPublic,
+		EntityID:          w.entityID,
+		Expiration:        uint64(epoch) + 2,
 		Committee: node.CommitteeInfo{
 			Certificate:     w.identity.GetTLSCertificate().Certificate[0],
 			NextCertificate: nextCert,


### PR DESCRIPTION
Fixes #2581 

This introduces a DescriptorVersion field to all entity, node and runtime
descriptors to support future updates and handling of legacy descriptors at
genesis.

All new registrations only accept the latest version while initializing from
genesis is also allowed with an older version to support a dump/restore upgrade.