### PR TITLE
metrics: Fix prometheus push issues

### DIFF
--- a/.changelog/2936.bugfix.1.md
+++ b/.changelog/2936.bugfix.1.md
@@ -1,0 +1,5 @@
+go/oasis-node/cmd/common/metrics: Re-create the pusher on failure
+
+When using prometheus' push client, any single failure causes the client
+to be unusable for future requests.  Re-create the client on failure, so
+that metrics might start working again.

--- a/.changelog/2936.feature.1.md
+++ b/.changelog/2936.feature.1.md
@@ -1,0 +1,6 @@
+go/oasis-node/cmd/common/metrics: Deprecate formal pushgateway support
+
+The prometheus authors do not recommend using it for most situations,
+it appears to be somewhat fragile, and we shouldn't be using it
+internally, so the functionality is now only usable if the correct
+debug-only flags are set.

--- a/docs/oasis-node/metrics.md
+++ b/docs/oasis-node/metrics.md
@@ -2,12 +2,11 @@
 # Metrics
 
 `oasis-node` can report a number of metrics to Prometheus server. By default,
-no metrics are collected and reported. There are two ways to enable metrics
+no metrics are collected and reported. There is one way to enable metrics
 reporting:
 
 * *Pull mode* listens on given address and waits for Prometheus to scrape the
   metrics.
-* *Push mode* regularly pushes metrics to the provided Prometheus push gateway.
 
 ## Configuring `oasis-node` in Pull Mode
 
@@ -28,20 +27,6 @@ Prometheus:
 
     static_configs:
       - targets: ['localhost:3000']
-```
-
-## Configuring `oasis-node` in Push Mode
-
-First run Prometheus server and Prometheus push gateway. Then run `oasis-node`
-in *push mode* by setting flag `--metrics.mode push` and provide:
-
-* push gateway address with `--metrics.address`, and
-* push interval with `--metrics.interval`.
-
-For example:
-
-```
-oasis-node --metrics.mode push --metrics.address localhost:9091 --metrics.interval 5s
 ```
 
 ## Metrics Reported by `oasis-node`

--- a/docs/oasis-node/metrics.md.tpl
+++ b/docs/oasis-node/metrics.md.tpl
@@ -1,12 +1,11 @@
 # Metrics
 
 `oasis-node` can report a number of metrics to Prometheus server. By default,
-no metrics are collected and reported. There are two ways to enable metrics
+no metrics are collected and reported. There is one way to enable metrics
 reporting:
 
 * *Pull mode* listens on given address and waits for Prometheus to scrape the
   metrics.
-* *Push mode* regularly pushes metrics to the provided Prometheus push gateway.
 
 ## Configuring `oasis-node` in Pull Mode
 
@@ -27,20 +26,6 @@ Prometheus:
 
     static_configs:
       - targets: ['localhost:3000']
-```
-
-## Configuring `oasis-node` in Push Mode
-
-First run Prometheus server and Prometheus push gateway. Then run `oasis-node`
-in *push mode* by setting flag `--metrics.mode push` and provide:
-
-* push gateway address with `--metrics.address`, and
-* push interval with `--metrics.interval`.
-
-For example:
-
-```
-oasis-node --metrics.mode push --metrics.address localhost:9091 --metrics.interval 5s
 ```
 
 ## Metrics Reported by `oasis-node`


### PR DESCRIPTION
 * [x] go/oasis-node/cmd/common/metrics: Re-create the pusher on failure
 * ~investigate mystery crashes~
 * [x] Deprecate official push support (Feature-gate behind a debug flag).

Fixes #2936