### PR TITLE
notify runtimes of its key manager policy updates

### DIFF
--- a/.changelog/2919.bugfix.md
+++ b/.changelog/2919.bugfix.md
@@ -1,0 +1,6 @@
+runtime: Notify runtimes of its key manager policy updates
+
+Before runtimes were unaware of any key-manager policy updates. The runtime
+only queried for the active key-manager policy at startup. This is now changed
+so that the host notifies runtimes of any key-manager policy changes and
+runtime updates the policies.

--- a/go/oasis-test-runner/scenario/e2e/keymanager_upgrade.go
+++ b/go/oasis-test-runner/scenario/e2e/keymanager_upgrade.go
@@ -294,21 +294,16 @@ func (sc *kmUpgradeImpl) Run(childEnv *env.Env) error {
 		return fmt.Errorf("old keymanager node shutdown: %w", err)
 	}
 
-	// The last part of the test won't work until:
-	// https://github.com/oasislabs/oasis-core/issues/2919
-	/*
-		// Run test again.
-		sc.logger.Info("starting a second client to check if key manager works")
-		sc.runtimeImpl.clientArgs = []string{"--key", "key2"}
-		cmd, err = sc.startClient(childEnv)
-		if err != nil {
-			return err
-		}
-		client2ErrCh := make(chan error)
-		go func() {
-			client2ErrCh <- cmd.Wait()
-		}()
-		return sc.wait(childEnv, cmd, client2ErrCh)
-	*/
-	return nil
+	// Run client again.
+	sc.logger.Info("starting a second client to check if key manager works")
+	sc.runtimeImpl.clientArgs = []string{"--key", "key2"}
+	cmd, err = sc.startClient(childEnv)
+	if err != nil {
+		return err
+	}
+	client2ErrCh := make(chan error)
+	go func() {
+		client2ErrCh <- cmd.Wait()
+	}()
+	return sc.wait(childEnv, cmd, client2ErrCh)
 }

--- a/go/runtime/host/protocol/connection.go
+++ b/go/runtime/host/protocol/connection.go
@@ -65,6 +65,28 @@ type Handler interface {
 	Handle(ctx context.Context, body *Body) (*Body, error)
 }
 
+// Notifier is a protocol runtime notifier interface.
+type Notifier interface {
+	// Start the notifier.
+	Start() error
+
+	// Stop the notifier.
+	Stop()
+}
+
+// NoOpNotifier is the default no-op runtime notifier implementation.
+type NoOpNotifier struct {
+}
+
+// Start the no-op notifier.
+func (n *NoOpNotifier) Start() error {
+	return nil
+}
+
+// Stop the no-op notifier.
+func (n *NoOpNotifier) Stop() {
+}
+
 // Connection is a Runtime Host Protocol connection interface.
 type Connection interface {
 	// Close closes the connection.
@@ -340,10 +362,6 @@ func (c *connection) handleMessage(ctx context.Context, message *Message) {
 		var allowed bool
 		state := c.getState()
 		switch {
-		case state == stateInitializing:
-			// Only whitelisted methods are allowed.
-			body := message.Body
-			allowed = body.HostKeyManagerPolicyRequest != nil
 		case state == stateReady:
 			// All requests allowed.
 			allowed = true

--- a/go/runtime/host/protocol/types.go
+++ b/go/runtime/host/protocol/types.go
@@ -51,6 +51,12 @@ type Message struct {
 	SpanContext []byte      `json:"span_context"`
 }
 
+// RuntimeKeyManagerPolicyUpdateRequest is a runtime key manager policy request
+// message body.
+type RuntimeKeyManagerPolicyUpdateRequest struct {
+	SignedPolicyRaw []byte `json:"signed_policy_raw"`
+}
+
 // Body is a protocol message body.
 type Body struct {
 	Empty *Empty `json:",omitempty"`
@@ -77,18 +83,18 @@ type Body struct {
 	RuntimeExecuteTxBatchResponse         *RuntimeExecuteTxBatchResponse         `json:",omitempty"`
 	RuntimeAbortRequest                   *Empty                                 `json:",omitempty"`
 	RuntimeAbortResponse                  *Empty                                 `json:",omitempty"`
+	RuntimeKeyManagerPolicyUpdateRequest  *RuntimeKeyManagerPolicyUpdateRequest  `json:",omitempty"`
+	RuntimeKeyManagerPolicyUpdateResponse *Empty                                 `json:",omitempty"`
 
 	// Host interface.
-	HostKeyManagerPolicyRequest  *HostKeyManagerPolicyRequest  `json:",omitempty"`
-	HostKeyManagerPolicyResponse *HostKeyManagerPolicyResponse `json:",omitempty"`
-	HostRPCCallRequest           *HostRPCCallRequest           `json:",omitempty"`
-	HostRPCCallResponse          *HostRPCCallResponse          `json:",omitempty"`
-	HostStorageSyncRequest       *HostStorageSyncRequest       `json:",omitempty"`
-	HostStorageSyncResponse      *HostStorageSyncResponse      `json:",omitempty"`
-	HostLocalStorageGetRequest   *HostLocalStorageGetRequest   `json:",omitempty"`
-	HostLocalStorageGetResponse  *HostLocalStorageGetResponse  `json:",omitempty"`
-	HostLocalStorageSetRequest   *HostLocalStorageSetRequest   `json:",omitempty"`
-	HostLocalStorageSetResponse  *Empty                        `json:",omitempty"`
+	HostRPCCallRequest          *HostRPCCallRequest          `json:",omitempty"`
+	HostRPCCallResponse         *HostRPCCallResponse         `json:",omitempty"`
+	HostStorageSyncRequest      *HostStorageSyncRequest      `json:",omitempty"`
+	HostStorageSyncResponse     *HostStorageSyncResponse     `json:",omitempty"`
+	HostLocalStorageGetRequest  *HostLocalStorageGetRequest  `json:",omitempty"`
+	HostLocalStorageGetResponse *HostLocalStorageGetResponse `json:",omitempty"`
+	HostLocalStorageSetRequest  *HostLocalStorageSetRequest  `json:",omitempty"`
+	HostLocalStorageSetResponse *Empty                       `json:",omitempty"`
 }
 
 // Type returns the message type by determining the name of the first non-nil member.
@@ -224,15 +230,6 @@ type RuntimeExecuteTxBatchRequest struct {
 // RuntimeExecuteTxBatchResponse is a worker execute tx batch response message body.
 type RuntimeExecuteTxBatchResponse struct {
 	Batch ComputedBatch `json:"batch"`
-}
-
-// HostKeyManagerPolicyRequest is a host key manager policy request message body.
-type HostKeyManagerPolicyRequest struct {
-}
-
-// HostKeyManagerPolicyResponse is a host key manager policy response message body.
-type HostKeyManagerPolicyResponse struct {
-	SignedPolicyRaw []byte `json:"signed_policy_raw"`
 }
 
 // HostRPCCallRequest is a host RPC call request message body.

--- a/go/worker/common/committee/runtime_host.go
+++ b/go/worker/common/committee/runtime_host.go
@@ -3,19 +3,26 @@ package committee
 import (
 	"context"
 	"errors"
-	"fmt"
+	"sync"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/oasislabs/oasis-core/go/common/cbor"
-	consensus "github.com/oasislabs/oasis-core/go/consensus/api"
+	"github.com/oasislabs/oasis-core/go/common/logging"
 	keymanagerApi "github.com/oasislabs/oasis-core/go/keymanager/api"
 	keymanagerClient "github.com/oasislabs/oasis-core/go/keymanager/client"
-	registry "github.com/oasislabs/oasis-core/go/registry/api"
+	"github.com/oasislabs/oasis-core/go/runtime/host"
 	"github.com/oasislabs/oasis-core/go/runtime/host/protocol"
 	"github.com/oasislabs/oasis-core/go/runtime/localstorage"
 	runtimeRegistry "github.com/oasislabs/oasis-core/go/runtime/registry"
 	storage "github.com/oasislabs/oasis-core/go/storage/api"
+)
+
+const (
+	retryInterval = 1 * time.Second
+	maxRetries    = 15
 )
 
 var (
@@ -34,31 +41,6 @@ type computeRuntimeHostHandler struct {
 }
 
 func (h *computeRuntimeHostHandler) Handle(ctx context.Context, body *protocol.Body) (*protocol.Body, error) {
-	// Key manager.
-	if body.HostKeyManagerPolicyRequest != nil {
-		rt, err := h.runtime.RegistryDescriptor(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("runtime host: failed to obtain runtime descriptor: %w", err)
-		}
-		if rt.KeyManager == nil {
-			return nil, errors.New("runtime has no key manager")
-		}
-		status, err := h.keyManager.GetStatus(ctx, &registry.NamespaceQuery{
-			ID:     *rt.KeyManager,
-			Height: consensus.HeightLatest,
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		var policy keymanagerApi.SignedPolicySGX
-		if status != nil && status.Policy != nil {
-			policy = *status.Policy
-		}
-		return &protocol.Body{HostKeyManagerPolicyResponse: &protocol.HostKeyManagerPolicyResponse{
-			SignedPolicyRaw: cbor.Marshal(policy),
-		}}, nil
-	}
 	// RPC.
 	if body.HostRPCCallRequest != nil {
 		switch body.HostRPCCallRequest.Endpoint {
@@ -123,6 +105,121 @@ func (h *computeRuntimeHostHandler) Handle(ctx context.Context, body *protocol.B
 // Implements RuntimeHostHandlerFactory.
 func (n *Node) GetRuntime() runtimeRegistry.Runtime {
 	return n.Runtime
+}
+
+// computeRuntimeHostNotifier is a runtime host notifier suitable for compute
+// runtimes.
+type computeRuntimeHostNotifier struct {
+	sync.Mutex
+
+	ctx context.Context
+
+	stopCh chan struct{}
+
+	started    bool
+	runtime    runtimeRegistry.Runtime
+	host       host.Runtime
+	keyManager keymanagerApi.Backend
+
+	logger *logging.Logger
+}
+
+func (n *computeRuntimeHostNotifier) watchPolicyUpdates() {
+	// Wait for the runtime.
+	rt, err := n.runtime.RegistryDescriptor(n.ctx)
+	if err != nil {
+		n.logger.Error("failed to wait for registry descriptor",
+			"err", err,
+		)
+		return
+	}
+	if rt.KeyManager == nil {
+		n.logger.Info("no keymanager needed, not watching for policy updates")
+		return
+	}
+
+	stCh, stSub := n.keyManager.WatchStatuses()
+	defer stSub.Close()
+	n.logger.Info("watching policy updates", "keymanager_runtime", rt.KeyManager)
+
+	for {
+		select {
+		case <-n.ctx.Done():
+			n.logger.Warn("contex canceled")
+			return
+		case <-n.stopCh:
+			n.logger.Warn("termination requested")
+			return
+		case st := <-stCh:
+			n.logger.Debug("got policy update", "status", st)
+
+			// Ignore status updates if key manager is not yet known (is nil)
+			// or if the status update is for a different key manager.
+			if !st.ID.Equal(rt.KeyManager) {
+				continue
+			}
+
+			raw := cbor.Marshal(st.Policy)
+			req := &protocol.Body{RuntimeKeyManagerPolicyUpdateRequest: &protocol.RuntimeKeyManagerPolicyUpdateRequest{
+				SignedPolicyRaw: raw,
+			}}
+
+			var response *protocol.Body
+			call := func() error {
+				resp, err := n.host.Call(n.ctx, req)
+				if err != nil {
+					n.logger.Error("failed to dispatch RPC call to runtime",
+						"err", err,
+					)
+					return err
+				}
+				response = resp
+				return nil
+			}
+
+			retry := backoff.WithMaxRetries(backoff.NewConstantBackOff(retryInterval), maxRetries)
+			err := backoff.Retry(call, backoff.WithContext(retry, n.ctx))
+			if err != nil {
+				n.logger.Error("failed dispatching key manager policy update to runtime",
+					"err", err,
+				)
+				continue
+			}
+			n.logger.Debug("key manager policy updated dispatched", "response", response)
+		}
+	}
+}
+
+// Implements protocol.Notifier.
+func (n *computeRuntimeHostNotifier) Start() error {
+	n.Lock()
+	defer n.Unlock()
+
+	if n.started {
+		return nil
+	}
+	n.started = true
+
+	go n.watchPolicyUpdates()
+
+	return nil
+}
+
+// Implements protocol.Notifier.
+func (n *computeRuntimeHostNotifier) Stop() {
+	close(n.stopCh)
+}
+
+// Implements RuntimeHostHandlerFactory.
+func (n *Node) NewNotifier(ctx context.Context, host host.Runtime) protocol.Notifier {
+	return &computeRuntimeHostNotifier{
+		ctx:        ctx,
+		stopCh:     make(chan struct{}),
+		runtime:    n.Runtime,
+		host:       host,
+		keyManager: n.KeyManager,
+		logger:     logging.GetLogger("committee/runtime-host"),
+	}
 }
 
 // Implements RuntimeHostHandlerFactory.

--- a/go/worker/common/runtime_host.go
+++ b/go/worker/common/runtime_host.go
@@ -14,8 +14,9 @@ import (
 type RuntimeHostNode struct {
 	sync.Mutex
 
-	cfg     *RuntimeHostConfig
-	factory RuntimeHostHandlerFactory
+	cfg      *RuntimeHostConfig
+	factory  RuntimeHostHandlerFactory
+	notifier protocol.Notifier
 
 	runtime host.Runtime
 }
@@ -24,35 +25,37 @@ type RuntimeHostNode struct {
 //
 // This method may return before the runtime is fully provisioned. The returned runtime will not be
 // started automatically, you must call Start explicitly.
-func (n *RuntimeHostNode) ProvisionHostedRuntime(ctx context.Context) (host.Runtime, error) {
+func (n *RuntimeHostNode) ProvisionHostedRuntime(ctx context.Context) (host.Runtime, protocol.Notifier, error) {
 	rt, err := n.factory.GetRuntime().RegistryDescriptor(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get runtime registry descriptor: %w", err)
+		return nil, nil, fmt.Errorf("failed to get runtime registry descriptor: %w", err)
 	}
 
 	provisioner, ok := n.cfg.Provisioners[rt.TEEHardware]
 	if !ok {
-		return nil, fmt.Errorf("no provisioner suitable for TEE hardware '%s'", rt.TEEHardware)
+		return nil, nil, fmt.Errorf("no provisioner suitable for TEE hardware '%s'", rt.TEEHardware)
 	}
 
 	// Get a copy of the configuration template for the given runtime and apply updates.
 	cfg, ok := n.cfg.Runtimes[rt.ID]
 	if !ok {
-		return nil, fmt.Errorf("missing runtime host configuration for runtime '%s'", rt.ID)
+		return nil, nil, fmt.Errorf("missing runtime host configuration for runtime '%s'", rt.ID)
 	}
 	cfg.MessageHandler = n.factory.NewRuntimeHostHandler()
 
 	// Provision the runtime.
 	prt, err := provisioner.NewRuntime(ctx, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to provision runtime: %w", err)
+		return nil, nil, fmt.Errorf("failed to provision runtime: %w", err)
 	}
+	notifier := n.factory.NewNotifier(ctx, prt)
 
 	n.Lock()
 	n.runtime = prt
+	n.notifier = notifier
 	n.Unlock()
 
-	return prt, nil
+	return prt, notifier, nil
 }
 
 // GetHostedRuntime returns the provisioned hosted runtime (if any).
@@ -63,14 +66,17 @@ func (n *RuntimeHostNode) GetHostedRuntime() host.Runtime {
 	return rt
 }
 
-// RuntimeHostHandlerFactory is an interface that can be used to create new runtime handlers when
-// provisioning hosted runtimes.
+// RuntimeHostHandlerFactory is an interface that can be used to create new runtime handlers and
+// notifiers when provisioning hosted runtimes.
 type RuntimeHostHandlerFactory interface {
 	// GetRuntime returns the registered runtime for which a runtime host handler is to be created.
 	GetRuntime() runtimeRegistry.Runtime
 
 	// NewRuntimeHostHandler creates a new runtime host handler.
 	NewRuntimeHostHandler() protocol.Handler
+
+	// NewNotifier creates a new runtime host notifier.
+	NewNotifier(ctx context.Context, host host.Runtime) protocol.Notifier
 }
 
 // NewRuntimeHostNode creates a new runtime host node.

--- a/go/worker/compute/executor/committee/node.go
+++ b/go/worker/compute/executor/committee/node.go
@@ -859,7 +859,7 @@ func (n *Node) worker() {
 	n.logger.Info("starting committee node")
 
 	// Provision the hosted runtime.
-	hrt, err := n.ProvisionHostedRuntime(n.ctx)
+	hrt, hrtNotifier, err := n.ProvisionHostedRuntime(n.ctx)
 	if err != nil {
 		n.logger.Error("failed to provision hosted runtime",
 			"err", err,
@@ -883,6 +883,14 @@ func (n *Node) worker() {
 		return
 	}
 	defer hrt.Stop()
+
+	if err = hrtNotifier.Start(); err != nil {
+		n.logger.Error("failed to start runtime notifier",
+			"err", err,
+		)
+		return
+	}
+	defer hrtNotifier.Stop()
 
 	// We are initialized.
 	close(n.initCh)

--- a/go/worker/compute/txnscheduler/committee/node.go
+++ b/go/worker/compute/txnscheduler/committee/node.go
@@ -490,7 +490,7 @@ func (n *Node) worker() {
 	var hrtEventCh <-chan *host.Event
 	if n.checkTxEnabled {
 		// Provision hosted runtime.
-		hrt, err := n.ProvisionHostedRuntime(n.ctx)
+		hrt, hrtNotifier, err := n.ProvisionHostedRuntime(n.ctx)
 		if err != nil {
 			n.logger.Error("failed to provision hosted runtime",
 				"err", err,
@@ -515,6 +515,14 @@ func (n *Node) worker() {
 			return
 		}
 		defer hrt.Stop()
+
+		if err = hrtNotifier.Start(); err != nil {
+			n.logger.Error("failed to start runtime notifier",
+				"err", err,
+			)
+			return
+		}
+		defer hrtNotifier.Stop()
 	}
 
 	// Initialize transaction scheduler's algorithm.

--- a/runtime/src/dispatcher.rs
+++ b/runtime/src/dispatcher.rs
@@ -243,6 +243,16 @@ impl Dispatcher {
                         true,
                     );
                 }
+                Ok((ctx, id, Body::RuntimeKeyManagerPolicyUpdateRequest { signed_policy_raw })) => {
+                    // KeyManager policy update local RPC call.
+                    self.handle_km_policy_update(
+                        &mut rpc_dispatcher,
+                        &protocol,
+                        ctx,
+                        id,
+                        signed_policy_raw,
+                    );
+                }
                 Ok(_) => {
                     error!(self.logger, "Unsupported request type");
                     break 'dispatch;
@@ -585,6 +595,23 @@ impl Dispatcher {
         let protocol_response = Body::RuntimeLocalRPCCallResponse { response };
 
         protocol.send_response(id, protocol_response).unwrap();
+    }
+
+    fn handle_km_policy_update(
+        &self,
+        rpc_dispatcher: &mut RpcDispatcher,
+        protocol: &Arc<Protocol>,
+        _ctx: Context,
+        id: u64,
+        signed_policy_raw: Vec<u8>,
+    ) {
+        debug!(self.logger, "Received km policy update request");
+        rpc_dispatcher.handle_km_policy_update(signed_policy_raw);
+        debug!(self.logger, "KM policy update request complete");
+
+        protocol
+            .send_response(id, Body::RuntimeKeyManagerPolicyUpdateResponse {})
+            .unwrap();
     }
 }
 

--- a/runtime/src/protocol.rs
+++ b/runtime/src/protocol.rs
@@ -324,6 +324,12 @@ impl Protocol {
                 self.dispatcher.queue_request(ctx, id, req)?;
                 Ok(None)
             }
+            req @ Body::RuntimeKeyManagerPolicyUpdateRequest { .. } => {
+                info!(self.logger, "Received key manager policy update request");
+                self.can_handle_runtime_requests()?;
+                self.dispatcher.queue_request(ctx, id, req)?;
+                Ok(None)
+            }
             req => {
                 warn!(self.logger, "Received unsupported request"; "req" => format!("{:?}", req));
                 Err(ProtocolError::MethodNotSupported.into())

--- a/runtime/src/rpc/dispatcher.rs
+++ b/runtime/src/rpc/dispatcher.rs
@@ -124,12 +124,17 @@ impl Method {
     }
 }
 
+/// Key manager policy update handler callback.
+pub type KeyManagerPolicyHandler = dyn Fn(Vec<u8>) -> ();
+
 /// RPC call dispatcher.
 pub struct Dispatcher {
     /// Registered RPC methods.
     methods: HashMap<String, Method>,
     /// Registered local RPC methods.
     local_methods: HashMap<String, Method>,
+    /// Registered key manager policy handler.
+    km_policy_handler: Option<Box<KeyManagerPolicyHandler>>,
     /// Registered context initializer.
     ctx_initializer: Option<Box<dyn ContextInitializer>>,
 }
@@ -140,6 +145,7 @@ impl Dispatcher {
         Self {
             methods: HashMap::new(),
             local_methods: HashMap::new(),
+            km_policy_handler: None,
             ctx_initializer: None,
         }
     }
@@ -210,5 +216,20 @@ impl Dispatcher {
                 body: Body::Error(format!("{}", error)),
             },
         }
+    }
+
+    /// Handle key manager policy update.
+    pub fn handle_km_policy_update(&self, signed_policy_raw: Vec<u8>) {
+        self.km_policy_handler
+            .as_ref()
+            .map(|handler| handler(signed_policy_raw));
+    }
+
+    /// Update key manager policy update handler.
+    pub fn set_keymanager_policy_update_handler(
+        &mut self,
+        f: Option<Box<KeyManagerPolicyHandler>>,
+    ) {
+        self.km_policy_handler = f;
     }
 }

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -124,13 +124,13 @@ pub enum Body {
     RuntimeExecuteTxBatchResponse {
         batch: ComputedBatch,
     },
-
-    // Host interface.
-    HostKeyManagerPolicyRequest {},
-    HostKeyManagerPolicyResponse {
+    RuntimeKeyManagerPolicyUpdateRequest {
         #[serde(with = "serde_bytes")]
         signed_policy_raw: Vec<u8>,
     },
+    RuntimeKeyManagerPolicyUpdateResponse {},
+
+    // Host interface.
     HostRPCCallRequest {
         endpoint: String,
         #[serde(with = "serde_bytes")]


### PR DESCRIPTION
Fixes: #2919

This will also require (minor) changes to the oasis-runtime (updating the initalizer with the keymanager-update handle)