### PR TITLE
go/oasis-node: Add the `debug dumpdb` command

### DIFF
--- a/.changelog/2359.feature.md
+++ b/.changelog/2359.feature.md
@@ -1,0 +1,17 @@
+go/oasis-node/cmd/debug: Add the `dumpdb` command
+
+This command will attempt to extract the ABCI state from a combination
+of a shutdown node's on-disk database and the genesis document currently
+being used by the network, and will write the output as a JSON formatted
+genesis document.
+
+Some caveats:
+
+- It is not guaranteed that the dumped output will be usable as an
+  actual genesis document without manual intervention.
+
+- Only the state that would be exported via a normal dump from a running
+  node will be present in the dump.
+
+- The epochtime base will be that of the original genesis document, and
+  not the most recent epoch (different from a genesis dump).

--- a/go/consensus/tendermint/abci/mux.go
+++ b/go/consensus/tendermint/abci/mux.go
@@ -72,6 +72,9 @@ type ApplicationConfig struct {
 
 	// MemoryOnlyStorage forces in-memory storage to be used for the state storage.
 	MemoryOnlyStorage bool
+
+	// ReadOnlyStorage forces read-only access for the state storage.
+	ReadOnlyStorage bool
 }
 
 // TransactionAuthHandler is the interface for ABCI applications that handle

--- a/go/consensus/tendermint/abci/state/state.go
+++ b/go/consensus/tendermint/abci/state/state.go
@@ -24,7 +24,7 @@ type ImmutableState struct {
 }
 
 // NewImmutableState creates a new immutable consensus backend state wrapper.
-func NewImmutableState(ctx context.Context, state api.ApplicationState, version int64) (*ImmutableState, error) {
+func NewImmutableState(ctx context.Context, state api.ApplicationQueryState, version int64) (*ImmutableState, error) {
 	is, err := api.NewImmutableState(ctx, state, version)
 	if err != nil {
 		return nil, err

--- a/go/consensus/tendermint/api/state.go
+++ b/go/consensus/tendermint/api/state.go
@@ -25,11 +25,7 @@ var (
 
 // ApplicationState is the overall past, present and future state of all multiplexed applications.
 type ApplicationState interface {
-	// Storage returns the storage backend.
-	Storage() storage.LocalBackend
-
-	// BlockHeight returns the last committed block height.
-	BlockHeight() int64
+	ApplicationQueryState
 
 	// BlockHash returns the last committed block hash.
 	BlockHash() []byte
@@ -49,9 +45,6 @@ type ApplicationState interface {
 	// GetBaseEpoch returns the base epoch.
 	GetBaseEpoch() (epochtime.EpochTime, error)
 
-	// GetEpoch returns epoch at block height.
-	GetEpoch(ctx context.Context, blockHeight int64) (epochtime.EpochTime, error)
-
 	// GetCurrentEpoch returns the epoch at the current block height.
 	GetCurrentEpoch(ctx context.Context) (epochtime.EpochTime, error)
 
@@ -67,6 +60,19 @@ type ApplicationState interface {
 
 	// NewContext creates a new application processing context.
 	NewContext(mode ContextMode, now time.Time) *Context
+}
+
+// ApplicationQueryState is minimum methods required to service
+// ApplicationState queries.
+type ApplicationQueryState interface {
+	// Storage returns the storage backend.
+	Storage() storage.LocalBackend
+
+	// BlockHeight returns the last committed block height.
+	BlockHeight() int64
+
+	// GetEpoch returns epoch at block height.
+	GetEpoch(ctx context.Context, blockHeight int64) (epochtime.EpochTime, error)
 }
 
 // MockApplicationStateConfig is the configuration for the mock application state.
@@ -203,7 +209,7 @@ func (s *ImmutableState) Close() {
 }
 
 // NewImmutableState creates a new immutable state wrapper.
-func NewImmutableState(ctx context.Context, state ApplicationState, version int64) (*ImmutableState, error) {
+func NewImmutableState(ctx context.Context, state ApplicationQueryState, version int64) (*ImmutableState, error) {
 	if state == nil {
 		return nil, ErrNoState
 	}

--- a/go/consensus/tendermint/apps/beacon/query.go
+++ b/go/consensus/tendermint/apps/beacon/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	beacon "github.com/oasislabs/oasis-core/go/beacon/api"
+	abciAPI "github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
 	beaconState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/beacon/state"
 )
 
@@ -15,12 +16,12 @@ type Query interface {
 
 // QueryFactory is the beacon query factory.
 type QueryFactory struct {
-	app *beaconApplication
+	state abciAPI.ApplicationQueryState
 }
 
 // QueryAt returns the beacon query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := beaconState.NewImmutableState(ctx, sf.app.state, height)
+	state, err := beaconState.NewImmutableState(ctx, sf.state, height)
 	if err != nil {
 		return nil, err
 	}
@@ -36,5 +37,11 @@ func (bq *beaconQuerier) Beacon(ctx context.Context) ([]byte, error) {
 }
 
 func (app *beaconApplication) QueryFactory() interface{} {
-	return &QueryFactory{app}
+	return &QueryFactory{app.state}
+}
+
+// NewQueryFactory returns a new QueryFactory backed by the given state
+// instance.
+func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {
+	return &QueryFactory{state}
 }

--- a/go/consensus/tendermint/apps/beacon/state/state.go
+++ b/go/consensus/tendermint/apps/beacon/state/state.go
@@ -28,7 +28,7 @@ type ImmutableState struct {
 	is *abciAPI.ImmutableState
 }
 
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationState, version int64) (*ImmutableState, error) {
+func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
 	is, err := abciAPI.NewImmutableState(ctx, state, version)
 	if err != nil {
 		return nil, err

--- a/go/consensus/tendermint/apps/epochtime_mock/query.go
+++ b/go/consensus/tendermint/apps/epochtime_mock/query.go
@@ -3,6 +3,7 @@ package epochtimemock
 import (
 	"context"
 
+	abciAPI "github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 )
 
@@ -13,12 +14,12 @@ type Query interface {
 
 // QueryFactory is the mock epochtime query factory.
 type QueryFactory struct {
-	app *epochTimeMockApplication
+	state abciAPI.ApplicationQueryState
 }
 
 // QueryAt returns the mock epochtime query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := newImmutableState(ctx, sf.app.state, height)
+	state, err := newImmutableState(ctx, sf.state, height)
 	if err != nil {
 		return nil, err
 	}
@@ -34,5 +35,11 @@ func (eq *epochtimeMockQuerier) Epoch(ctx context.Context) (epochtime.EpochTime,
 }
 
 func (app *epochTimeMockApplication) QueryFactory() interface{} {
-	return &QueryFactory{app}
+	return &QueryFactory{app.state}
+}
+
+// NewQueryFactory returns a new QueryFactory backed by the given state
+// instance.
+func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {
+	return &QueryFactory{state}
 }

--- a/go/consensus/tendermint/apps/epochtime_mock/state.go
+++ b/go/consensus/tendermint/apps/epochtime_mock/state.go
@@ -63,7 +63,7 @@ func (s *immutableState) getFutureEpoch(ctx context.Context) (*mockEpochTimeStat
 	return &state, nil
 }
 
-func newImmutableState(ctx context.Context, state abciAPI.ApplicationState, version int64) (*immutableState, error) {
+func newImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*immutableState, error) {
 	is, err := abciAPI.NewImmutableState(ctx, state, version)
 	if err != nil {
 		return nil, err

--- a/go/consensus/tendermint/apps/keymanager/query.go
+++ b/go/consensus/tendermint/apps/keymanager/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/oasislabs/oasis-core/go/common"
+	abciAPI "github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
 	keymanagerState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/keymanager/state"
 	keymanager "github.com/oasislabs/oasis-core/go/keymanager/api"
 )
@@ -17,12 +18,12 @@ type Query interface {
 
 // QueryFactory is the key manager query factory.
 type QueryFactory struct {
-	app *keymanagerApplication
+	state abciAPI.ApplicationQueryState
 }
 
 // QueryAt returns the key manager query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := keymanagerState.NewImmutableState(ctx, sf.app.state, height)
+	state, err := keymanagerState.NewImmutableState(ctx, sf.state, height)
 	if err != nil {
 		return nil, err
 	}
@@ -42,5 +43,11 @@ func (kq *keymanagerQuerier) Statuses(ctx context.Context) ([]*keymanager.Status
 }
 
 func (app *keymanagerApplication) QueryFactory() interface{} {
-	return &QueryFactory{app}
+	return &QueryFactory{app.state}
+}
+
+// NewQueryFactory returns a new QueryFactory backed by the given state
+// instance.
+func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {
+	return &QueryFactory{state}
 }

--- a/go/consensus/tendermint/apps/keymanager/state/state.go
+++ b/go/consensus/tendermint/apps/keymanager/state/state.go
@@ -74,7 +74,7 @@ func (st *ImmutableState) Status(ctx context.Context, id common.Namespace) (*api
 	return &status, nil
 }
 
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationState, version int64) (*ImmutableState, error) {
+func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
 	is, err := abciAPI.NewImmutableState(ctx, state, version)
 	if err != nil {
 		return nil, err

--- a/go/consensus/tendermint/apps/registry/state/state.go
+++ b/go/consensus/tendermint/apps/registry/state/state.go
@@ -530,7 +530,7 @@ func (s *ImmutableState) NodeBySubKey(ctx context.Context, key signature.PublicK
 	return s.Node(ctx, id)
 }
 
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationState, version int64) (*ImmutableState, error) {
+func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
 	is, err := abciAPI.NewImmutableState(ctx, state, version)
 	if err != nil {
 		return nil, err

--- a/go/consensus/tendermint/apps/roothash/query.go
+++ b/go/consensus/tendermint/apps/roothash/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/oasislabs/oasis-core/go/common"
+	abciAPI "github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
 	roothashState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/roothash/state"
 	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
 	"github.com/oasislabs/oasis-core/go/roothash/api/block"
@@ -18,12 +19,12 @@ type Query interface {
 
 // QueryFactory is the roothash query factory.
 type QueryFactory struct {
-	app *rootHashApplication
+	state abciAPI.ApplicationQueryState
 }
 
 // QueryAt returns the roothash query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := roothashState.NewImmutableState(ctx, sf.app.state, height)
+	state, err := roothashState.NewImmutableState(ctx, sf.state, height)
 	if err != nil {
 		return nil, err
 	}
@@ -51,5 +52,11 @@ func (rq *rootHashQuerier) GenesisBlock(ctx context.Context, id common.Namespace
 }
 
 func (app *rootHashApplication) QueryFactory() interface{} {
-	return &QueryFactory{app}
+	return &QueryFactory{app.state}
+}
+
+// NewQueryFactory returns a new QueryFactory backed by the given state
+// instance.
+func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {
+	return &QueryFactory{state}
 }

--- a/go/consensus/tendermint/apps/roothash/state/state.go
+++ b/go/consensus/tendermint/apps/roothash/state/state.go
@@ -43,7 +43,7 @@ type ImmutableState struct {
 	is *abciAPI.ImmutableState
 }
 
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationState, version int64) (*ImmutableState, error) {
+func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
 	is, err := abciAPI.NewImmutableState(ctx, state, version)
 	if err != nil {
 		return nil, err

--- a/go/consensus/tendermint/apps/scheduler/state/state.go
+++ b/go/consensus/tendermint/apps/scheduler/state/state.go
@@ -163,7 +163,7 @@ func (s *ImmutableState) ConsensusParameters(ctx context.Context) (*api.Consensu
 	return &params, nil
 }
 
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationState, version int64) (*ImmutableState, error) {
+func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
 	is, err := abciAPI.NewImmutableState(ctx, state, version)
 	if err != nil {
 		return nil, err

--- a/go/consensus/tendermint/apps/staking/query.go
+++ b/go/consensus/tendermint/apps/staking/query.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
 	"github.com/oasislabs/oasis-core/go/common/quantity"
+	abciAPI "github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
 	stakingState "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/staking/state"
 	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
 	staking "github.com/oasislabs/oasis-core/go/staking/api"
@@ -27,12 +28,12 @@ type Query interface {
 
 // QueryFactory is the staking query factory.
 type QueryFactory struct {
-	app *stakingApplication
+	state abciAPI.ApplicationQueryState
 }
 
 // QueryAt returns the staking query interface for a specific height.
 func (sf *QueryFactory) QueryAt(ctx context.Context, height int64) (Query, error) {
-	state, err := stakingState.NewImmutableState(ctx, sf.app.state, height)
+	state, err := stakingState.NewImmutableState(ctx, sf.state, height)
 	if err != nil {
 		return nil, err
 	}
@@ -93,5 +94,11 @@ func (sq *stakingQuerier) ConsensusParameters(ctx context.Context) (*staking.Con
 }
 
 func (app *stakingApplication) QueryFactory() interface{} {
-	return &QueryFactory{app}
+	return &QueryFactory{app.state}
+}
+
+// NewQueryFactory returns a new QueryFactory backed by the given state
+// instance.
+func NewQueryFactory(state abciAPI.ApplicationQueryState) *QueryFactory {
+	return &QueryFactory{state}
 }

--- a/go/consensus/tendermint/apps/staking/state/state.go
+++ b/go/consensus/tendermint/apps/staking/state/state.go
@@ -489,7 +489,7 @@ func (s *ImmutableState) EpochSigning(ctx context.Context) (*EpochSigning, error
 	return &es, nil
 }
 
-func NewImmutableState(ctx context.Context, state abciAPI.ApplicationState, version int64) (*ImmutableState, error) {
+func NewImmutableState(ctx context.Context, state abciAPI.ApplicationQueryState, version int64) (*ImmutableState, error) {
 	is, err := abciAPI.NewImmutableState(ctx, state, version)
 	if err != nil {
 		return nil, err

--- a/go/oasis-node/cmd/debug/debug.go
+++ b/go/oasis-node/cmd/debug/debug.go
@@ -7,6 +7,7 @@ import (
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/debug/byzantine"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/debug/consim"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/debug/control"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/debug/dumpdb"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/debug/fixgenesis"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/debug/storage"
 	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/debug/txsource"
@@ -25,6 +26,7 @@ func Register(parentCmd *cobra.Command) {
 	fixgenesis.Register(debugCmd)
 	control.Register(debugCmd)
 	consim.Register(debugCmd)
+	dumpdb.Register(debugCmd)
 
 	parentCmd.AddCommand(debugCmd)
 }

--- a/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
+++ b/go/oasis-node/cmd/debug/dumpdb/dumpdb.go
@@ -1,0 +1,387 @@
+// Package dumpdb implements the dumpdb sub-command.
+package dumpdb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	beacon "github.com/oasislabs/oasis-core/go/beacon/api"
+	"github.com/oasislabs/oasis-core/go/common/logging"
+	consensus "github.com/oasislabs/oasis-core/go/consensus/genesis"
+	tendermint "github.com/oasislabs/oasis-core/go/consensus/tendermint"
+	"github.com/oasislabs/oasis-core/go/consensus/tendermint/abci"
+	abciState "github.com/oasislabs/oasis-core/go/consensus/tendermint/abci/state"
+	tendermintAPI "github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
+	beaconApp "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/beacon"
+	keymanagerApp "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/keymanager"
+	registryApp "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/registry"
+	roothashApp "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/roothash"
+	schedulerApp "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/scheduler"
+	stakingApp "github.com/oasislabs/oasis-core/go/consensus/tendermint/apps/staking"
+	epochtime "github.com/oasislabs/oasis-core/go/epochtime/api"
+	genesis "github.com/oasislabs/oasis-core/go/genesis/api"
+	genesisFile "github.com/oasislabs/oasis-core/go/genesis/file"
+	keymanager "github.com/oasislabs/oasis-core/go/keymanager/api"
+	cmdCommon "github.com/oasislabs/oasis-core/go/oasis-node/cmd/common"
+	"github.com/oasislabs/oasis-core/go/oasis-node/cmd/common/flags"
+	registry "github.com/oasislabs/oasis-core/go/registry/api"
+	roothash "github.com/oasislabs/oasis-core/go/roothash/api"
+	scheduler "github.com/oasislabs/oasis-core/go/scheduler/api"
+	staking "github.com/oasislabs/oasis-core/go/staking/api"
+	storage "github.com/oasislabs/oasis-core/go/storage/api"
+	storageDB "github.com/oasislabs/oasis-core/go/storage/database"
+
+	"encoding/json"
+)
+
+const (
+	cfgDumpOutput     = "dump.output"
+	cfgDumpReadOnlyDB = "dump.read_only_db"
+	cfgDumpVersion    = "dump.version"
+)
+
+var (
+	dumpDBCmd = &cobra.Command{
+		Use:   "dumpdb",
+		Short: "dump the on-disk consensus DB to a JSON document",
+		Run:   doDumpDB,
+	}
+
+	dumpDBFlags = flag.NewFlagSet("", flag.ContinueOnError)
+
+	logger = logging.GetLogger("cmd/debug/dumpdb")
+)
+
+func doDumpDB(cmd *cobra.Command, args []string) {
+	var ok bool
+	defer func() {
+		if !ok {
+			os.Exit(1)
+		}
+	}()
+
+	if err := cmdCommon.Init(); err != nil {
+		cmdCommon.EarlyLogAndExit(err)
+	}
+
+	dataDir := cmdCommon.DataDir()
+	if dataDir == "" {
+		logger.Error("data directory must be set")
+		return
+	}
+
+	// Load the old genesis document, required for filling in parameters
+	// that are not persisted to ABCI state.
+	fp, err := genesisFile.NewFileProvider(flags.GenesisFile())
+	if err != nil {
+		logger.Error("failed to load existing genesis document",
+			"err", err,
+		)
+		return
+	}
+	oldDoc, err := fp.GetGenesisDocument()
+	if err != nil {
+		logger.Error("failed to get existing genesis document",
+			"err", err,
+		)
+		return
+	}
+
+	// Initialize the ABCI state storage for access.
+	//
+	// Note: While it would be great to always use read-only DB access,
+	// badger will refuse to open a DB that isn't closed properly in
+	// read-only mode because it needs to truncate the value log.
+	//
+	// Hope you have backups if you ever run into this.
+	ctx := context.Background()
+	ldb, _, stateRoot, err := abci.InitStateStorage(
+		ctx,
+		&abci.ApplicationConfig{
+			DataDir:           filepath.Join(dataDir, tendermint.StateDir),
+			StorageBackend:    storageDB.BackendNameBadgerDB, // No other backend for now.
+			MemoryOnlyStorage: false,
+			ReadOnlyStorage:   viper.GetBool(cfgDumpReadOnlyDB),
+		},
+	)
+	if err != nil {
+		logger.Error("failed to initialize ABCI storage backend",
+			"err", err,
+		)
+	}
+	defer ldb.Cleanup()
+
+	latestVersion := int64(stateRoot.Version)
+	dumpVersion := viper.GetInt64(cfgDumpVersion)
+	if dumpVersion == 0 {
+		dumpVersion = latestVersion
+	}
+	if dumpVersion <= 0 || dumpVersion > latestVersion {
+		logger.Error("dump requested for version that does not exist",
+			"dump_version", dumpVersion,
+			"latest_version", latestVersion,
+		)
+		return
+	}
+
+	// Generate the dump by querying all of the relevant backends, and
+	// extracting the immutable parameters from the current genesis
+	// document.
+	//
+	// WARNING: The state is not guaranteed to be usable as a genesis
+	// document without manual intervention, and only the state that
+	// would be exported by the normal dump process will be present
+	// in the dump.
+	qs := &dumpQueryState{
+		ldb:    ldb,
+		height: dumpVersion,
+	}
+	doc := &genesis.Document{
+		Height:    qs.BlockHeight(),
+		Time:      time.Now(), // XXX: Make this deterministic?
+		ChainID:   oldDoc.ChainID,
+		EpochTime: oldDoc.EpochTime,
+		HaltEpoch: oldDoc.HaltEpoch,
+		ExtraData: oldDoc.ExtraData,
+	}
+
+	// BUG(?): EpochTime.Base in a exported dump will be set to the
+	// current epoch, this uses the original genesis doc.  I'm not
+	// sure if there is a right answer here.
+
+	// Registry
+	registrySt, err := dumpRegistry(ctx, qs)
+	if err != nil {
+		logger.Error("failed to dump registry state",
+			"err", err,
+		)
+	}
+	doc.Registry = *registrySt
+
+	// RootHash
+	rootHashSt, err := dumpRootHash(ctx, qs)
+	if err != nil {
+		logger.Error("failed to dump root hash state",
+			"err", err,
+		)
+		return
+	}
+	doc.RootHash = *rootHashSt
+
+	// Staking
+	stakingSt, err := dumpStaking(ctx, qs)
+	if err != nil {
+		logger.Error("failed to dump staking state",
+			"err", err,
+		)
+		return
+	}
+	doc.Staking = *stakingSt
+
+	// KeyManager
+	keyManagerSt, err := dumpKeyManager(ctx, qs)
+	if err != nil {
+		logger.Error("failed to dump key manager state",
+			"err", err,
+		)
+		return
+	}
+	doc.KeyManager = *keyManagerSt
+
+	// Scheduler
+	schedulerSt, err := dumpScheduler(ctx, qs)
+	if err != nil {
+		logger.Error("failed to dump scheduler state",
+			"err", err,
+		)
+		return
+	}
+	doc.Scheduler = *schedulerSt
+
+	// Beacon
+	beaconSt, err := dumpBeacon(ctx, qs)
+	if err != nil {
+		logger.Error("failed to dump beacon state",
+			"err", err,
+		)
+		return
+	}
+	doc.Beacon = *beaconSt
+
+	// Consensus
+	consensusSt, err := dumpConsensus(ctx, qs)
+	if err != nil {
+		logger.Error("failed to dump consensus state",
+			"err", err,
+		)
+		return
+	}
+	doc.Consensus = *consensusSt
+
+	logger.Info("writing state dump",
+		"output", viper.GetString(cfgDumpOutput),
+	)
+
+	// Write out the document.
+	w, shouldClose, err := cmdCommon.GetOutputWriter(cmd, cfgDumpOutput)
+	if err != nil {
+		logger.Error("failed to get output writer for state dump",
+			"err", err,
+		)
+		return
+	}
+	if shouldClose {
+		defer w.Close()
+	}
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		logger.Error("failed to marshal state dump into JSON",
+			"err", err,
+		)
+		return
+	}
+	if _, err := w.Write(raw); err != nil {
+		logger.Error("failed to write state dump file",
+			"err", err,
+		)
+		return
+	}
+
+	ok = true
+}
+
+func dumpRegistry(ctx context.Context, qs *dumpQueryState) (*registry.Genesis, error) {
+	qf := registryApp.NewQueryFactory(qs)
+	q, err := qf.QueryAt(ctx, qs.BlockHeight())
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to create registry query: %w", err)
+	}
+	st, err := q.Genesis(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to dump registry state: %w", err)
+	}
+	return st, nil
+}
+
+func dumpRootHash(ctx context.Context, qs *dumpQueryState) (*roothash.Genesis, error) {
+	qf := roothashApp.NewQueryFactory(qs)
+	q, err := qf.QueryAt(ctx, qs.BlockHeight())
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to create root hash query: %w", err)
+	}
+	st, err := q.Genesis(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to dump root hash state: %w", err)
+	}
+	return st, nil
+}
+
+func dumpStaking(ctx context.Context, qs *dumpQueryState) (*staking.Genesis, error) {
+	qf := stakingApp.NewQueryFactory(qs)
+	q, err := qf.QueryAt(ctx, qs.BlockHeight())
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to create staking query: %w", err)
+	}
+	st, err := q.Genesis(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to dump staking state: %w", err)
+	}
+	return st, nil
+}
+
+func dumpKeyManager(ctx context.Context, qs *dumpQueryState) (*keymanager.Genesis, error) {
+	qf := keymanagerApp.NewQueryFactory(qs)
+	q, err := qf.QueryAt(ctx, qs.BlockHeight())
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to create key manager query: %w", err)
+	}
+	st, err := q.Genesis(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to dump key manager state: %w", err)
+	}
+	return st, nil
+}
+
+func dumpScheduler(ctx context.Context, qs *dumpQueryState) (*scheduler.Genesis, error) {
+	qf := schedulerApp.NewQueryFactory(qs)
+	q, err := qf.QueryAt(ctx, qs.BlockHeight())
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to create scheduler query: %w", err)
+	}
+	st, err := q.Genesis(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to dump scheduler state: %w", err)
+	}
+	return st, nil
+}
+
+func dumpBeacon(ctx context.Context, qs *dumpQueryState) (*beacon.Genesis, error) {
+	qf := beaconApp.NewQueryFactory(qs)
+	q, err := qf.QueryAt(ctx, qs.BlockHeight())
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to create beacon query: %w", err)
+	}
+	st, err := q.Genesis(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to dump beacon state: %w", err)
+	}
+	return st, nil
+}
+
+func dumpConsensus(ctx context.Context, qs *dumpQueryState) (*consensus.Genesis, error) {
+	is, err := abciState.NewImmutableState(ctx, qs, qs.BlockHeight())
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to get consensus state: %w", err)
+	}
+	params, err := is.ConsensusParameters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dumpdb: failed to get consensus params: %w", err)
+	}
+	_ = params
+	return &consensus.Genesis{
+		Backend:    tendermintAPI.BackendName,
+		Parameters: *params,
+	}, nil
+}
+
+type dumpQueryState struct {
+	ldb    storage.LocalBackend
+	height int64
+}
+
+func (qs *dumpQueryState) Storage() storage.LocalBackend {
+	return qs.ldb
+}
+
+func (qs *dumpQueryState) BlockHeight() int64 {
+	return qs.height
+}
+
+func (qs *dumpQueryState) GetEpoch(ctx context.Context, blockHeight int64) (epochtime.EpochTime, error) {
+	// This is only required because certain registry backend queries
+	// need the epoch to filter out expired nodes.  It is not
+	// implemented because acquiring a full state dump does not
+	// involve any of the relevant queries.
+	return epochtime.EpochTime(0), fmt.Errorf("dumpdb/dumpQueryState: GetEpoch not supported")
+}
+
+// Register registers the dumpdb sub-commands.
+func Register(parentCmd *cobra.Command) {
+	dumpDBCmd.Flags().AddFlagSet(flags.GenesisFileFlags)
+	dumpDBCmd.Flags().AddFlagSet(dumpDBFlags)
+	parentCmd.AddCommand(dumpDBCmd)
+}
+
+func init() {
+	dumpDBFlags.String(cfgDumpOutput, "dump.json", "path to dumped ABCI state")
+	dumpDBFlags.Bool(cfgDumpReadOnlyDB, false, "read-only DB access")
+	dumpDBFlags.Int64(cfgDumpVersion, 0, "ABCI state version to dump (0 = most recent)")
+	_ = viper.BindPFlags(dumpDBFlags)
+}

--- a/go/oasis-test-runner/cmd/root.go
+++ b/go/oasis-test-runner/cmd/root.go
@@ -550,5 +550,6 @@ func init() {
 		}
 
 		viper.Set(nodeFlags.CfgDebugDontBlameOasis, true)
+		viper.Set(nodeCommon.CfgDebugAllowTestKeys, true)
 	})
 }

--- a/go/oasis-test-runner/scenario/e2e/dump_restore.go
+++ b/go/oasis-test-runner/scenario/e2e/dump_restore.go
@@ -52,7 +52,7 @@ func (sc *dumpRestoreImpl) Run(childEnv *env.Env) error {
 	if err != nil {
 		return err
 	}
-	if err = sc.dumpRestoreNetwork(childEnv, fixture); err != nil {
+	if err = sc.dumpRestoreNetwork(childEnv, fixture, true); err != nil {
 		return err
 	}
 

--- a/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
+++ b/go/oasis-test-runner/scenario/e2e/gas_fees_staking.go
@@ -121,7 +121,7 @@ func (sc *gasFeesImpl) Run(childEnv *env.Env) error {
 		if err != nil {
 			return err
 		}
-		if err := sc.dumpRestoreNetwork(childEnv, fixture); err != nil {
+		if err := sc.dumpRestoreNetwork(childEnv, fixture, false); err != nil {
 			return err
 		}
 		if err := sc.runTests(ctx); err != nil {

--- a/go/storage/api/api.go
+++ b/go/storage/api/api.go
@@ -69,6 +69,8 @@ var (
 	ErrRootNotFound = nodedb.ErrRootNotFound
 	// ErrRootMustFollowOld indicates that the passed new root does not follow old root.
 	ErrRootMustFollowOld = nodedb.ErrRootMustFollowOld
+	// ErrReadOnly indicates that the storage backend is read-only.
+	ErrReadOnly = nodedb.ErrReadOnly
 
 	// ReceiptSignatureContext is the signature context used for verifying MKVS receipts.
 	ReceiptSignatureContext = signature.NewContext("oasis-core/storage: receipt", signature.WithChainSeparation())
@@ -105,6 +107,9 @@ type Config struct { // nolint: maligned
 
 	// MemoryOnly will make the storage memory-only (if the backend supports it).
 	MemoryOnly bool
+
+	// ReadOnly will make the storage read-only.
+	ReadOnly bool
 }
 
 // ToNodeDB converts from a Config to a node DB Config.
@@ -115,6 +120,7 @@ func (cfg *Config) ToNodeDB() *nodedb.Config {
 		MaxCacheSize:     cfg.MaxCacheSize,
 		NoFsync:          cfg.NoFsync,
 		MemoryOnly:       cfg.MemoryOnly,
+		ReadOnly:         cfg.ReadOnly,
 		DiscardWriteLogs: cfg.DiscardWriteLogs,
 	}
 }

--- a/go/storage/mkvs/db/api/api.go
+++ b/go/storage/mkvs/db/api/api.go
@@ -43,6 +43,8 @@ var (
 	ErrBadNamespace = errors.New(ModuleName, 10, "mkvs: bad namespace")
 	// ErrNotEarliest indicates that the given version is not the earliest version.
 	ErrNotEarliest = errors.New(ModuleName, 11, "mkvs: version is not the earliest version")
+	// ErrReadOnly indicates that a write operation failed due to a read-only database.
+	ErrReadOnly = errors.New(ModuleName, 12, "mkvs: read-only database")
 )
 
 // Config is the node database backend configuration.
@@ -55,6 +57,9 @@ type Config struct { // nolint: maligned
 
 	// MemoryOnly will make the storage memory-only (if the backend supports it).
 	MemoryOnly bool
+
+	// ReadOnly will make the storage read-only.
+	ReadOnly bool
 
 	// Namespace is the namespace contained within the database.
 	Namespace common.Namespace


### PR DESCRIPTION
Fixes #2359

 * [x] Add support for making storage backends read-only.
 * [x] Refactor timekeeping so that state queries can happen without an ApplicationState.
 * [x] Write the tool.
 * [x] Write test cases.