### PR TITLE
go/oasis-node: Signer configuration fixes

### DIFF
--- a/.changelog/2949.bugfix.md
+++ b/.changelog/2949.bugfix.md
@@ -1,0 +1,6 @@
+go/oasis-node: Fix signer configuration via YAML
+
+The `--signer` argument has been renamed to `--signer.backend` to allow
+signer configuration to be passed via a YAML config. Previously, this would
+be impossible as `signer` would need to be both a string and a map at the
+same time when set via a YAML config.

--- a/.changelog/2950.bugfix.md
+++ b/.changelog/2950.bugfix.md
@@ -1,0 +1,1 @@
+go/oasis-node: Fix parsing of signer configuration

--- a/go/oasis-node/cmd/common/signer/signer.go
+++ b/go/oasis-node/cmd/common/signer/signer.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// CfgSigner is the flag used to specify the backend of the signer.
-	CfgSigner = "signer"
+	CfgSigner = "signer.backend"
 
 	// CfgCLISignerDir is the flag used to specify the directory with the
 	// entity files, for the purpose of some of the node sub-command's

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -798,6 +798,7 @@ func init() {
 		metrics.Flags,
 		tracing.Flags,
 		cmdGrpc.ServerLocalFlags,
+		cmdSigner.Flags,
 		pprof.Flags,
 		storage.Flags,
 		supplementarysanity.Flags,

--- a/go/oasis-test-runner/oasis/entity.go
+++ b/go/oasis-test-runner/oasis/entity.go
@@ -70,7 +70,7 @@ func (ent *Entity) Signer() signature.Signer {
 
 func (ent *Entity) toGenesisArgs() []string {
 	if ent.dir != nil {
-		return []string{"--signer", fileSigner.SignerName, "--signer.dir", ent.dir.String()}
+		return []string{"--" + cmdSigner.CfgSigner, fileSigner.SignerName, "--" + cmdSigner.CfgCLISignerDir, ent.dir.String()}
 	} else if ent.isDebugTestEntity {
 		return entityArgsDebugTest
 	}
@@ -99,7 +99,7 @@ func (ent *Entity) update() error {
 		"--" + cmdSigner.CfgCLISignerDir, ent.dir.String(),
 	}
 	for _, n := range ent.nodes {
-		args = append(args, "--entity.node.id", n.String())
+		args = append(args, "--"+cmdEntity.CfgNodeID, n.String())
 	}
 
 	w, err := ent.dir.NewLogWriter("update.log")


### PR DESCRIPTION
Fixes #2949
Fixes #2950 

This may require updates to the operator docs after 20.7 is released as `--signer` has been renamed to `--signer.backend`.