### PR TITLE
go/common/keyformat: Add support for hashed key elements

### DIFF
--- a/.changelog/2929.bugfix.md
+++ b/.changelog/2929.bugfix.md
@@ -1,0 +1,1 @@
+go/consensus: Hash user-controlled storage key elements

--- a/go/common/crypto/signature/signature.go
+++ b/go/common/crypto/signature/signature.go
@@ -19,6 +19,7 @@ import (
 	"github.com/oasislabs/ed25519"
 
 	"github.com/oasislabs/oasis-core/go/common/cbor"
+	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/pem"
 	"github.com/oasislabs/oasis-core/go/common/prettyprint"
 )
@@ -208,6 +209,11 @@ func (k *PublicKey) LoadPEM(fn string, signer Signer) error {
 	}
 
 	return nil
+}
+
+// Hash returns a cryptographic hash of the public key.
+func (k PublicKey) Hash() hash.Hash {
+	return hash.NewFromBytes(k[:])
 }
 
 func (k PublicKey) isBlacklisted() bool {

--- a/go/common/keyformat/hashed.go
+++ b/go/common/keyformat/hashed.go
@@ -1,0 +1,80 @@
+package keyformat
+
+import (
+	"encoding"
+	"fmt"
+
+	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
+)
+
+// PreHashed represents a pre-hashed value that will be encoded without additional hashing when used
+// together with a hashed format.
+type PreHashed hash.Hash
+
+// MarshalBinary encodes a hash into binary form.
+func (ph *PreHashed) MarshalBinary() ([]byte, error) {
+	return (*hash.Hash)(ph).MarshalBinary()
+}
+
+// UnmarshalBinary decodes a binary marshaled hash.
+func (ph *PreHashed) UnmarshalBinary(data []byte) error {
+	return (*hash.Hash)(ph).UnmarshalBinary(data)
+}
+
+// Equal compares vs another hash for equality.
+func (ph *PreHashed) Equal(cmp *PreHashed) bool {
+	return (*hash.Hash)(ph).Equal((*hash.Hash)(cmp))
+}
+
+// String returns the string representation of a hash.
+func (ph PreHashed) String() string {
+	return hash.Hash(ph).String()
+}
+
+type hashedFormat struct {
+	inner interface{}
+}
+
+func (h *hashedFormat) getData(v interface{}) ([]byte, error) {
+	switch t := v.(type) {
+	case encoding.BinaryMarshaler:
+		return t.MarshalBinary()
+	case []byte:
+		return t, nil
+	default:
+		return nil, fmt.Errorf("unsupported type: %T", t)
+	}
+}
+
+// Implements CustomFormat.
+func (h *hashedFormat) MarshalBinary(v interface{}) (data []byte, err error) {
+	if ph, ok := v.(*PreHashed); ok {
+		return ph[:], nil
+	}
+
+	data, err = h.getData(v)
+	if err != nil {
+		return
+	}
+	hh := hash.NewFromBytes(data)
+	data = hh[:]
+	return
+}
+
+// Implements CustomFormat.
+func (h *hashedFormat) UnmarshalBinary(v interface{}, data []byte) error {
+	if ph, ok := v.(*PreHashed); ok {
+		return ph.UnmarshalBinary(data)
+	}
+	return fmt.Errorf("hashed format can only be decoded into a keyformat.PreHashed")
+}
+
+// Implements CustomFormat.
+func (h *hashedFormat) Size() int {
+	return hash.Size
+}
+
+// H wraps a key element to signal that the element should be hashed after regular encoding.
+func H(inner interface{}) CustomFormat {
+	return &hashedFormat{inner}
+}

--- a/go/common/keyformat/hashed_test.go
+++ b/go/common/keyformat/hashed_test.go
@@ -1,0 +1,65 @@
+package keyformat
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasislabs/oasis-core/go/common"
+	"github.com/oasislabs/oasis-core/go/common/crypto/signature"
+)
+
+func TestHashed(t *testing.T) {
+	require := require.New(t)
+
+	var pk signature.PublicKey
+	err := pk.UnmarshalHex("47aadd91516ac548decdb436fde957992610facc09ba2f850da0fe1b2be96119")
+	require.NoError(err, "UnmarshalHex")
+
+	var ns common.Namespace
+
+	fmt1 := New(0x42, uint64(0), H(&common.Namespace{}), H(&signature.PublicKey{}))
+	require.Equal(1+8+32+32, fmt1.Size())
+
+	// Make sure both keys have been hashed.
+	enc := fmt1.Encode(uint64(42), &ns, &pk)
+	require.Equal("42000000000000002aaf13c048991224a5e4c664446b688aaf48fb5456db3629601b00ec160c74e55477df373036881e67c7b0079f8c062d6634e4bab9581a532210228bc4118baf45", hex.EncodeToString(enc))
+
+	var (
+		decInt         uint64
+		decNs          common.Namespace
+		decPk          signature.PublicKey
+		decPh1, decPh2 PreHashed
+	)
+	ok := fmt1.Decode(enc, &decInt)
+	require.True(ok, "Decode")
+	require.EqualValues(42, decInt, "decoded uint64 value must be correct")
+
+	require.Panics(func() { _ = fmt1.Decode(enc, &decInt, &decNs) })
+	require.Panics(func() { _ = fmt1.Decode(enc, &decInt, &decPh1, &decPk) })
+
+	ok = fmt1.Decode(enc, &decInt, &decPh1, &decPh2)
+	require.True(ok, "Decode")
+	require.EqualValues(42, decInt, "decoded uint64 value must be correct")
+	require.Equal("af13c048991224a5e4c664446b688aaf48fb5456db3629601b00ec160c74e554", hex.EncodeToString(decPh1[:]))
+	require.Equal("77df373036881e67c7b0079f8c062d6634e4bab9581a532210228bc4118baf45", hex.EncodeToString(decPh2[:]))
+
+	// Make sure we can correctly encode with prehashed values.
+	enc2 := fmt1.Encode(uint64(42), &decPh1, &decPh2)
+	require.EqualValues(enc, enc2, "encoding with pre-hashed values must produce correct results")
+
+	// Make sure we can encode variable-length bytes.
+	fmt2 := New(0x43, uint64(0), H([]byte{}))
+	require.Equal(1+8+32, fmt2.Size())
+
+	enc = fmt2.Encode(uint64(42), []byte("hello world"))
+	require.Equal("43000000000000002a0ac561fac838104e3f2e4ad107b4bee3e938bf15f2b15f009ccccd61a913f017", hex.EncodeToString(enc))
+
+	ok = fmt2.Decode(enc, &decInt, &decPh1)
+	require.True(ok, "Decode")
+	require.Equal("0ac561fac838104e3f2e4ad107b4bee3e938bf15f2b15f009ccccd61a913f017", hex.EncodeToString(decPh1[:]))
+
+	var decBytes []byte
+	require.Panics(func() { _ = fmt2.Decode(enc, &decInt, &decBytes) })
+}

--- a/go/consensus/tendermint/abci/timer.go
+++ b/go/consensus/tendermint/abci/timer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/oasislabs/oasis-core/go/common/crypto/hash"
 	"github.com/oasislabs/oasis-core/go/common/keyformat"
 	"github.com/oasislabs/oasis-core/go/common/logging"
 	"github.com/oasislabs/oasis-core/go/consensus/tendermint/api"
@@ -68,6 +69,9 @@ type Timer struct {
 func NewTimer(ctx *api.Context, app Application, kind uint8, id []byte, data []byte) *Timer {
 	if data == nil {
 		data = []byte{}
+	} else {
+		h := hash.NewFromBytes(data)
+		data = h[:]
 	}
 
 	state := &timerState{

--- a/go/consensus/tendermint/apps/keymanager/state/state.go
+++ b/go/consensus/tendermint/apps/keymanager/state/state.go
@@ -15,7 +15,7 @@ var (
 	// statusKeyFmt is the key manager status key format.
 	//
 	// Value is CBOR-serialized key manager status.
-	statusKeyFmt = keyformat.New(0x70, &common.Namespace{})
+	statusKeyFmt = keyformat.New(0x70, keyformat.H(&common.Namespace{}))
 )
 
 // ImmutableState is the immutable key manager state wrapper.

--- a/go/consensus/tendermint/apps/roothash/state/state.go
+++ b/go/consensus/tendermint/apps/roothash/state/state.go
@@ -19,7 +19,7 @@ var (
 	// runtimeKeyFmt is the key format used for per-runtime roothash state.
 	//
 	// Value is CBOR-serialized runtime state.
-	runtimeKeyFmt = keyformat.New(0x20, &common.Namespace{})
+	runtimeKeyFmt = keyformat.New(0x20, keyformat.H(&common.Namespace{}))
 	// parametersKeyFmt is the key format used for consensus parameters.
 	//
 	// Value is CBOR-serialized roothash.ConsensusParameters.


### PR DESCRIPTION
Add support for hashed key elements and hash some of the key elements.

Staking state is omitted as it will not be needed once we do #2928 (as all account identifiers will already be hashed then).