### PR TITLE
consensus: Fix GenesisHeight in GetStatus

### DIFF
--- a/go/consensus/tendermint/tendermint.go
+++ b/go/consensus/tendermint/tendermint.go
@@ -710,12 +710,12 @@ func (t *tendermintService) GetTransactions(ctx context.Context, height int64) (
 }
 
 func (t *tendermintService) GetStatus(ctx context.Context) (*consensusAPI.Status, error) {
-	genDoc, err := t.GetGenesisDocument(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	genBlk, err := t.GetBlock(ctx, genDoc.Height)
+	// Genesis block is hardcoded as block 1, since tendermint doesn't have
+	// a genesis block as such, but some external tooling expects there to be
+	// one, so here we are.
+	// This may soon change if the following tendermint issue gets fixed:
+	// https://github.com/tendermint/tendermint/issues/2543
+	genBlk, err := t.GetBlock(ctx, 1)
 	if err != nil {
 		return nil, err
 	}
@@ -739,7 +739,7 @@ func (t *tendermintService) GetStatus(ctx context.Context) (*consensusAPI.Status
 		LatestHeight:     latestBlk.Height,
 		LatestHash:       latestBlk.Hash,
 		LatestTime:       latestBlk.Time,
-		GenesisHeight:    genDoc.Height,
+		GenesisHeight:    1, // See above for an explanation why this is 1.
 		GenesisHash:      genBlk.Hash,
 	}, nil
 }

--- a/go/consensus/tests/tester.go
+++ b/go/consensus/tests/tester.go
@@ -40,7 +40,7 @@ func ConsensusImplementationTests(t *testing.T, backend consensus.ClientBackend)
 	status, err := backend.GetStatus(ctx)
 	require.NoError(err, "GetStatus")
 	require.NotNil(status, "returned status should not be nil")
-	require.EqualValues(genDoc.Height, status.GenesisHeight)
+	require.EqualValues(1, status.GenesisHeight, "genesis height must be 1")
 	require.EqualValues(blk.Height, status.LatestHeight, "latest block heights should match")
 	require.EqualValues(blk.Hash, status.LatestHash, "latest block hashes should match")
 


### PR DESCRIPTION
This PR fixes the `GenesisHeight` in `GetStatus`, so that it always returns 1 as the genesis height.