### PR TITLE
go/oasis-node: Don't bypass Stop in newNode failure handler

### DIFF
--- a/.changelog/2966.bugfix.md
+++ b/.changelog/2966.bugfix.md
@@ -1,0 +1,1 @@
+go/oasis-node: Don't bypass Stop in newNode failure handler

--- a/go/oasis-node/cmd/node/node.go
+++ b/go/oasis-node/cmd/node/node.go
@@ -492,7 +492,7 @@ func newNode(testNode bool) (*Node, error) { // nolint: gocyclo
 	var startOk bool
 	defer func() {
 		if !startOk {
-			node.svcMgr.Stop()
+			node.Stop()
 			node.Cleanup()
 		}
 	}()


### PR DESCRIPTION
Missed this in #2964 :disappointed: 