### PR TITLE
KM upgrade E2E test

### DIFF
--- a/.buildkite/benchmarks.pipeline.yml
+++ b/.buildkite/benchmarks.pipeline.yml
@@ -97,14 +97,17 @@ steps:
     command:
       - .buildkite/rust/build_runtime.sh tests/runtimes/simple-keymanager
       - .buildkite/rust/build_runtime.sh tests/runtimes/simple-keyvalue
+      - .buildkite/rust/build_runtime.sh tests/runtimes/simple-keymanager-upgrade
 
       # Upload the built artifacts.
       - cd /var/tmp/artifacts/sgx/x86_64-fortanix-unknown-sgx/debug
       - buildkite-agent artifact upload simple-keymanager.sgxs
       - buildkite-agent artifact upload simple-keyvalue.sgxs
+      - buildkite-agent artifact upload simple-keymanager-upgrade.sgxs
       - cd /var/tmp/artifacts/default/debug
       - buildkite-agent artifact upload simple-keymanager
       - buildkite-agent artifact upload simple-keyvalue
+      - buildkite-agent artifact upload simple-keymanager-upgrade
     agents:
       buildkite_agent_size: large
     plugins:

--- a/.buildkite/code.pipeline.yml
+++ b/.buildkite/code.pipeline.yml
@@ -159,14 +159,17 @@ steps:
     command:
       - .buildkite/rust/build_runtime.sh tests/runtimes/simple-keymanager
       - .buildkite/rust/build_runtime.sh tests/runtimes/simple-keyvalue
+      - .buildkite/rust/build_runtime.sh tests/runtimes/simple-keymanager-upgrade
 
       # Upload the built artifacts.
       - cd /var/tmp/artifacts/sgx/x86_64-fortanix-unknown-sgx/debug
       - buildkite-agent artifact upload simple-keymanager.sgxs
       - buildkite-agent artifact upload simple-keyvalue.sgxs
+      - buildkite-agent artifact upload simple-keymanager-upgrade.sgxs
       - cd /var/tmp/artifacts/default/debug
       - buildkite-agent artifact upload simple-keymanager
       - buildkite-agent artifact upload simple-keyvalue
+      - buildkite-agent artifact upload simple-keymanager-upgrade
     agents:
       buildkite_agent_size: large
     retry:

--- a/.buildkite/longtests.pipeline.yml
+++ b/.buildkite/longtests.pipeline.yml
@@ -81,14 +81,17 @@ steps:
     command:
       - .buildkite/rust/build_runtime.sh tests/runtimes/simple-keymanager
       - .buildkite/rust/build_runtime.sh tests/runtimes/simple-keyvalue
+      - .buildkite/rust/build_runtime.sh tests/runtimes/simple-keymanager-upgrade
 
       # Upload the built artifacts.
       - cd /var/tmp/artifacts/sgx/x86_64-fortanix-unknown-sgx/debug
       - buildkite-agent artifact upload simple-keymanager.sgxs
       - buildkite-agent artifact upload simple-keyvalue.sgxs
+      - buildkite-agent artifact upload simple-keymanager-upgrade.sgxs
       - cd /var/tmp/artifacts/default/debug
       - buildkite-agent artifact upload simple-keymanager
       - buildkite-agent artifact upload simple-keyvalue
+      - buildkite-agent artifact upload simple-keymanager-upgrade
     agents:
       buildkite_agent_size: large
     plugins:

--- a/.buildkite/scripts/download_e2e_test_artifacts.sh
+++ b/.buildkite/scripts/download_e2e_test_artifacts.sh
@@ -24,6 +24,10 @@ download_artifact oasis-core-runtime-loader target/default/debug 755
 download_artifact simple-keymanager.sgxs target/sgx/x86_64-fortanix-unknown-sgx/debug 755
 download_artifact simple-keymanager target/default/debug 755
 
+# Simple Key manager runtime used in keymenager upgrade test.
+download_artifact simple-keymanager-upgrade.sgxs target/sgx/x86_64-fortanix-unknown-sgx/debug 755
+download_artifact simple-keymanager-upgrade target/default/debug 755
+
 # Test simple-keyvalue runtime and clients.
 download_artifact test-long-term-client target/default/debug 755
 download_artifact simple-keyvalue-client target/default/debug 755

--- a/.changelog/2517.bugfix.md
+++ b/.changelog/2517.bugfix.md
@@ -1,0 +1,6 @@
+go/worker/keymanager: retry initialization in case of failure
+
+The keymanager worker registers only after the initialization either fails or
+succeeds. In case the worker needs to replicate the first initialization will
+always fail, since other nodes' access control prevents it from replicating.
+In that case the initialization should be retried.

--- a/.changelog/2517.feature.md
+++ b/.changelog/2517.feature.md
@@ -1,0 +1,1 @@
+e2e/tests: added keymanager runtime upgrade test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,6 +1337,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple-keymanager-upgrade"
+version = "0.3.0-alpha"
+dependencies = [
+ "oasis-core-keymanager-api-common 0.3.0-alpha",
+ "oasis-core-keymanager-lib 0.3.0-alpha",
+ "oasis-core-runtime 0.3.0-alpha",
+ "oasis-core-tools 0.3.0-alpha",
+]
+
+[[package]]
 name = "simple-keyvalue"
 version = "0.3.0-alpha"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ members = [
     # Test runtimes.
     "tests/runtimes/simple-keyvalue",
     "tests/runtimes/simple-keymanager",
+    "tests/runtimes/simple-keymanager-upgrade",
+
     # Test clients.
     "tests/clients/simple-keyvalue",
     "tests/clients/simple-keyvalue-enc",

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ include common.mk
 
 # List of runtimes to build.
 RUNTIMES := tests/runtimes/simple-keyvalue \
-	tests/runtimes/simple-keymanager
+	tests/runtimes/simple-keymanager \
+	tests/runtimes/simple-keymanager-upgrade
 
 # Set all target as the default target.
 all: build

--- a/go/oasis-net-runner/fixtures/default.go
+++ b/go/oasis-net-runner/fixtures/default.go
@@ -67,7 +67,7 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 				Kind:       registry.KindKeyManager,
 				Entity:     0,
 				Keymanager: -1,
-				Binary:     viper.GetString(cfgKeymanagerBinary),
+				Binaries:   viper.GetStringSlice(cfgKeymanagerBinary),
 				AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 					AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},
 				},
@@ -78,7 +78,7 @@ func newDefaultFixture() (*oasis.NetworkFixture, error) {
 				Kind:       registry.KindCompute,
 				Entity:     0,
 				Keymanager: 0,
-				Binary:     viper.GetString(cfgRuntimeBinary),
+				Binaries:   viper.GetStringSlice(cfgRuntimeBinary),
 				Executor: registry.ExecutorParameters{
 					GroupSize:       2,
 					GroupBackupSize: 1,

--- a/go/oasis-test-runner/oasis/args.go
+++ b/go/oasis-test-runner/oasis/args.go
@@ -454,9 +454,9 @@ func (args *argBuilder) appendRuntimePruner(p *RuntimePrunerCfg) *argBuilder {
 	return args
 }
 
-func (args *argBuilder) appendComputeNodeRuntime(rt *Runtime) *argBuilder {
+func (args *argBuilder) appendComputeNodeRuntime(rt *Runtime, binaryIdx int) *argBuilder {
 	args = args.runtimeSupported(rt.id).
-		workerRuntimePath(rt.id, rt.binary).
+		workerRuntimePath(rt.id, rt.binaries[binaryIdx]).
 		appendRuntimePruner(&rt.pruner)
 	return args
 }
@@ -494,7 +494,7 @@ func (args *argBuilder) byzantineFakeSGX() *argBuilder {
 
 func (args *argBuilder) byzantineVersionFakeEnclaveID(rt *Runtime) *argBuilder {
 	eid := sgx.EnclaveIdentity{
-		MrEnclave: *rt.mrEnclave,
+		MrEnclave: *rt.mrEnclaves[0],
 		MrSigner:  *rt.mrSigner,
 	}
 	args.vec = append(args.vec, "--"+byzantine.CfgVersionFakeEnclaveID, eid.String())

--- a/go/oasis-test-runner/oasis/compute.go
+++ b/go/oasis-test-runner/oasis/compute.go
@@ -95,7 +95,8 @@ func (worker *Compute) startNode() error {
 		if v.kind != registry.KindCompute {
 			continue
 		}
-		args = args.appendComputeNodeRuntime(v)
+		// XXX: could support configurable binary idx if ever needed.
+		args = args.appendComputeNodeRuntime(v, 0)
 	}
 
 	if err := worker.net.startOasisNode(&worker.Node, nil, args); err != nil {

--- a/go/oasis-test-runner/oasis/fixture.go
+++ b/go/oasis-test-runner/oasis/fixture.go
@@ -188,9 +188,9 @@ type RuntimeFixture struct { // nolint: maligned
 	Entity     int                  `json:"entity"`
 	Keymanager int                  `json:"keymanager"`
 
-	Binary       string `json:"binary"`
-	GenesisState string `json:"genesis_state"`
-	GenesisRound uint64 `json:"genesis_round"`
+	Binaries     []string `json:"binaries"`
+	GenesisState string   `json:"genesis_state"`
+	GenesisRound uint64   `json:"genesis_round"`
 
 	Executor     registry.ExecutorParameters     `json:"executor"`
 	Merge        registry.MergeParameters        `json:"merge"`
@@ -235,7 +235,7 @@ func (f *RuntimeFixture) Create(netFixture *NetworkFixture, net *Network) (*Runt
 		TxnScheduler:       f.TxnScheduler,
 		Storage:            f.Storage,
 		AdmissionPolicy:    f.AdmissionPolicy,
-		Binary:             f.Binary,
+		Binaries:           f.Binaries,
 		GenesisState:       f.GenesisState,
 		GenesisRound:       f.GenesisRound,
 		Pruner:             f.Pruner,
@@ -271,6 +271,8 @@ type KeymanagerFixture struct {
 	AllowEarlyTermination bool `json:"allow_early_termination"`
 	AllowErrorTermination bool `json:"allow_error_termination"`
 
+	NoAutoStart bool `json:"no_auto_start,omitempty"`
+
 	Sentries []int `json:"sentries,omitempty"`
 
 	// Consensus contains configuration for the consensus backend.
@@ -300,6 +302,7 @@ func (f *KeymanagerFixture) Create(net *Network) (*Keymanager, error) {
 			AllowErrorTermination:      f.AllowErrorTermination,
 			LogWatcherHandlerFactories: f.LogWatcherHandlerFactories,
 			Consensus:                  f.Consensus,
+			NoAutoStart:                f.NoAutoStart,
 		},
 		Runtime:       runtime,
 		Entity:        entity,

--- a/go/oasis-test-runner/scenario/e2e/e2e.go
+++ b/go/oasis-test-runner/scenario/e2e/e2e.go
@@ -126,6 +126,8 @@ func RegisterScenarios() error {
 		LateStart,
 		// Restore from v20.6 genesis file.
 		RestoreV206,
+		// KeymanagerUpgrade test.
+		KeymanagerUpgrade,
 	} {
 		if err := cmd.Register(s); err != nil {
 			return err

--- a/go/oasis-test-runner/scenario/e2e/keymanager_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/keymanager_upgrade.go
@@ -1,0 +1,314 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/oasislabs/oasis-core/go/common"
+	"github.com/oasislabs/oasis-core/go/common/cbor"
+	"github.com/oasislabs/oasis-core/go/common/sgx"
+	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
+	keymanager "github.com/oasislabs/oasis-core/go/keymanager/api"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/env"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/oasis"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/oasis/cli"
+	"github.com/oasislabs/oasis-core/go/oasis-test-runner/scenario"
+	registry "github.com/oasislabs/oasis-core/go/registry/api"
+)
+
+// KeymanagerUpgrade is the keymanager upgrade scenario.
+var KeymanagerUpgrade scenario.Scenario = newKmUpgradeImpl()
+
+type kmUpgradeImpl struct {
+	runtimeImpl
+
+	nonce uint64
+}
+
+func newKmUpgradeImpl() scenario.Scenario {
+	return &kmUpgradeImpl{
+		runtimeImpl: *newRuntimeImpl(
+			"keymanager-upgrade",
+			"simple-keyvalue-enc-client",
+			nil,
+		),
+	}
+}
+
+func (sc *kmUpgradeImpl) Fixture() (*oasis.NetworkFixture, error) {
+	f, err := sc.runtimeImpl.Fixture()
+	if err != nil {
+		return nil, err
+	}
+
+	// Load the upgraded keymanager binary.
+	newKmBinary, err := sc.resolveRuntimeBinary("simple-keymanager-upgrade")
+	if err != nil {
+		return nil, fmt.Errorf("error resolving binary: %w", err)
+	}
+	// Setup the upgraded runtime.
+	kmRuntimeFix := f.Runtimes[0]
+	if kmRuntimeFix.Kind != registry.KindKeyManager {
+		return nil, fmt.Errorf("expected first runtime in fixture to be keymanager runtime, got: %s", kmRuntimeFix.Kind)
+	}
+	kmRuntimeFix.Binaries = append([]string{newKmBinary}, kmRuntimeFix.Binaries...)
+	// The upgraded runtime will be registered later.
+	kmRuntimeFix.ExcludeFromGenesis = true
+	f.Runtimes = append(f.Runtimes, kmRuntimeFix)
+
+	// Add the upgraded keymanager, will be started later.
+	f.Keymanagers = append(f.Keymanagers, oasis.KeymanagerFixture{Runtime: 2, Entity: 1, NoAutoStart: true})
+
+	f.Network.IAS.UseRegistry = true
+
+	return f, nil
+}
+
+func (sc *kmUpgradeImpl) Clone() scenario.Scenario {
+	return &kmUpgradeImpl{
+		runtimeImpl: *sc.runtimeImpl.Clone().(*runtimeImpl),
+	}
+}
+
+func (sc *kmUpgradeImpl) applyUpgradePolicy(childEnv *env.Env) error {
+	cli := cli.New(childEnv, sc.net, sc.logger)
+
+	kmPolicyPath := filepath.Join(childEnv.Dir(), "km_policy.cbor")
+	kmPolicySig1Path := filepath.Join(childEnv.Dir(), "km_policy_sig1.pem")
+	kmPolicySig2Path := filepath.Join(childEnv.Dir(), "km_policy_sig2.pem")
+	kmPolicySig3Path := filepath.Join(childEnv.Dir(), "km_policy_sig3.pem")
+	kmUpdateTxPath := filepath.Join(childEnv.Dir(), "km_gen_update.json")
+
+	oldKMRuntime := sc.net.Runtimes()[0]
+	newKMRuntime := sc.net.Runtimes()[2]
+	// Sanity check fixture.
+	if err := func() error {
+		if oldKMRuntime.Kind() != registry.KindKeyManager {
+			return fmt.Errorf("old keymanager runtime not of kind KindKeyManager")
+		}
+		if newKMRuntime.Kind() != registry.KindKeyManager {
+			return fmt.Errorf("new keymanager runtime not of kind KindKeyManager")
+		}
+		if oldKMRuntime.ID() != newKMRuntime.ID() {
+			return fmt.Errorf("keymanager runtimes ID mismatch")
+		}
+		return nil
+	}(); err != nil {
+		return fmt.Errorf("keymanager runtimes fixture sanity check: %w", err)
+	}
+
+	oldKMEncID := oldKMRuntime.GetEnclaveIdentity()
+	newKMEncID := newKMRuntime.GetEnclaveIdentity()
+
+	if oldKMEncID == nil && newKMEncID == nil {
+		sc.logger.Info("No SGX runtimes, skipping policy update")
+		return nil
+	}
+
+	// Ensure enclave IDs differ between the old and new runtimes.
+	oldEncID, _ := oldKMEncID.MarshalText()
+	newEncID, _ := newKMEncID.MarshalText()
+	if bytes.Equal(oldEncID, newEncID) {
+		return fmt.Errorf("expected different enclave identities, got: %s", newEncID)
+	}
+
+	// Build updated SGX policies.
+	sc.logger.Info("building new KM SGX policy enclave policies map")
+	enclavePolicies := make(map[sgx.EnclaveIdentity]*keymanager.EnclavePolicySGX)
+
+	enclavePolicies[*newKMEncID] = &keymanager.EnclavePolicySGX{}
+	enclavePolicies[*newKMEncID].MayQuery = make(map[common.Namespace][]sgx.EnclaveIdentity)
+	enclavePolicies[*oldKMEncID] = &keymanager.EnclavePolicySGX{}
+	enclavePolicies[*oldKMEncID].MayQuery = make(map[common.Namespace][]sgx.EnclaveIdentity)
+
+	// Allow new runtime enclave to replicate from the old runtime enclave.
+	enclavePolicies[*oldKMEncID].MayReplicate = []sgx.EnclaveIdentity{*newKMEncID}
+
+	// Allow compute runtime to query new runtime.
+	for _, rt := range sc.net.Runtimes() {
+		if rt.Kind() != registry.KindCompute {
+			continue
+		}
+		if eid := rt.GetEnclaveIdentity(); eid != nil {
+			enclavePolicies[*newKMEncID].MayQuery[rt.ID()] = []sgx.EnclaveIdentity{*eid}
+		}
+	}
+
+	sc.logger.Info("initing updated KM policy")
+	if err := cli.Keymanager.InitPolicy(oldKMRuntime.ID(), 2, enclavePolicies, kmPolicyPath); err != nil {
+		return err
+	}
+	sc.logger.Info("signing updated KM policy")
+	if err := cli.Keymanager.SignPolicy("1", kmPolicyPath, kmPolicySig1Path); err != nil {
+		return err
+	}
+	if err := cli.Keymanager.SignPolicy("2", kmPolicyPath, kmPolicySig2Path); err != nil {
+		return err
+	}
+	if err := cli.Keymanager.SignPolicy("3", kmPolicyPath, kmPolicySig3Path); err != nil {
+		return err
+	}
+
+	sc.logger.Info("updating KM policy")
+	if err := cli.Keymanager.GenUpdate(sc.nonce, kmPolicyPath, []string{kmPolicySig1Path, kmPolicySig2Path, kmPolicySig3Path}, kmUpdateTxPath); err != nil {
+		return err
+	}
+	if err := cli.Consensus.SubmitTx(kmUpdateTxPath); err != nil {
+		return fmt.Errorf("failed to update KM policy: %w", err)
+	}
+	sc.nonce++
+
+	return nil
+}
+
+func (sc *kmUpgradeImpl) ensureReplicationWorked(ctx context.Context, km *oasis.Keymanager, rt *oasis.Runtime) error {
+	ctrl, err := oasis.NewController(km.SocketPath())
+	if err != nil {
+		return err
+	}
+	node, err := ctrl.Registry.GetNode(
+		ctx,
+		&registry.IDQuery{
+			ID: km.NodeID,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	nodeRt := node.GetRuntime(rt.ID())
+	if nodeRt == nil {
+		return fmt.Errorf("node is missing keymanager runtime from descriptor")
+	}
+	var signedInitResponse keymanager.SignedInitResponse
+	if err = cbor.Unmarshal(nodeRt.ExtraInfo, &signedInitResponse); err != nil {
+		return fmt.Errorf("failed to unmarshal replica extrainfo")
+	}
+
+	// Grab a state dump and ensure all keymanager nodes have a matching
+	// checksum.
+	doc, err := ctrl.Consensus.StateToGenesis(context.Background(), 0)
+	if err != nil {
+		return fmt.Errorf("failed to obtain consensus state: %w", err)
+	}
+	if err = func() error {
+		for _, status := range doc.KeyManager.Statuses {
+			if !status.ID.Equal(&nodeRt.ID) {
+				continue
+			}
+			if !status.IsInitialized {
+				return fmt.Errorf("key manager failed to initialize")
+			}
+			if !bytes.Equal(status.Checksum, signedInitResponse.InitResponse.Checksum) {
+				return fmt.Errorf("key manager failed to replicate, checksum mismatch")
+			}
+			return nil
+		}
+		return fmt.Errorf("consensus state missing km status")
+	}(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sc *kmUpgradeImpl) Run(childEnv *env.Env) error {
+	ctx := context.Background()
+	cli := cli.New(childEnv, sc.net, sc.logger)
+
+	clientErrCh, cmd, err := sc.runtimeImpl.start(childEnv)
+	if err != nil {
+		return err
+	}
+	sc.logger.Info("waiting for client to exit")
+	// Wait for the client to exit.
+	select {
+	case err = <-sc.runtimeImpl.net.Errors():
+		_ = cmd.Process.Kill()
+	case err = <-clientErrCh:
+	}
+	if err != nil {
+		return err
+	}
+
+	// Generate and update a policy that will allow replication for the new
+	// keymanager.
+	if err = sc.applyUpgradePolicy(childEnv); err != nil {
+		return fmt.Errorf("updating policies: %w", err)
+	}
+
+	// Start the new keymanager.
+	sc.logger.Info("starting new keymanager")
+	newKm := sc.net.Keymanagers()[1]
+	if err = newKm.Start(); err != nil {
+		return fmt.Errorf("starting new key-manager: %w", err)
+	}
+
+	// Update runtime to include the new enclave identity.
+	sc.logger.Info("updating keymanager runtime descriptor")
+	newRt := sc.net.Runtimes()[2]
+	kmRtDesc := newRt.ToRuntimeDescriptor()
+	kmTxPath := filepath.Join(childEnv.Dir(), "register_update_km_runtime.json")
+	if err = cli.Registry.GenerateRegisterRuntimeTx(sc.nonce, kmRtDesc, kmTxPath, ""); err != nil {
+		return fmt.Errorf("failed to generate register KM runtime tx: %w", err)
+	}
+	sc.nonce++
+	if err = cli.Consensus.SubmitTx(kmTxPath); err != nil {
+		return fmt.Errorf("failed to update KM runtime: %w", err)
+	}
+
+	// Wait for the new node to register.
+	sc.logger.Info("waiting for new keymanager node to register",
+		"num_nodes", sc.net.NumRegisterNodes(),
+	)
+
+	if err = sc.net.Controller().WaitNodesRegistered(ctx, sc.net.NumRegisterNodes()); err != nil {
+		return fmt.Errorf("failed to wait for nodes: %w", err)
+	}
+
+	sc.logger.Info("wait for few epochs to ensure replication finishes")
+	var waitEpoch epochtime.EpochTime
+	waitEpoch, err = sc.net.Controller().Consensus.GetEpoch(ctx, 0)
+	if err != nil {
+		return err
+	}
+	waitEpoch += 3
+	sc.logger.Info("waiting for epoch",
+		"wait_epoch", waitEpoch,
+	)
+	err = sc.net.Controller().Consensus.WaitEpoch(ctx, waitEpoch)
+	if err != nil {
+		return err
+	}
+
+	// Ensure replication succeeded.
+	if err = sc.ensureReplicationWorked(ctx, newKm, newRt); err != nil {
+		return err
+	}
+
+	// Shutdown old km.
+	sc.logger.Info("shutting down old keymanager")
+	oldKm := sc.net.Keymanagers()[0]
+	if err = oldKm.Stop(); err != nil {
+		return fmt.Errorf("old keymanager node shutdown: %w", err)
+	}
+
+	// The last part of the test won't work until:
+	// https://github.com/oasislabs/oasis-core/issues/2919
+	/*
+		// Run test again.
+		sc.logger.Info("starting a second client to check if key manager works")
+		sc.runtimeImpl.clientArgs = []string{"--key", "key2"}
+		cmd, err = sc.startClient(childEnv)
+		if err != nil {
+			return err
+		}
+		client2ErrCh := make(chan error)
+		go func() {
+			client2ErrCh <- cmd.Wait()
+		}()
+		return sc.wait(childEnv, cmd, client2ErrCh)
+	*/
+	return nil
+}

--- a/go/oasis-test-runner/scenario/e2e/multiple_runtimes.go
+++ b/go/oasis-test-runner/scenario/e2e/multiple_runtimes.go
@@ -84,7 +84,7 @@ func (mr *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 		if rt.Kind == registry.KindCompute {
 			if runtimeBinary == "" {
 				copy(id[:], rt.ID[:])
-				runtimeBinary = rt.Binary
+				runtimeBinary = rt.Binaries[0]
 			}
 		} else {
 			rts = append(rts, rt)
@@ -105,7 +105,7 @@ func (mr *multipleRuntimesImpl) Fixture() (*oasis.NetworkFixture, error) {
 			Kind:       registry.KindCompute,
 			Entity:     0,
 			Keymanager: 0,
-			Binary:     runtimeBinary,
+			Binaries:   []string{runtimeBinary},
 			Executor: registry.ExecutorParameters{
 				GroupSize:       uint64(mr.executorGroupSize),
 				GroupBackupSize: 0,

--- a/go/oasis-test-runner/scenario/e2e/runtime.go
+++ b/go/oasis-test-runner/scenario/e2e/runtime.go
@@ -164,7 +164,7 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 				AdmissionPolicy: registry.RuntimeAdmissionPolicy{
 					AnyNode: &registry.AnyNodeRuntimeAdmissionPolicy{},
 				},
-				Binary: keyManagerBinary,
+				Binaries: []string{keyManagerBinary},
 			},
 			// Compute runtime.
 			oasis.RuntimeFixture{
@@ -172,7 +172,7 @@ func (sc *runtimeImpl) Fixture() (*oasis.NetworkFixture, error) {
 				Kind:       registry.KindCompute,
 				Entity:     0,
 				Keymanager: 0,
-				Binary:     runtimeBinary,
+				Binaries:   []string{runtimeBinary},
 				Executor: registry.ExecutorParameters{
 					GroupSize:       2,
 					GroupBackupSize: 1,
@@ -552,6 +552,11 @@ func (sc *runtimeImpl) initialEpochTransitions() error {
 		sc.logger.Info("waiting for (some) nodes to register",
 			"num_nodes", numNodes,
 		)
+
+		// TODO: once #2130 is done, aditionally wait for nodes to be Ready here.
+		// As generally a keymanager can register (with missing extra info)
+		// before actually being initialized and triggering an epoch transition
+		// at that point would be too soon.
 
 		if err := sc.net.Controller().WaitNodesRegistered(ctx, numNodes); err != nil {
 			return fmt.Errorf("failed to wait for nodes: %w", err)

--- a/go/worker/keymanager/init.go
+++ b/go/worker/keymanager/init.go
@@ -56,6 +56,7 @@ func New(
 		stopCh:       make(chan struct{}),
 		quitCh:       make(chan struct{}),
 		initCh:       make(chan struct{}),
+		initTickerCh: nil,
 		commonWorker: commonWorker,
 		backend:      backend,
 		grpcPolicy:   policy.NewDynamicRuntimePolicyChecker(enclaverpc.ServiceName, commonWorker.GrpcPolicyWatcher),

--- a/tests/fixture-data/net-runner/default.json
+++ b/tests/fixture-data/net-runner/default.json
@@ -34,7 +34,9 @@
             "kind": 2,
             "entity": 0,
             "keymanager": -1,
-            "binary": "simple-keymanager",
+            "binaries": [
+                "simple-keymanager"
+            ],
             "genesis_state": "",
             "genesis_round": 0,
             "executor": {
@@ -80,7 +82,9 @@
             "kind": 1,
             "entity": 0,
             "keymanager": 0,
-            "binary": "simple-keyvalue",
+            "binaries": [
+                "simple-keyvalue"
+            ],
             "genesis_state": "",
             "genesis_round": 0,
             "executor": {

--- a/tests/runtimes/simple-keymanager-upgrade/Cargo.toml
+++ b/tests/runtimes/simple-keymanager-upgrade/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "simple-keymanager-upgrade"
+version = "0.3.0-alpha"
+authors = ["Oasis Labs Inc. <info@oasislabs.com>"]
+edition = "2018"
+
+[package.metadata.fortanix-sgx]
+heap-size = 134217728
+stack-size = 2097152
+threads = 2
+
+[dependencies]
+oasis-core-runtime = { path = "../../../runtime" }
+oasis-core-keymanager-lib = { path = "../../../keymanager-lib" }
+oasis-core-keymanager-api-common = { path = "../../../keymanager-api-common" }
+
+[build-dependencies]
+oasis-core-tools = { path = "../../../tools" }

--- a/tests/runtimes/simple-keymanager-upgrade/src/api.rs
+++ b/tests/runtimes/simple-keymanager-upgrade/src/api.rs
@@ -1,0 +1,28 @@
+use oasis_core_keymanager_api_common::*;
+use oasis_core_runtime::common::crypto::signature::PrivateKey as OasisPrivateKey;
+use std::collections::HashSet;
+
+pub fn trusted_policy_signers() -> TrustedPolicySigners {
+    TrustedPolicySigners {
+        signers: {
+            let mut set = HashSet::new();
+            if option_env!("OASIS_UNSAFE_KM_POLICY_KEYS").is_some() {
+                for seed in [
+                    "ekiden key manager test multisig key 0",
+                    "ekiden key manager test multisig key 1",
+                    "ekiden key manager test multisig key 2",
+                ]
+                .iter()
+                {
+                    let private_key = OasisPrivateKey::from_test_seed(seed.to_string());
+                    set.insert(private_key.public_key());
+                }
+            }
+
+            set
+        },
+        // Maintain compatible simple-keymanager, but ensure a different
+        // MRENCLAVE for the keymanager-upgrade test.
+        threshold: 9002,
+    }
+}

--- a/tests/runtimes/simple-keymanager-upgrade/src/lib.rs
+++ b/tests/runtimes/simple-keymanager-upgrade/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod api;
+
+// Re-exports.
+pub use api::*;

--- a/tests/runtimes/simple-keymanager-upgrade/src/main.rs
+++ b/tests/runtimes/simple-keymanager-upgrade/src/main.rs
@@ -1,0 +1,9 @@
+use oasis_core_keymanager_lib::keymanager::*;
+use oasis_core_runtime::{common::version::Version, version_from_cargo};
+
+mod api;
+
+fn main() {
+    let init = new_keymanager(api::trusted_policy_signers());
+    oasis_core_runtime::start_runtime(init, version_from_cargo!());
+}


### PR DESCRIPTION
Closes: #2517 

TODO:
- [x] instead of using the `OASIS_UNSAFE_KM_POLICY_THRESHOLD` build-time-flag to ensure different binaries, just duplicate the test-keymanager crate with a change, it will make the code simpler
- [x] will be done in a separate PR. Last part of the test (running the client again with the new km), is not working yet, requires: https://github.com/oasislabs/oasis-core/issues/2919 (potentially do it as part of this PR)
  - will be handled in a separate PR
- [x] address the remaining todo: https://github.com/oasislabs/oasis-core/pull/2920/files#diff-59b3c0087bae96951be3b7509d5cd9b7R560-R563