### PR TITLE
[20.6.x] go/staking: Relax account identifier sanity check added in 20.6.1

### DIFF
--- a/.changelog/2945.bugfix.md
+++ b/.changelog/2945.bugfix.md
@@ -1,0 +1,5 @@
+go/staking: Relax account identifier sanity check added in 20.6.1
+
+Version 20.6.1 introduced an additional sanity check for account identifier
+validity, but this actually breaks some existing deployments. This revert
+makes the checks consistent with 20.6 behavior.

--- a/go/consensus/tendermint/apps/staking/state/state.go
+++ b/go/consensus/tendermint/apps/staking/state/state.go
@@ -187,10 +187,6 @@ func (s *ImmutableState) Accounts(ctx context.Context) ([]signature.PublicKey, e
 }
 
 func (s *ImmutableState) Account(ctx context.Context, id signature.PublicKey) (*staking.Account, error) {
-	if !id.IsValid() {
-		return nil, fmt.Errorf("tendermint/staking: invalid account ID")
-	}
-
 	value, err := s.is.Get(ctx, accountKeyFmt.Encode(&id))
 	if err != nil {
 		return nil, abciAPI.UnavailableStateError(err)

--- a/go/staking/api/sanity_check.go
+++ b/go/staking/api/sanity_check.go
@@ -42,9 +42,6 @@ func (p *ConsensusParameters) SanityCheck() error {
 // SanityCheckAccount examines an account's balances.
 // Adds the balances to a running total `total`.
 func SanityCheckAccount(total *quantity.Quantity, parameters *ConsensusParameters, now epochtime.EpochTime, id signature.PublicKey, acct *Account) error {
-	if !id.IsValid() {
-		return fmt.Errorf("staking: sanity check failed: account has invalid ID: %s", id)
-	}
 	if !acct.General.Balance.IsValid() {
 		return fmt.Errorf("staking: sanity check failed: general balance is invalid for account with ID: %s", id)
 	}


### PR DESCRIPTION
Version 20.6.1 introduced an additional sanity check for account identifier
validity, but this actually breaks some existing deployments. This revert makes
the checks consistent with 20.6 behavior.